### PR TITLE
Don't leak object passed in to loader.

### DIFF
--- a/Code/ObjectMapping/RKObjectLoader.m
+++ b/Code/ObjectMapping/RKObjectLoader.m
@@ -44,6 +44,8 @@
     // Weak reference
     _objectManager = nil;
     
+	[_targetObject release];
+	_targetObject = nil;
 	[_response release];
 	_response = nil;
 	[_keyPath release];


### PR DESCRIPTION
Hello all.
So I have the feeling this patch is wrong, but I can't figure out why.  I was running some leak tests on our app and found more than I would have liked.  A number of the leaks seemed to trace back to the objectLoader, so I poked around and found this.

It's a retained property and it's set using property syntax on line 207 of RKObjectManager.m:
"loader.targetObject = object;"

So far as I can find, the property is only read after that, thus that reference hangs through the autorelease of the loader.  So I added this patch to our code and voila, those leaks went away.  I would've liked to have tested it with an example, but I didn't see any that called "objectLoaderForObject:..."

Let me know if this is bunk or not.  

Thanks,
Pat Shields
