### PR TITLE
I updated the serializer, so you can use the dateFormatStrings attribute to format serialized dates.

### DIFF
--- a/Code/ObjectMapping/RKObjectSerializer.h
+++ b/Code/ObjectMapping/RKObjectSerializer.h
@@ -48,4 +48,6 @@
  */
 - (id<RKRequestSerializable>)serializationForMIMEType:(NSString*)mimeType error:(NSError**)error;
 
+- (NSString *)formattedStringFromDate:(NSDate*)date;
+
 @end


### PR DESCRIPTION
I updated the serializer, so you can use the dateFormatStrings attribute from the mapper to format date attributes when they are being serialized. This modification adds the method declaration for formatting the date.
