### PR TITLE
Requests were not sent at all after 5 requests with 40x HTTP Code response.

### DIFF
--- a/Code/ObjectMapping/RKObjectLoader.m
+++ b/Code/ObjectMapping/RKObjectLoader.m
@@ -289,6 +289,7 @@
     }
     
     [(NSObject<RKObjectLoaderDelegate>*)_delegate objectLoader:self didFailWithError:error];
+    [self finalizeLoad:NO error:error];    
 }
 
 #pragma mark - RKRequest & RKRequestDelegate methods


### PR DESCRIPTION
finalizeLoad:error: call added in handleResponseError thus avoiding non finalized requests when receiving 40x HTTP response to requests.
