### PR TITLE
Checked for "t" and "f" in mapping database booleans to NSNumbers

### DIFF
--- a/Code/ObjectMapping/RKObjectMapper.m
+++ b/Code/ObjectMapping/RKObjectMapper.m
@@ -438,6 +438,9 @@ static const NSString* kRKModelMapperRailsDateFormatString = @"MM/dd/yyyy";
                     if ([propertyValue isEqualToString:@"true"] ||
                         [propertyValue isEqualToString:@"false"]) {
                         propertyValue = [NSNumber numberWithBool:[propertyValue isEqualToString:@"true"]];
+                    } else if ([propertyValue isEqualToString:@"t"] ||
+                               [propertyValue isEqualToString:@"f"]) {
+                        propertyValue = [NSNumber numberWithBool:[propertyValue isEqualToString:@"t"]];
                     } else {
                         propertyValue = [NSNumber numberWithDouble:[propertyValue doubleValue]];
                     }


### PR DESCRIPTION
In trying to map a boolean on my SQLite3 (development) and PostgreSQL (production) databases, I found that they give me "t" and "f" for booleans and currently, RestKit only checks for "true" and "false" strings. I added a check for "t" and "f" in the RKObjectMapper to handle this case.
