### PR TITLE
When resetting a RKRequest/RKObjectLoader then also set _params to nil

### DIFF
--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -84,6 +84,8 @@
     [_URLRequest setCachePolicy:NSURLRequestReloadIgnoringCacheData];
     [_connection release];
     _connection = nil;
+    [_params release];
+    _params = nil;
     _isLoading = NO;
     _isLoaded = NO;
 }


### PR DESCRIPTION
When a RKObjectLoader is about to be reused the method reset is send to the objectLoader (i.e. the load method in RKObjectLoaderTTModel). If the _params value from a previous POST request is not cleared then the method addHeadersToRequest will add a none zero Content-Length header to a GET request.
