### PR TITLE
Removed unnecessary schedule/unschedule of reachability observer

### DIFF
--- a/Code/Network/RKReachabilityObserver.m
+++ b/Code/Network/RKReachabilityObserver.m
@@ -81,15 +81,6 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 	if (self = [self init]) {
 		_reachabilityRef = reachabilityRef;
 		[self scheduleObserver];
-		
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(scheduleObserver)
-													 name:UIApplicationDidBecomeActiveNotification
-												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(unscheduleObserver)
-													 name:UIApplicationWillResignActiveNotification
-												   object:nil];
 	}
 	return self;
 }


### PR DESCRIPTION
We've been seeing some weird behavior with the reachability state changes when the app is in the background or inactive.  Some testing and referral to the Apple Reachability sample code suggests it is unnecessary to unschedule the observer when in the background/inactive state, so I've removed the schedule/unschedule notifications triggers based on application state changes.
