### PR TITLE
Added support for serialized NSDecimalNumber

### DIFF
--- a/Code/ObjectMapping/RKObjectMapper.m
+++ b/Code/ObjectMapping/RKObjectMapper.m
@@ -443,6 +443,8 @@ static const NSString* kRKModelMapperRailsDateFormatString = @"MM/dd/yyyy";
                     }
                 } else if (class == [NSURL class] && [propertyValue isKindOfClass:[NSString class]]) {
                     propertyValue = [NSURL URLWithString:propertyValue];
+                } else if (class == [NSDecimalNumber class] && [propertyValue isKindOfClass:[NSString class]]) {
+                    propertyValue = [NSDecimalNumber decimalNumberWithString:propertyValue];
                 } else {
                     [NSException raise:@"NoElementValueConversionMethod" format:@"Don't know how to convert %@ (%@) to %@", propertyValue, [propertyValue class], class];
                 }

--- a/Specs/Models/RKMappableObject.h
+++ b/Specs/Models/RKMappableObject.h
@@ -14,7 +14,8 @@
 	NSDate* _dateTest;
 	NSNumber* _numberTest;
 	NSString* _stringTest;
-    NSURL* _urlTest;
+	NSURL* _urlTest;
+	NSDecimalNumber* _decimalNumberTest;
 	RKMappableAssociation* _hasOne;
 	NSSet* _hasMany;
 }
@@ -23,6 +24,7 @@
 @property (nonatomic, retain) NSNumber* numberTest;
 @property (nonatomic, retain) NSString* stringTest;
 @property (nonatomic, retain) NSURL* urlTest;
+@property (nonatomic, retain) NSDecimalNumber * decimalNumberTest;
 @property (nonatomic, retain) RKMappableAssociation* hasOne;
 @property (nonatomic, retain) NSSet* hasMany;
 

--- a/Specs/Models/RKMappableObject.m
+++ b/Specs/Models/RKMappableObject.m
@@ -12,13 +12,15 @@
 @implementation RKMappableObject
 
 @synthesize dateTest = _dateTest, numberTest = _numberTest, stringTest = _stringTest, urlTest = _urlTest,
-hasOne = _hasOne, hasMany = _hasMany;
+decimalNumberTest = _decimalNumberTest, hasOne = _hasOne, hasMany = _hasMany;
 
 + (NSDictionary*)elementToPropertyMappings {
 	return [NSDictionary dictionaryWithKeysAndObjects:@"date_test", @"dateTest", 
 					@"number_test", @"numberTest", 
 					@"string_test", @"stringTest",
-					@"url_test", @"urlTest", nil];
+					@"url_test", @"urlTest",
+					@"decimal_number_test", @"decimalNumberTest",
+					nil];
 }
 
 + (NSDictionary*)elementToRelationshipMappings {

--- a/Specs/ObjectMapping/RKObjectMapperSpec.m
+++ b/Specs/ObjectMapping/RKObjectMapperSpec.m
@@ -127,6 +127,7 @@
 	[expectThat([result numberTest]) should:be(2)];
 	[expectThat([result stringTest]) should:be(@"SomeString")];
 	[expectThat([result urlTest]) should:be([NSURL URLWithString:@"https://github.com/twotoasters/RestKit"])];
+	[expectThat([result decimalNumberTest]) should:be([NSDecimalNumber decimalNumberWithString:@"3.14159265"])];
 	
 	[expectThat([result hasOne]) shouldNot:be(nil)];
 	[expectThat([[result hasOne] testString]) should:be(@"A String")];
@@ -344,6 +345,7 @@
 	@"      \"number_test\":2,"
 	@"      \"string_test\":\"SomeString\","
 	@"      \"url_test\":\"https://github.com/twotoasters/RestKit\","
+	@"      \"decimal_number_test\":\"3.14159265\","
 	@"      \"has_one\":{"
 	@"         \"test_string\":\"A String\""
 	@"      },"


### PR DESCRIPTION
This commit allows RestKit to handle the serialization of high-precision decimals by parsing NSDecimalNumber from string parameters.

Would be happy to add more tests, but the framework should most likely handle NSDecimalNumber without modification since it subclasses the already-supported NSNumber.
