### PR TITLE
Three20 empty reload

### DIFF
--- a/Code/Three20/RKRequestTTModel.h
+++ b/Code/Three20/RKRequestTTModel.h
@@ -10,7 +10,7 @@
 #import "../RestKit.h"
 
 /**
- * Generic class for loading a remote model using a RestKit request and supplying the model to a 
+ * Generic class for loading a remote model using a RestKit request and supplying the model to a
  * TTListDataSource subclass
  */
 @interface RKRequestTTModel : TTModel <RKObjectLoaderDelegate> {
@@ -18,6 +18,7 @@
 	BOOL _isLoaded;
 	BOOL _isLoading;
 	BOOL _cacheLoaded;
+	BOOL _emptyReloadAttempted;
 
 	NSString* _resourcePath;
 	NSDictionary* _params;


### PR DESCRIPTION
Made some changes to where we attempt an empty reload to better handle offline mode cases.  In the case where we're using a local cache and that cache has no entries for a given resourcePath, instead of causing a network request on the initial load, we defer this empty load logic to the three20 reload path.
