### PR TITLE
Improved the flexibility of the block loaders significantly by allowing t

### DIFF
--- a/Code/ObjectMapping/RKObjectManager.h
+++ b/Code/ObjectMapping/RKObjectManager.h
@@ -241,7 +241,8 @@ typedef enum {
     - (BOOL)changePassword:(NSString*)newPassword error:(NSError**)error {
         if ([self validatePassword:newPassword error:error]) {
             self.password = newPassword;
-            [[RKObjectManager sharedManager] sendObject:self method:RKRequestMethodPOST delegate:self block:^(RKObjectLoader* loader) {
+            [[RKObjectManager sharedManager] sendObject:self delegate:self block:^(RKObjectLoader* loader) {
+                loader.method = RKRequestMethodPOST;
                 loader.serializationMIMEType = RKMIMETypeJSON; // We want to send this request as JSON
                 loader.targetObject = nil;  // Map the results back onto a new object instead of self
                 // Set up a custom serialization mapping to handle this request
@@ -252,7 +253,7 @@ typedef enum {
         }
     }
  */
-- (RKObjectLoader*)sendObject:(id<NSObject>)object method:(RKRequestMethod)method delegate:(id<RKObjectLoaderDelegate>)delegate block:(void(^)(RKObjectLoader*))block;
+- (RKObjectLoader*)sendObject:(id<NSObject>)object delegate:(id<RKObjectLoaderDelegate>)delegate block:(void(^)(RKObjectLoader*))block;
 
 /**
  GET a remote object instance and yield the object loader to the block before sending

--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -33,6 +33,8 @@ NSString* const RKObjectMappingNestingAttributeKeyName = @"<RK_NESTING_ATTRIBUTE
     return [self mappingForClass:[NSMutableDictionary class]];
 }
 
+#if NS_BLOCKS_AVAILABLE
+
 + (id)mappingForClass:(Class)objectClass block:(void(^)(RKObjectMapping*))block {
     RKObjectMapping* mapping = [self mappingForClass:objectClass];
     block(mapping);
@@ -45,6 +47,7 @@ NSString* const RKObjectMappingNestingAttributeKeyName = @"<RK_NESTING_ATTRIBUTE
     return mapping;
 }
 
+#endif // NS_BLOCKS_AVAILABLE
 
 - (id)init {
     self = [super init];


### PR DESCRIPTION
Improved the flexibility of the block loaders significantly by allowing them to override the object mapping and routing selection. Made sendObject:method:delegate:block private and introduced public sendObject:delegate:block method instead. Wrote some basic specs for overriding the router.
