### PR TITLE
Fixes #218

### DIFF
--- a/Code/Network/RKNotifications.h
+++ b/Code/Network/RKNotifications.h
@@ -22,3 +22,4 @@ extern NSString* const RKRequestDidLoadResponseNotificationUserInfoResponseKey;
 extern NSString* const RKRequestDidFailWithErrorNotification;
 extern NSString* const RKRequestDidFailWithErrorNotificationUserInfoErrorKey;
 extern NSString* const RKServiceDidBecomeUnavailableNotification;
+extern NSString* const RKRequestDidCancelNotification;

--- a/Code/Network/RKNotifications.m
+++ b/Code/Network/RKNotifications.m
@@ -14,3 +14,4 @@ NSString* const RKRequestDidFailWithErrorNotificationUserInfoErrorKey = @"error"
 NSString* const RKRequestDidLoadResponseNotification = @"RKRequestDidLoadResponseNotification";
 NSString* const RKRequestDidLoadResponseNotificationUserInfoResponseKey = @"response";
 NSString* const RKServiceDidBecomeUnavailableNotification = @"RKServiceDidBecomeUnavailableNotification";
+NSString* const RKRequestDidCancelNotification = @"RKRequestDidCancelNotification";

--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -221,6 +221,10 @@
     if (informDelegate && [_delegate respondsToSelector:@selector(requestDidCancelLoad:)]) {
         [_delegate requestDidCancelLoad:self];
     }
+
+    // notify RKRequestQueue that we've canceled
+    [[NSNotificationCenter defaultCenter] postNotificationName:RKRequestDidCancelNotification
+                                                        object:self];
 }
 
 - (NSString*)HTTPMethod {

--- a/Code/Network/RKRequestQueue.h
+++ b/Code/Network/RKRequestQueue.h
@@ -173,4 +173,9 @@
  */
 - (void)requestQueue:(RKRequestQueue*)queue didFailRequest:(RKRequest*)request withError:(NSError*)error;
 
+/**
+ * Sent when a request is canceled
+ */
+- (void)requestQueue:(RKRequestQueue*)queue didCancelRequest:(RKRequest*)request;
+
 @end

--- a/Code/Network/RKRequestQueue.m
+++ b/Code/Network/RKRequestQueue.m
@@ -235,6 +235,10 @@ static const NSTimeInterval kFlushDelay = 0.3;
                                              selector:@selector(requestFinishedWithNotification:)
                                                  name:RKRequestDidFailWithErrorNotification
                                                object:request];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(requestFinishedWithNotification:)
+                                                 name:RKRequestDidCancelNotification
+                                               object:request];
     
 	[self loadNextInQueue];
 }
@@ -246,6 +250,7 @@ static const NSTimeInterval kFlushDelay = 0.3;
         
         [[NSNotificationCenter defaultCenter] removeObserver:self name:RKRequestDidLoadResponseNotification object:request];
         [[NSNotificationCenter defaultCenter] removeObserver:self name:RKRequestDidFailWithErrorNotification object:request];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:RKRequestDidCancelNotification object:request];
         
         if (decrementCounter) {
             NSAssert(self.loadingCount > 0, @"Attempted to decrement loading count below zero");
@@ -361,6 +366,15 @@ static const NSTimeInterval kFlushDelay = 0.3;
             if ([_delegate respondsToSelector:@selector(requestQueue:didFailRequest:withError:)]) {
                 [_delegate requestQueue:self didFailRequest:request withError:error];
             }
+        } else if ([notification.name isEqualToString:RKRequestDidCancelNotification]) {
+            // We canceled
+            RKLogDebug(@"Request %@ canceled loading in queue %@. (Now loading %d of %d)",
+                       request, self, _loadingCount, _concurrentRequestsLimit);
+            
+            if ([_delegate respondsToSelector:@selector(requestQueue:didCancelRequest:)]) {
+                [_delegate requestQueue:self didCancelRequest:request];
+            }
+
         }
         
         // Load the next request


### PR DESCRIPTION
- Post a notification when we cancel an RKRequest
- Make RKRequestQueue subscribe to this notification and finish canceled requests.
- Allow RKRequestQueueDelegates to hook into cancels, too.
