### PR TITLE
RKJSONParserSBJSON serializes itself instead of the object

### DIFF
--- a/Code/Support/Parsers/JSON/RKJSONParserSBJSON.m
+++ b/Code/Support/Parsers/JSON/RKJSONParserSBJSON.m
@@ -25,7 +25,7 @@
 
 - (NSString*)stringFromObject:(id)object error:(NSError **)error {
     SBJsonWriter *jsonWriter = [SBJsonWriter new];    
-    NSString *json = [jsonWriter stringWithObject:self];
+    NSString *json = [jsonWriter stringWithObject:object];
     if (!json) {
         if (error) *error = [[jsonWriter errorTrace] lastObject];
     }


### PR DESCRIPTION
RKJSONParserSBJSON serializer passes itself to the SBJsonWriter instead of the object
