### PR TITLE
Changed 'class' (reserved word in ObjC++) to 'cls'

### DIFF
--- a/Code/ObjectMapping/RKDynamicRouter.h
+++ b/Code/ObjectMapping/RKDynamicRouter.h
@@ -25,11 +25,11 @@
  * (i.e. /this/is/the/path) or dynamic (i.e. /users/(userID)/(username)). Dynamic routes are
  * evaluated against the object being routed using Key-Value coding and coerced into a string.
  */
-- (void)routeClass:(Class<RKObjectMappable>)class toResourcePath:(NSString*)resourcePath;
+- (void)routeClass:(Class<RKObjectMappable>)cls toResourcePath:(NSString*)resourcePath;
 
 /**
  * Register a mapping from an object class to a resource path for a specific HTTP method.
  */
-- (void)routeClass:(Class<RKObjectMappable>)class toResourcePath:(NSString*)resourcePath forMethod:(RKRequestMethod)method;
+- (void)routeClass:(Class<RKObjectMappable>)cls toResourcePath:(NSString*)resourcePath forMethod:(RKRequestMethod)method;
 
 @end

--- a/Code/ObjectMapping/RKObjectManager.h
+++ b/Code/ObjectMapping/RKObjectManager.h
@@ -85,7 +85,7 @@ typedef enum {
 /**
  * Register a resource mapping from a domain model class to a JSON/XML element name
  */
-- (void)registerClass:(Class<RKObjectMappable>)class forElementNamed:(NSString*)elementName;
+- (void)registerClass:(Class<RKObjectMappable>)cls forElementNamed:(NSString*)elementName;
 
 /**
  * Mapper object responsible for mapping remote HTTP resources to Cocoa objects

--- a/Code/ObjectMapping/RKObjectMapper.h
+++ b/Code/ObjectMapping/RKObjectMapper.h
@@ -150,18 +150,18 @@ typedef enum {
  * Map the objects in a given payload string to a particular object class, optionally filtering
  * the parsed result set via a keyPath before mapping the results.
  */
-- (NSObject<RKObjectMappable>*)mapFromString:(NSString *)string toClass:(Class<RKObjectMappable>)class keyPath:(NSString*)keyPath;
+- (NSObject<RKObjectMappable>*)mapFromString:(NSString *)string toClass:(Class<RKObjectMappable>)cls keyPath:(NSString*)keyPath;
 
 /**
  * Map a dictionary of elements to an instance of a particular class
  */
-- (id)mapObjectFromDictionary:(NSDictionary*)dictionary toClass:(Class)class;
+- (id)mapObjectFromDictionary:(NSDictionary*)dictionary toClass:(Class)cls;
 
 /**
  * Map an array of object dictionary representations to instances of a particular
  * object class
  */
-- (NSArray*)mapObjectsFromArrayOfDictionaries:(NSArray*)array toClass:(Class<RKObjectMappable>)class;
+- (NSArray*)mapObjectsFromArrayOfDictionaries:(NSArray*)array toClass:(Class<RKObjectMappable>)cls;
 
 /**
  * Parse a string using the appropriate parser and return the results

--- a/Code/ObjectMapping/RKObjectPropertyInspector.h
+++ b/Code/ObjectMapping/RKObjectPropertyInspector.h
@@ -16,6 +16,6 @@
 /**
  * Returns a dictionary of names and types for the properties of a given class
  */
-- (NSDictionary *)propertyNamesAndTypesForClass:(Class)class;
+- (NSDictionary *)propertyNamesAndTypesForClass:(Class)cls;
 
 @end

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -610,7 +610,8 @@
 				25BD43BD1340315800DBACDD /* libRestKitXMLParserLibxml.a */,
 			);
 			name = Products;
-			sourceTree = "<group>";
+			path = ../..;
+			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		0867D691FE84028FC02AAC07 /* OTRestFramework */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Attempting to include RestKit headers on Objective-C++ compiles causes errors due to method prototypes with arguments named "class", which is a reserved word in ObjC++.
