### PR TITLE
Support for server certificate validation in RKClient/RKResponse

### DIFF
--- a/Code/Network/RKClient.h
+++ b/Code/Network/RKClient.h
@@ -122,6 +122,8 @@ NSString* RKPathAppendQueryParams(NSString* resourcePath, NSDictionary* queryPar
 	NSString* _username;
 	NSString* _password;
 	NSMutableDictionary* _HTTPHeaders;
+	NSMutableSet *_additionalRootCertificates;
+	BOOL _disableCertificateValidation;
 	RKReachabilityObserver* _baseURLReachabilityObserver;
 	NSString* _serviceUnavailableAlertTitle;
 	NSString* _serviceUnavailableAlertMessage;
@@ -142,6 +144,22 @@ NSString* RKPathAppendQueryParams(NSString* resourcePath, NSDictionary* queryPar
  */
 @property(nonatomic, readonly) NSMutableDictionary* HTTPHeaders;
 
+#ifdef RESTKIT_SSL_VALIDATION
+/**
+ * A set of additional certificates to be used in evaluating server
+ * SSL certificates.
+ */
+@property(nonatomic, readonly) NSSet* additionalRootCertificates;
+#endif
+
+/**
+ * Accept all SSL certificates. This is a potential security exposure,
+ * and should be used ONLY while debugging in a controlled environment.
+ *
+ * *Default*: _NO_
+ */
+@property(nonatomic, assign) BOOL disableCertificateValidation;
+
 /**
  *  Will check for network connectivity to the host specified in the baseURL
  *
@@ -159,6 +177,16 @@ NSString* RKPathAppendQueryParams(NSString* resourcePath, NSDictionary* queryPar
  * @see HTTPHeaders
  */
 - (void)setValue:(NSString*)value forHTTPHeaderField:(NSString*)header;
+
+#ifdef RESTKIT_SSL_VALIDATION
+/**
+ * Adds an additional certificate that will be used to evaluate server SSL certs
+ *
+ * @param cert The HTTP header to add
+ * @see additionalRootCertificates
+ */
+- (void)addRootCertificate:(SecCertificateRef)cert;
+#endif
 
 /////////////////////////////////////////////////////////////////////////
 /// @name HTTP Authentication

--- a/Code/Network/RKClient.m
+++ b/Code/Network/RKClient.m
@@ -77,6 +77,10 @@ NSString* RKPathAppendQueryParams(NSString* resourcePath, NSDictionary* queryPar
 @synthesize username = _username;
 @synthesize password = _password;
 @synthesize HTTPHeaders = _HTTPHeaders;
+#ifdef RESTKIT_SSL_VALIDATION
+@synthesize additionalRootCertificates = _additionalRootCertificates;
+#endif
+@synthesize disableCertificateValidation = _disableCertificateValidation;
 @synthesize baseURLReachabilityObserver = _baseURLReachabilityObserver;
 @synthesize serviceUnavailableAlertTitle = _serviceUnavailableAlertTitle;
 @synthesize serviceUnavailableAlertMessage = _serviceUnavailableAlertMessage;
@@ -113,6 +117,7 @@ NSString* RKPathAppendQueryParams(NSString* resourcePath, NSDictionary* queryPar
     self = [super init];
 	if (self) {
 		_HTTPHeaders = [[NSMutableDictionary alloc] init];
+		_additionalRootCertificates = [[NSMutableSet alloc] init];
 		self.serviceUnavailableAlertEnabled = NO;
 		self.serviceUnavailableAlertTitle = NSLocalizedString(@"Service Unavailable", nil);
 		self.serviceUnavailableAlertMessage = NSLocalizedString(@"The remote resource is unavailable. Please try again later.", nil);
@@ -132,6 +137,7 @@ NSString* RKPathAppendQueryParams(NSString* resourcePath, NSDictionary* queryPar
 	self.serviceUnavailableAlertTitle = nil;
 	self.serviceUnavailableAlertMessage = nil;
 	[_HTTPHeaders release];
+	[_additionalRootCertificates release];
     
 	[super dealloc];
 }
@@ -172,6 +178,12 @@ NSString* RKPathAppendQueryParams(NSString* resourcePath, NSDictionary* queryPar
 - (void)setValue:(NSString*)value forHTTPHeaderField:(NSString*)header {
 	[_HTTPHeaders setValue:value forKey:header];
 }
+
+#ifdef RESTKIT_SSL_VALIDATION
+- (void)addRootCertificate:(SecCertificateRef)cert {
+  [_additionalRootCertificates addObject:(id)cert];
+}
+#endif
 
 - (void)setBaseURL:(NSString*)baseURL {
 	[_baseURL release];

--- a/Code/Network/RKResponse.m
+++ b/Code/Network/RKResponse.m
@@ -8,6 +8,7 @@
 
 #import "RKResponse.h"
 #import "RKNotifications.h"
+#import "RKClient.h"
 #import "RKJSONParser.h"
 #import "RKNetwork.h"
 
@@ -57,18 +58,81 @@
 	[super dealloc];
 }
 
-// Handle basic auth
-- (void)connection:(NSURLConnection *)connection didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
-    if ([challenge previousFailureCount] == 0) {
-        NSURLCredential *newCredential;
-        newCredential = [NSURLCredential credentialWithUser:[NSString stringWithFormat:@"%@", _request.username]
-                                                   password:[NSString stringWithFormat:@"%@", _request.password]
-                                                persistence:RKNetworkGetGlobalCredentialPersistence()];
-        [[challenge sender] useCredential:newCredential
-               forAuthenticationChallenge:challenge];
-    } else {
-        [[challenge sender] cancelAuthenticationChallenge:challenge];
+- (BOOL)isServerTrusted:(SecTrustRef)trust {
+  RKClient* client = [RKClient sharedClient];
+  BOOL proceed = NO;
+  
+  if( client.disableCertificateValidation ) {
+    proceed = YES;
+  }
+#ifdef RESTKIT_SSL_VALIDATION
+  else if( [client.additionalRootCertificates count] > 0 ) {
+    CFArrayRef rootCerts = (CFArrayRef)[client.additionalRootCertificates allObjects];
+    SecTrustResultType result;
+    OSStatus returnCode;
+    
+    if( rootCerts && CFArrayGetCount(rootCerts) ) {
+      // this could fail, but the trust evaluation will proceed (it's likely to fail, of course)
+      SecTrustSetAnchorCertificates(trust, rootCerts);
     }
+    
+    returnCode = SecTrustEvaluate(trust, &result);
+    
+    if( returnCode == errSecSuccess ) {
+      proceed = (result == kSecTrustResultProceed || result == kSecTrustResultConfirm || result == kSecTrustResultUnspecified);
+      if( result == kSecTrustResultRecoverableTrustFailure ) {
+        // TODO: should try to recover here
+        // call SecTrustGetCssmResult() for more information about the failure
+      }
+    }
+  }
+#endif
+  
+  return proceed;
+}
+
+// Handle basic auth & SSL certificate validation
+- (void)connection:(NSURLConnection *)connection didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
+	if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+		SecTrustRef trust = [[challenge protectionSpace] serverTrust];
+		if ([self isServerTrusted:trust]) {
+			[challenge.sender useCredential:[NSURLCredential credentialForTrust:trust] forAuthenticationChallenge:challenge];
+		} else {
+			[[challenge sender] cancelAuthenticationChallenge:challenge];
+		}
+		return;
+	}
+	if ([challenge previousFailureCount] == 0) {
+		NSURLCredential *newCredential;
+		newCredential=[NSURLCredential credentialWithUser:[NSString stringWithFormat:@"%@", _request.username]
+		                                         password:[NSString stringWithFormat:@"%@", _request.password]
+		                                      persistence:NSURLCredentialPersistenceNone];
+		[[challenge sender] useCredential:newCredential
+		       forAuthenticationChallenge:challenge];
+	} else {
+		[[challenge sender] cancelAuthenticationChallenge:challenge];
+	}
+}
+
+- (BOOL)connection:(NSURLConnection *)connection canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)space { 
+	if ([[space authenticationMethod] isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+		// server is using an SSL certificate that the OS can't validate
+		// see whether the client settings allow validation here
+		RKClient* client = [RKClient sharedClient];
+		if (client.disableCertificateValidation
+#ifdef RESTKIT_SSL_VALIDATION
+            || [client.additionalRootCertificates count] > 0
+#endif
+            ) {
+			return YES;
+		} else { 
+			return NO;
+		} 
+	}
+	
+	// If no other authentication is required, return NO for everything 
+	// Otherwise maybe YES for NSURLAuthenticationMethodDefault and etc. 
+	return NO; 
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {


### PR DESCRIPTION
I've added some new APIs to RKClient to allow validation of server SSL certs that are from CAs that iOS doesn't have root certificates for. Primarily, those would be self-signed certs.
- `disableCertificateValidation` is a Boolean property that, if set, will cause RKResponse objects to trust _all_ server certs. Obviously, that's not a wise thing in general, but it can be useful in development environments, or when debugging.
- `-addRootCertificate:` can be used to add custom certificates that will be added to the OS's pool when evaluating initially untrusted server certs. RKResponse will only attempt the validation step if at least one cert has been added. The set of certs is available from the `additionalRootCertificates` property.

_NOTE:_ In order to add additional certificates, the project must be linked against Security.framework. In order to not foist that new dependency off on folks that don't need it, the certificate APIs will only be available if the preprocessor variable `RESTKIT_SSL_VALIDATION` is defined. (By default, it is not.)

Here's some basic example code for how the setup might go with these changes:

```
RKClient* client = [RKClient clientWithBaseURL:@"https://example.com"];

// assumes that the CA cert has been exported to a DER-encoded X.509 .cer file in the app's bundle
NSData* certData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"my-own-signer" ofType:@"cer"]];
if( [certData length] ) {
  SecCertificateRef cert = SecCertificateCreateWithData(NULL, (CFDataRef)certData);
  if( cert != NULL ) {
    [client addRootCertificate:cert];
    CFRelease(cert);
  }
}
```

(This pull request replaces #31. Because I needed to edit the commit, rebasing against the latest 0.9, and adding the preprocessor flag.)
