### PR TITLE
Fix for issue #172: unique object identification for non-string primary keys 

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -349,7 +349,7 @@ static NSString* const RKManagedObjectStoreThreadDictionaryEntityCacheKey = @"RK
     
     if (object == nil) {
         object = [[[NSManagedObject alloc] initWithEntity:entity insertIntoManagedObjectContext:self.managedObjectContext] autorelease];
-        [dictionary setObject:object forKey:primaryKeyValue];
+        [dictionary setObject:object forKey:lookupValue];
     }
         
 	return object;


### PR DESCRIPTION
Fix for issue #172: use the same key for reading from and writing to the entity cache, so that non-string primary keys do not result in duplicate objects.
