### PR TITLE
Using a seed db after deleting the store

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.h
+++ b/Code/CoreData/RKManagedObjectStore.h
@@ -106,6 +106,7 @@ extern NSString* const RKManagedObjectStoreDidFailSaveNotification;
  * This deletes and recreates the managed object context and 
  * persistant store, effectively clearing all data
  */
+- (void)deletePersistantStoreUsingSeedDatabaseName:(NSString *)seedFile;
 - (void)deletePersistantStore;
 
 /**

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -172,7 +172,7 @@ static NSString* const kRKManagedObjectContextKey = @"RKManagedObjectContext";
     }
 }
 
-- (void)deletePersistantStore {
+- (void)deletePersistantStoreUsingSeedDatabaseName:(NSString *)seedFile {
 	NSURL* storeUrl = [NSURL fileURLWithPath:self.pathToStoreFile];
 	
 	NSError* error;
@@ -194,7 +194,14 @@ static NSString* const kRKManagedObjectContextKey = @"RKManagedObjectContext";
         [threadDictionary removeObjectForKey:kRKManagedObjectContextKey];
     }
 	
+	if (seedFile)
+		[self createStoreIfNecessaryUsingSeedDatabase:seedFile];
+
 	[self createPersistentStoreCoordinator];
+}
+
+- (void)deletePersistantStore {
+	[self deletePersistantStoreUsingSeedDatabaseName:nil];
 }
 
 /**


### PR DESCRIPTION
Normally deleting a store db will initiate a new blank store.  This commit allows the user to delete the store and then init from a seeded db.
