### PR TITLE
Stop repetitive authentication challenge traffic

### DIFF
--- a/Code/Network/RKResponse.m
+++ b/Code/Network/RKResponse.m
@@ -52,20 +52,6 @@
 	[super dealloc];
 }
 
-// Handle basic auth
--(void)connection:(NSURLConnection *)connection didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
-    if ([challenge previousFailureCount] == 0) {
-        NSURLCredential *newCredential;
-        newCredential=[NSURLCredential credentialWithUser:[NSString stringWithFormat:@"%@", _request.username]
-                                                 password:[NSString stringWithFormat:@"%@", _request.password]
-                                              persistence:NSURLCredentialPersistenceNone];
-        [[challenge sender] useCredential:newCredential
-               forAuthenticationChallenge:challenge];
-    } else {
-        [[challenge sender] cancelAuthenticationChallenge:challenge];
-    }
-}
-
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
 	if (NO == _loading) {
 		_loading = YES;


### PR DESCRIPTION
Using NSURLConnection delegate methods to respond to authentication challenges unnecessarily turns each network request into 2 requests and makes RestKit more chatty than is needed. So instead of waiting for a 401 challenge to be returned, I changed RKRequest to add the Authentication headers to its NSURLRequest before sending it over the wire so we never have to deal with 401 responses (unless the supplied credentials are wrong, of course).
