### PR TITLE
Managed object store improvements

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.h
+++ b/Code/CoreData/RKManagedObjectStore.h
@@ -37,6 +37,7 @@ extern NSString* const RKManagedObjectStoreDidFailSaveNotification;
 @interface RKManagedObjectStore : NSObject {
 	NSObject<RKManagedObjectStoreDelegate>* _delegate;
 	NSString* _storeFilename;
+	NSString* _pathToStoreFile;
     NSManagedObjectModel* _managedObjectModel;
 	NSPersistentStoreCoordinator* _persistentStoreCoordinator;
 	NSObject<RKManagedObjectCache>* _managedObjectCache;
@@ -74,11 +75,21 @@ extern NSString* const RKManagedObjectStoreDidFailSaveNotification;
 + (RKManagedObjectStore*)objectStoreWithStoreFilename:(NSString*)storeFilename;
 
 /**
- * Initialize a new managed object store backed by a SQLite database with the specified filename. If a seed database name is provided
- * and no existing database is found, initialize the store by copying the seed database from the main bundle. If the managed object model
- * provided is nil, all models will be merged from the main bundle for you.
+ * Initialize a new managed object store backed by a SQLite database with the specified filename.
+ * If a seed database name is provided and no existing database is found, initialize the store by
+ * copying the seed database from the main bundle. If the managed object model provided is nil,
+ * all models will be merged from the main bundle for you.
  */
 + (RKManagedObjectStore*)objectStoreWithStoreFilename:(NSString *)storeFilename usingSeedDatabaseName:(NSString *)nilOrNameOfSeedDatabaseInMainBundle managedObjectModel:(NSManagedObjectModel*)nilOrManagedObjectModel;
+
+/**
+ * Initialize a new managed object store backed by a SQLite database with the specified filename,
+ * in the specified directory. If no directory is specified, will use the app's Documents
+ * directory. If a seed database name is provided and no existing database is found, initialize
+ * the store by copying the seed database from the main bundle. If the managed object model
+ * provided is nil, all models will be merged from the main bundle for you.
+ */
++ (RKManagedObjectStore*)objectStoreWithStoreFilename:(NSString *)storeFilename inDirectory:(NSString *)directory usingSeedDatabaseName:(NSString *)nilOrNameOfSeedDatabaseInMainBundle managedObjectModel:(NSManagedObjectModel*)nilOrManagedObjectModel;
 
 /**
  * Initialize a new managed object store with a SQLite database with the filename specified


### PR DESCRIPTION
For the app I'm working on, I need to keep the Core Data storage out of the Documents directory, so I did a little work on `RKManagedObjectStore` to add that capability: an explicit directory path can now be passed to the class method that creates the store, defaulting to the Documents directory as it does now.

I also added a delegate protocol to knock out some of the error-handling TODO items in the code. And I've cleaned up a few places where [`NSError**` arguments were being examined _without_ checking the return value first](http://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html#//apple_ref/doc/uid/TP40001806-CH204-BAJIIGCC). (It makes the [baby @bbum cry](http://twitter.com/bbum/status/55495191372644352)!)

You'll note that there's one delegate method for failure-to-save, called with either an error or an exception; there might be a case to be made for separating those, but I imagine that the client code is going to be the same for both most of the time.
