### PR TITLE
Added support for mapping NSURL properties. Fixes #52

### DIFF
--- a/Code/ObjectMapping/RKObjectMapper.m
+++ b/Code/ObjectMapping/RKObjectMapper.m
@@ -386,6 +386,8 @@ static const NSString* kRKModelMapperRailsDateFormatString = @"MM/dd/yyyy";
                     } else {
                         propertyValue = [NSNumber numberWithDouble:[propertyValue doubleValue]];
                     }
+                } else if (class == [NSURL class] && [propertyValue isKindOfClass:[NSString class]]) {
+                    propertyValue = [NSURL URLWithString:propertyValue];
                 } else {
                     [NSException raise:@"NoElementValueConversionMethod" format:@"Don't know how to convert %@ (%@) to %@", propertyValue, [propertyValue class], class];
                 }

--- a/Specs/Models/RKMappableObject.h
+++ b/Specs/Models/RKMappableObject.h
@@ -14,6 +14,7 @@
 	NSDate* _dateTest;
 	NSNumber* _numberTest;
 	NSString* _stringTest;
+    NSURL* _urlTest;
 	RKMappableAssociation* _hasOne;
 	NSSet* _hasMany;
 }
@@ -21,6 +22,7 @@
 @property (nonatomic, retain) NSDate* dateTest;
 @property (nonatomic, retain) NSNumber* numberTest;
 @property (nonatomic, retain) NSString* stringTest;
+@property (nonatomic, retain) NSURL* urlTest;
 @property (nonatomic, retain) RKMappableAssociation* hasOne;
 @property (nonatomic, retain) NSSet* hasMany;
 

--- a/Specs/Models/RKMappableObject.m
+++ b/Specs/Models/RKMappableObject.m
@@ -11,13 +11,14 @@
 
 @implementation RKMappableObject
 
-@synthesize dateTest = _dateTest, numberTest = _numberTest, stringTest = _stringTest,
+@synthesize dateTest = _dateTest, numberTest = _numberTest, stringTest = _stringTest, urlTest = _urlTest,
 hasOne = _hasOne, hasMany = _hasMany;
 
 + (NSDictionary*)elementToPropertyMappings {
 	return [NSDictionary dictionaryWithKeysAndObjects:@"date_test", @"dateTest", 
 					@"number_test", @"numberTest", 
-					@"string_test", @"stringTest", nil];
+					@"string_test", @"stringTest",
+					@"url_test", @"urlTest", nil];
 }
 
 + (NSDictionary*)elementToRelationshipMappings {

--- a/Specs/ObjectMapping/RKObjectMapperSpec.m
+++ b/Specs/ObjectMapping/RKObjectMapperSpec.m
@@ -105,6 +105,7 @@
 	[expectThat([result dateTest]) shouldNot:be(nil)];
 	[expectThat([result numberTest]) should:be(2)];
 	[expectThat([result stringTest]) should:be(@"SomeString")];
+	[expectThat([result urlTest]) should:be([NSURL URLWithString:@"https://github.com/twotoasters/RestKit"])];
 	
 	[expectThat([result hasOne]) shouldNot:be(nil)];
 	[expectThat([[result hasOne] testString]) should:be(@"A String")];
@@ -329,6 +330,7 @@
 	@"      \"date_test\":\"2009-08-17T19:24:40Z\","
 	@"      \"number_test\":2,"
 	@"      \"string_test\":\"SomeString\","
+	@"      \"url_test\":\"https://github.com/twotoasters/RestKit\","
 	@"      \"has_one\":{"
 	@"         \"test_string\":\"A String\""
 	@"      },"


### PR DESCRIPTION
Hi there!

I added a few lines to `RKObjectMapper` to support converting property values into `NSURL` objects. This should fix issue #52 (I'm part of the team that found the problem, so it's near and dear to my heart).

Thanks for a great library!
