### PR TITLE
Exposing cacheTimeoutInterval as a property of RKObjectManager

### DIFF
--- a/Code/ObjectMapping/RKObjectManager.h
+++ b/Code/ObjectMapping/RKObjectManager.h
@@ -167,6 +167,13 @@ typedef enum {
  */
 @property (nonatomic, assign) NSString* acceptMIMEType;
 
+/**
+ * The timeout interval within which the requests should not be sent
+ * and the cached response should be used. Used if the cache policy
+ * includes RKRequestCachePolicyTimeout
+ */
+@property (nonatomic, assign) NSTimeInterval cacheTimeoutInterval;
+
 ////////////////////////////////////////////////////////
 /// @name Registered Object Loaders
 

--- a/Code/ObjectMapping/RKObjectManager.m
+++ b/Code/ObjectMapping/RKObjectManager.m
@@ -30,6 +30,7 @@ static RKObjectManager* sharedManager = nil;
 @synthesize router = _router;
 @synthesize mappingProvider = _mappingProvider;
 @synthesize serializationMIMEType = _serializationMIMEType;
+@synthesize cacheTimeoutInterval = _cacheTimeoutInterval;
 
 - (id)initWithBaseURL:(NSString*)baseURL {
     self = [super init];
@@ -38,6 +39,7 @@ static RKObjectManager* sharedManager = nil;
 		_router = [RKObjectRouter new];
 		_client = [[RKClient clientWithBaseURL:baseURL] retain];
         _onlineState = RKObjectManagerOnlineStateUndetermined;
+		_cacheTimeoutInterval = 0;
         
         self.acceptMIMEType = RKMIMETypeJSON;
         self.serializationMIMEType = RKMIMETypeFormURLEncoded;
@@ -129,6 +131,8 @@ static RKObjectManager* sharedManager = nil;
         objectLoader = [RKObjectLoader loaderWithResourcePath:resourcePath objectManager:self delegate:delegate];
     }	
     
+	objectLoader.cacheTimeoutInterval = self.cacheTimeoutInterval;
+	
 	return objectLoader;
 }
 
@@ -160,6 +164,7 @@ static RKObjectManager* sharedManager = nil;
     loader.method = method;
     loader.sourceObject = object;
     loader.targetObject = object;
+	loader.cacheTimeoutInterval = self.cacheTimeoutInterval;
     loader.serializationMIMEType = self.serializationMIMEType;
     loader.serializationMapping = [self.mappingProvider serializationMappingForClass:[object class]];
 


### PR DESCRIPTION
Added cacheTimeoutInterval as a property on RKObjectManager to allow for
 globally setting that value for all RKObjectManager managed requests.

Right now you can't easily implement a cache timeout using OM 2.0.  This simply allows you to set a default cache timeout interval for all requests initiated by RKObjectManager.  You can still get an RKObjectLoader or RKRequest and set a timeout on each individually.
