### PR TITLE
Allow numbers to map to strings

### DIFF
--- a/Code/ObjectMapping/RKObjectMappingOperation.m
+++ b/Code/ObjectMapping/RKObjectMappingOperation.m
@@ -150,13 +150,13 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue) {
         if ([destinationType isSubclassOfClass:[NSSet class]]) {
             return [NSSet setWithArray:value];
         }
-    } else if ([sourceType isSubclassOfClass:[NSNumber class]]) {
-        // Number -> Date
-        if ([destinationType isSubclassOfClass:[NSDate class]]) {
-            return [NSDate dateWithTimeIntervalSince1970:[(NSNumber*)value intValue]];
-        } else if (([sourceType isSubclassOfClass:NSClassFromString(@"__NSCFBoolean")] || [sourceType isSubclassOfClass:NSClassFromString(@"NSCFBoolean")]) && [destinationType isSubclassOfClass:[NSString class]]) {
-            return ([value boolValue] ? @"true" : @"false");
-        }
+    } else if ([sourceType isSubclassOfClass:[NSNumber class]] && [destinationType isSubclassOfClass:[NSDate class]]) {
+      // Number -> Date
+      return [NSDate dateWithTimeIntervalSince1970:[(NSNumber*)value intValue]];
+    } else if ( ([sourceType isSubclassOfClass:NSClassFromString(@"__NSCFBoolean")] ||
+                 [sourceType isSubclassOfClass:NSClassFromString(@"NSCFBoolean")] ) &&
+               [destinationType isSubclassOfClass:[NSString class]]) {
+        return ([value boolValue] ? @"true" : @"false");
     } else if ([destinationType isSubclassOfClass:[NSString class]] && [value respondsToSelector:@selector(stringValue)]) {
         return [value stringValue];
     }

--- a/Specs/ObjectMapping/RKObjectMappingOperationSpec.m
+++ b/Specs/ObjectMapping/RKObjectMappingOperationSpec.m
@@ -77,6 +77,21 @@
     [operation release];
 }
 
+- (void)itShouldSuccessfullyMapNumbersToStrings {
+    RKObjectMapping* mapping = [RKObjectMapping mappingForClass:[TestMappable class]];
+    [mapping mapKeyPath:@"number" toAttribute:@"boolString"];
+    TestMappable* object = [[[TestMappable alloc] init] autorelease];
+    
+    id<RKParser> parser = [[RKParserRegistry sharedRegistry] parserForMIMEType:@"application/json"];
+    id data = [parser objectFromString:@"{\"number\":123}" error:nil];
+    
+    RKObjectMappingOperation* operation = [[RKObjectMappingOperation alloc] initWithSourceObject:data destinationObject:object mapping:mapping];
+    BOOL success = [operation performMapping:nil];
+    assertThatBool(success, is(equalToBool(YES)));
+    assertThat(object.boolString, is(equalTo(@"123")));
+    [operation release];
+}
+
 - (void)itShouldFailTheMappingOperationIfKeyValueValidationSetsAnError {
     RKObjectMapping* mapping = [RKObjectMapping mappingForClass:[TestMappable class]];
     [mapping mapAttributes:@"boolString", nil];


### PR DESCRIPTION
The way the `if/else` checks were nested before prevented an `NSNumber` `sourceType` to fall into the check for `respondsTo:@selector(stringValue)`, even if the `destinationType` was an `NSString`.

This change allows you to have a number in your json map to a string on your model.

If you want me to change the test or anything just let me know.
