### PR TITLE
Use MIMEType as parser registry key, not content type

### DIFF
--- a/Code/Network/RKResponse.m
+++ b/Code/Network/RKResponse.m
@@ -150,7 +150,7 @@ extern NSString* cacheURLKey;
 }
 
 - (id)parsedBody:(NSError**)error {
-    id<RKParser> parser = [[RKParserRegistry sharedRegistry] parserForMIMEType:[self contentType]];
+    id<RKParser> parser = [[RKParserRegistry sharedRegistry] parserForMIMEType:[self MIMEType]];
     id object = [parser objectFromString:[self bodyAsString] error:error];
     if (object == nil) {
         RKLogError(@"Unable to parse response body: %@", [*error localizedDescription]);


### PR DESCRIPTION
I noticed that the content type was being used as the key to the registry in `parserForMIMEType`, and my server was returning the full header with encoding: `Content-Type: application/json; charset=utf-8`. Switching from content type to MIME type makes the lookup work.

I attempted to get UISpec working to write a test for this, but failed. If there is a quick guide somewhere, or instructions for your specific project, I'd happily try again.
