### PR TITLE
Self-signed certificates

### DIFF
--- a/Code/Network/RKClient.h
+++ b/Code/Network/RKClient.h
@@ -58,6 +58,8 @@ NSString* RKMakePathWithObject(NSString* path, id object);
 	NSString* _username;
 	NSString* _password;
 	NSMutableDictionary* _HTTPHeaders;
+	NSMutableSet *_additionalRootCertificates;
+	BOOL _disableCertificateValidation;
 	RKReachabilityObserver* _baseURLReachabilityObserver;
 	NSString* _serviceUnavailableAlertTitle;
 	NSString* _serviceUnavailableAlertMessage;
@@ -83,6 +85,18 @@ NSString* RKMakePathWithObject(NSString* path, id object);
  * A dictionary of headers to be sent with each request
  */
 @property(nonatomic, readonly) NSDictionary* HTTPHeaders;
+
+/**
+ * A set of additional certificates to be used in evaluating self-signed
+ * SSL certificates.
+ */
+@property(nonatomic, readonly) NSSet* additionalRootCertificates;
+
+/**
+ * Accept all SSL certificates. This is a potential security exposure,
+ * and should be used ONLY while debugging in a controlled environment.
+ */
+@property(nonatomic, assign) BOOL disableCertificateValidation;
 
 /**
  * The RKReachabilityObserver used to monitor whether or not the client has a connection
@@ -147,6 +161,11 @@ NSString* RKMakePathWithObject(NSString* path, id object);
  * Adds an HTTP header to each request dispatched through the Rest client
  */
 - (void)setValue:(NSString*)value forHTTPHeaderField:(NSString*)header;
+
+/**
+ * Adds an additional certificate that will be used to evaluate self-signed SSL certs
+ */
+- (void)addRootCertificate:(SecCertificateRef)cert;
 
 /**
  * Returns a resource path with a dictionary of query parameters URL encoded and appended

--- a/Code/Network/RKClient.m
+++ b/Code/Network/RKClient.m
@@ -71,6 +71,8 @@ NSString* RKMakePathWithObject(NSString* path, id object) {
 @synthesize username = _username;
 @synthesize password = _password;
 @synthesize HTTPHeaders = _HTTPHeaders;
+@synthesize additionalRootCertificates = _additionalRootCertificates;
+@synthesize disableCertificateValidation = _disableCertificateValidation;
 @synthesize baseURLReachabilityObserver = _baseURLReachabilityObserver;
 @synthesize serviceUnavailableAlertTitle = _serviceUnavailableAlertTitle;
 @synthesize serviceUnavailableAlertMessage = _serviceUnavailableAlertMessage;
@@ -115,8 +117,9 @@ NSString* RKMakePathWithObject(NSString* path, id object) {
 }
 
 - (id)init {
-	if (self = [super init]) {
+	if ((self = [super init])) {
 		_HTTPHeaders = [[NSMutableDictionary alloc] init];
+		_additionalRootCertificates = [[NSMutableSet alloc] init];
 		self.serviceUnavailableAlertEnabled = NO;
 		self.serviceUnavailableAlertTitle = NSLocalizedString(@"Service Unavailable", nil);
 		self.serviceUnavailableAlertMessage = NSLocalizedString(@"The remote resource is unavailable. Please try again later.", nil);
@@ -132,6 +135,7 @@ NSString* RKMakePathWithObject(NSString* path, id object) {
 	self.serviceUnavailableAlertTitle = nil;
 	self.serviceUnavailableAlertMessage = nil;
 	[_HTTPHeaders release];
+	[_additionalRootCertificates release];
 	[super dealloc];
 }
 
@@ -170,6 +174,10 @@ NSString* RKMakePathWithObject(NSString* path, id object) {
 
 - (void)setValue:(NSString*)value forHTTPHeaderField:(NSString*)header {
 	[_HTTPHeaders setValue:value forKey:header];
+}
+
+- (void)addRootCertificate:(SecCertificateRef)cert {
+  [_additionalRootCertificates addObject:(id)cert];
 }
 
 - (void)setBaseURL:(NSString*)baseURL {


### PR DESCRIPTION
Building on the patch that Blake was planning to add to RKResponse, here are some new APIs for RKClient to allow validation of self-signed SSL certs:
- `-addRootCertificate:` can be used to add custom certificates that will be added to the OS's pool when evaluating initially untrusted server certs. RKResponse will only attempt the validation step if at least one cert has been added. The set of certs is available from the `additionalRootCertificates` property.
- `disableCertificateValidation` is a Boolean property that, if set, will cause RKResponse objects to trust all server certs. Obviously, that's not a wise thing in general, but it can be useful in development environments, or when debugging.

One semi-unfortunate side-effect of this change is that it introduces a dependency on Security.framework (which is where the cert validation happens). If that's a big deal, perhaps those parts could be conditionally compiled (excluded by default).

EDIT to add: Here's some basic example code for how the setup might go with these changes:

```
RKClient* client = [RKClient clientWithBaseURL:@"https://example.com"];

// assumes that the CA cert has been exported to a DER-encoded X.509 .cer file in the app's bundle
NSData* certData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"my-own-signer" ofType:@"cer"]];
if( [certData length] ) {
  SecCertificateRef cert = SecCertificateCreateWithData(NULL, (CFDataRef)certData);
  if( cert != NULL ) {
    [client addRootCertificate:cert];
    CFRelease(cert);
  }
}
```
