### PR TITLE
Replaced deprecated methods with the current ones in RKTwitter example

### DIFF
--- a/Examples/RKTwitter/Classes/RKTwitterAppDelegate.m
+++ b/Examples/RKTwitter/Classes/RKTwitterAppDelegate.m
@@ -45,8 +45,8 @@
 	[statusMapping.dateFormatStrings addObject:@"E MMM d HH:mm:ss Z y"];
     
     // Register our mappings with the provider
-    [objectManager.mappingProvider setMapping:userMapping forKeyPath:@"user"];
-    [objectManager.mappingProvider setMapping:statusMapping forKeyPath:@"status"];
+    [objectManager.mappingProvider setObjectMapping:userMapping forKeyPath:@"user"];
+    [objectManager.mappingProvider setObjectMapping:statusMapping forKeyPath:@"status"];
     
     // Uncomment this to use XML, comment it to use JSON
 //  objectManager.acceptMIMEType = RKMIMETypeXML;


### PR DESCRIPTION
I'm a total newbie and when I tried to build RKTwitter I got two warnings about setMapping forKeyPath being deprecated. I searched and replaced them with the equivalent current methods.
