### PR TITLE
Preserve trailing slash in resource path

### DIFF
--- a/Code/Network/RKURL.m
+++ b/Code/Network/RKURL.m
@@ -31,6 +31,10 @@
 	NSString* resourcePathWithQueryString = RKPathAppendQueryParams(resourcePath, queryParams);
 	NSURL *baseURL = [NSURL URLWithString:baseURLString];
 	NSString* completePath = [[baseURL path] stringByAppendingPathComponent:resourcePathWithQueryString];
+    // Preserve trailing slash in resourcePath
+    if (resourcePath && [resourcePath characterAtIndex:[resourcePath length] - 1] == '/') {
+        completePath = [completePath stringByAppendingString:@"/"];
+    }
 	NSURL* completeURL = [NSURL URLWithString:completePath relativeToURL:baseURL];
 	if (!completeURL) {
 		[self release];

--- a/Specs/Network/RKURLSpec.m
+++ b/Specs/Network/RKURLSpec.m
@@ -63,5 +63,10 @@
     assertThat([URL absoluteString], is(equalTo(@"http://restkit.org/this/test")));
 }
 
+- (void)itShouldPreserveTrailingSlash {
+    RKURL* URL = [RKURL URLWithBaseURLString:@"http://restkit.org" resourcePath:@"/test/" queryParams:nil];
+    assertThat([URL absoluteString], is(equalTo(@"http://restkit.org/test/")));    
+}
+
 @end
  


### PR DESCRIPTION
Fixing regression introduced in 6de429051b694a781b9ec7dea1ba94958f7c3f93

See https://groups.google.com/d/topic/restkit/gcOtvAjfDKA/discussion for discussion
