### PR TITLE
Add timeZone property to RKObjectMapping

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.h
+++ b/Code/ObjectMapping/RKObjectMapping.h
@@ -35,6 +35,7 @@ relationship. Relationships are processed using an object mapping as well.
     Class _objectClass;
     NSMutableArray* _mappings;
     NSMutableArray* _dateFormatStrings;
+    NSTimeZone* _timeZone;
     NSString* _rootKeyPath;
     BOOL _setDefaultValueForMissingAttributes;
     BOOL _setNilForMissingRelationships;
@@ -127,6 +128,12 @@ relationship. Relationships are processed using an object mapping as well.
  until the date formatter does not return nil.
  */
 @property (nonatomic, retain) NSMutableArray* dateFormatStrings;
+
+/**
+ The timeZone to be used for dateMappings when a time zone is not included
+ in the date format string. Defaults to [NSTimeZone localTimeZone];
+ */
+@property (nonatomic, retain) NSTimeZone* timeZone;
 
 /**
  Returns an object mapping for the specified class that is ready for configuration

--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -19,6 +19,7 @@ NSString* const RKObjectMappingNestingAttributeKeyName = @"<RK_NESTING_ATTRIBUTE
 @synthesize objectClass = _objectClass;
 @synthesize mappings = _mappings;
 @synthesize dateFormatStrings = _dateFormatStrings;
+@synthesize timeZone = _timeZone;
 @synthesize rootKeyPath = _rootKeyPath;
 @synthesize setDefaultValueForMissingAttributes = _setDefaultValueForMissingAttributes;
 @synthesize setNilForMissingRelationships = _setNilForMissingRelationships;
@@ -56,6 +57,7 @@ NSString* const RKObjectMappingNestingAttributeKeyName = @"<RK_NESTING_ATTRIBUTE
     if (self) {
         _mappings = [NSMutableArray new];
         _dateFormatStrings = [[NSMutableArray alloc] initWithObjects:@"yyyy-MM-dd'T'HH:mm:ss'Z'", @"MM/dd/yyyy", nil];
+        self.timeZone = [NSTimeZone localTimeZone];
         self.setDefaultValueForMissingAttributes = NO;
         self.setNilForMissingRelationships = NO;
         self.forceCollectionMapping = NO;
@@ -69,6 +71,7 @@ NSString* const RKObjectMappingNestingAttributeKeyName = @"<RK_NESTING_ATTRIBUTE
     [_rootKeyPath release];
     [_mappings release];
     [_dateFormatStrings release];
+    [_timeZone release];
     [super dealloc];
 }
 

--- a/Code/ObjectMapping/RKObjectMappingOperation.m
+++ b/Code/ObjectMapping/RKObjectMappingOperation.m
@@ -98,7 +98,7 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue) {
     
 	NSDate* date = nil;
 	NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
-    formatter.timeZone = [NSTimeZone localTimeZone];
+    formatter.timeZone = self.objectMapping.timeZone;
 	for (NSString* formatString in self.objectMapping.dateFormatStrings) {
 		[formatter setDateFormat:formatString];
 		date = [formatter dateFromString:string];


### PR DESCRIPTION
Add timeZone property to RKObjectMapping to be used in RKObjectMappingOperation. Defaults to localTimeZone.
