### PR TITLE
0.9 error handling

### DIFF
--- a/Code/CoreData/RKManagedObject.m
+++ b/Code/CoreData/RKManagedObject.m
@@ -36,7 +36,7 @@
 + (NSArray*)objectsWithFetchRequest:(NSFetchRequest*)fetchRequest {
 	NSError* error = nil;
 	NSArray* objects = [[RKManagedObject managedObjectContext] executeFetchRequest:fetchRequest error:&error];
-	if (error != nil) {
+	if (objects == nil) {
 		NSLog(@"Error: %@", [error localizedDescription]);
 		// TODO: Error handling
 	}

--- a/Code/CoreData/RKManagedObjectSeeder.m
+++ b/Code/CoreData/RKManagedObjectSeeder.m
@@ -89,7 +89,7 @@ NSString* const RKDefaultSeedDatabaseFileName = @"RKSeedDatabase.sqlite";
 	NSString* filePath = [[NSBundle mainBundle] pathForResource:fileName ofType:nil];
 	NSString* payload = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:&error];
     
-	if (nil == error) {
+	if (payload != nil) {
         // TODO: When we support multiple parsers, we should auto-detect the MIME Type from the file extension
         // and pass it through to the mapper
 		id objects = [_manager.mapper parseString:payload];

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -107,6 +107,8 @@ static NSString* const kRKManagedObjectContextKey = @"RKManagedObjectContext";
 			
 			NSDictionary* userInfo = [NSDictionary dictionaryWithObject:error forKey:@"error"];
 			[[NSNotificationCenter defaultCenter] postNotificationName:RKManagedObjectStoreDidFailSaveNotification object:self userInfo:userInfo];
+			
+			return error;
 		}
 	}
 	@catch (NSException* e) {

--- a/Code/Network/RKParamsAttachment.m
+++ b/Code/Network/RKParamsAttachment.m
@@ -65,9 +65,12 @@ extern NSString* const kRKStringBoundary;
 		_MIMEType = [[self mimeTypeForExtension:[filePath pathExtension]] retain];
 		_bodyStream    = [[NSInputStream inputStreamWithFileAtPath:filePath] retain];
 		
-		NSError* error = nil;		
-		_bodyLength    = [[[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:&error] objectForKey:NSFileSize] unsignedIntegerValue];		
-		if (error) {
+		NSError* error;
+		NSDictionary* attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:&error];
+		if (attributes) {
+			_bodyLength    = [[attributes objectForKey:NSFileSize] unsignedIntegerValue];
+		}
+		else {
 			NSLog(@"Encountered an error while determining file size: %@", error);
 		}
 	}

--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -248,7 +248,7 @@
 
 - (RKResponse*)sendSynchronously {
 	NSURLResponse* URLResponse = nil;
-	NSError* error = nil;
+	NSError* error;
 	NSData* payload = nil;
 	RKResponse* response = nil;
 
@@ -266,13 +266,15 @@
         }
         
 		payload = [NSURLConnection sendSynchronousRequest:_URLRequest returningResponse:&URLResponse error:&error];
+		if (payload != nil) error = nil;
+		
 		response = [[[RKResponse alloc] initWithSynchronousRequest:self URLResponse:URLResponse body:payload error:error] autorelease];
-        
-        if (error) {
-            [self didFailLoadWithError:error];
-        } else {
-            [self didFinishLoad:response];
-        }
+		
+		if (payload == nil) {
+			[self didFailLoadWithError:error];
+		} else {
+			[self didFinishLoad:response];
+		}
 	} else {
 		NSString* errorMessage = [NSString stringWithFormat:@"The client is unable to contact the resource at %@", [[self URL] absoluteString]];
 		NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:


### PR DESCRIPTION
Some spot changes to bring error-handling into line with best practices. In particular, the requirement that calling code _never_ examine an `NSError**` argument until and unless the status of that call proves to be unsuccessful. (Returns `NO` / `nil` / whatever.)
