### PR TITLE
Use the actual class instead of hardcoded RKObjectManager class

### DIFF
--- a/Code/ObjectMapping/RKObjectManager.m
+++ b/Code/ObjectMapping/RKObjectManager.m
@@ -70,7 +70,7 @@ static RKObjectManager* sharedManager = nil;
 }
 
 + (RKObjectManager*)objectManagerWithBaseURL:(NSString*)baseURL {
-	RKObjectManager* manager = [[[RKObjectManager alloc] initWithBaseURL:baseURL] autorelease];
+	RKObjectManager* manager = [[[self alloc] initWithBaseURL:baseURL] autorelease];
 	if (nil == sharedManager) {
 		[RKObjectManager setSharedManager:manager];
 	}


### PR DESCRIPTION
Use the actual class instead of hardcoded RKObjectManager class in objectManagerWithBaseURL:

This makes inheritance from RKObjectManager a little bit cleaner.
