### PR TITLE
fixed "internal compiler error tree check" on ASSERT (iOS Device Scheme only)

### DIFF
--- a/Vendor/NXJSON/NXJsonParser.m
+++ b/Vendor/NXJSON/NXJsonParser.m
@@ -387,7 +387,7 @@ NSString* const kNextiveJsonParserErrorDomain = @"com.nextive.NXJsonParser";
 			value = NO;
 			break;
 		default:
-			ASSERT(!@"I should never be here. Fault the calling function."); 
+			ASSERT(@"I should never be here. Fault the calling function." != nil ? 1 : 0);  
 			break;
 	}
 	


### PR DESCRIPTION
When compiling for iOS Device Scheme I was receiving the following compiler error.

.../RestKit/Vendor/NXJSON/NXJsonParser.m:390: internal compiler error: tree check: expected tree that contains 'decl with visibility' structure, have 'const_decl'  in c_common_truthvalue_conversion, at c-common.c:2836

i fixed it by checking for nil:

ASSERT(!@"I should never be here. Fault the calling function."  != nil ? 1 : 0); 
