### PR TITLE
Removed warnings that occur when compiling with LLVM 3.0 and Objective-C+

### DIFF
--- a/Code/CoreData/RKManagedObjectMapping.m
+++ b/Code/CoreData/RKManagedObjectMapping.m
@@ -72,7 +72,7 @@
 }
 
 - (void)connectRelationship:(NSString*)relationshipName withObjectForPrimaryKeyAttribute:(NSString*)primaryKeyAttribute {
-    NSAssert([_relationshipToPrimaryKeyMappings objectForKey:relationshipName] == nil, @"Cannot add connect relationship %@ by primary key, a mapping already exists.", relationshipName);
+    NSAssert1([_relationshipToPrimaryKeyMappings objectForKey:relationshipName] == nil, @"Cannot add connect relationship %@ by primary key, a mapping already exists.", relationshipName);
     [_relationshipToPrimaryKeyMappings setObject:primaryKeyAttribute forKey:relationshipName];
 }
 

--- a/Code/CoreData/RKManagedObjectMappingOperation.m
+++ b/Code/CoreData/RKManagedObjectMappingOperation.m
@@ -71,11 +71,11 @@
         return;
     }
     RKObjectMapping* objectMapping = (RKObjectMapping*)mapping;
-    NSAssert(relationshipMapping, @"Unable to find relationship mapping '%@' to connect by primaryKey", relationshipName);
-    NSAssert([relationshipMapping isKindOfClass:[RKObjectRelationshipMapping class]], @"Expected mapping for %@ to be a relationship mapping", relationshipName);
+    NSAssert1(relationshipMapping, @"Unable to find relationship mapping '%@' to connect by primaryKey", relationshipName);
+    NSAssert1([relationshipMapping isKindOfClass:[RKObjectRelationshipMapping class]], @"Expected mapping for %@ to be a relationship mapping", relationshipName);
     NSAssert([relationshipMapping.mapping isKindOfClass:[RKManagedObjectMapping class]], @"Can only connect RKManagedObjectMapping relationships");
     NSString* primaryKeyAttributeOfRelatedObject = [(RKManagedObjectMapping*)objectMapping primaryKeyAttribute];
-    NSAssert(primaryKeyAttributeOfRelatedObject, @"Cannot connect relationship: mapping for %@ has no primary key attribute specified", NSStringFromClass(objectMapping.objectClass));
+    NSAssert1(primaryKeyAttributeOfRelatedObject, @"Cannot connect relationship: mapping for %@ has no primary key attribute specified", NSStringFromClass(objectMapping.objectClass));
     id valueOfLocalPrimaryKeyAttribute = [self.destinationObject valueForKey:primaryKeyAttribute];
     RKLogDebug(@"Connecting relationship at keyPath '%@' to object with primaryKey attribute '%@'", relationshipName, primaryKeyAttributeOfRelatedObject);
     if (valueOfLocalPrimaryKeyAttribute) {

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -202,7 +202,7 @@ static NSString* const RKManagedObjectStoreThreadDictionaryEntityCacheKey = @"RK
 		if (self.delegate != nil && [self.delegate respondsToSelector:@selector(managedObjectStore:didFailToCreatePersistentStoreCoordinatorWithError:)]) {
 			[self.delegate managedObjectStore:self didFailToCreatePersistentStoreCoordinatorWithError:error];
 		} else {
-			NSAssert(NO, @"Managed object store failed to create persistent store coordinator: %@", error);
+			NSAssert1(NO, @"Managed object store failed to create persistent store coordinator: %@", error);
 		}
     }
 }
@@ -216,7 +216,7 @@ static NSString* const RKManagedObjectStoreThreadDictionaryEntityCacheKey = @"RK
 			[self.delegate managedObjectStore:self didFailToDeletePersistentStore:self.pathToStoreFile error:error];
 		}
 		else {
-			NSAssert(NO, @"Managed object store failed to delete persistent store : %@", error);
+			NSAssert1(NO, @"Managed object store failed to delete persistent store : %@", error);
 		}
 	}
 	

--- a/Code/CoreData/RKManagedObjectThreadSafeInvocation.m
+++ b/Code/CoreData/RKManagedObjectThreadSafeInvocation.m
@@ -64,7 +64,7 @@
         if ([value isKindOfClass:[NSManagedObjectID class]]) {
             NSAssert(self.objectStore, @"Object store cannot be nil");
             NSManagedObject* managedObject = [self.objectStore objectWithID:(NSManagedObjectID*)value];
-            NSAssert(managedObject, @"Expected managed object for ID %@, got nil", value);
+            NSAssert1(managedObject, @"Expected managed object for ID %@, got nil", value);
             [argument setValue:managedObject forKeyPath:keyPath];
         } else if ([value respondsToSelector:@selector(allObjects)]) {
             id collection = [[[[[value class] alloc] init] autorelease] mutableCopy];

--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -36,8 +36,9 @@
 #undef RKLogComponent
 #define RKLogComponent lcl_cRestKitNetwork
 
-@implementation RKRequest
 @class TDOAuth;
+
+@implementation RKRequest
 
 @synthesize URL = _URL;
 @synthesize URLRequest = _URLRequest;
@@ -663,7 +664,7 @@
         compositeCacheKey = [NSString stringWithFormat:@"%@-%d", self.URL, _method];
     }
     
-    NSAssert(compositeCacheKey, @"Expected a cacheKey to be generated for request %@, but got nil", compositeCacheKey);
+    NSAssert1(compositeCacheKey, @"Expected a cacheKey to be generated for request %@, but got nil", compositeCacheKey);
     return [compositeCacheKey MD5];
 }
 

--- a/Code/Network/RKRequestQueue.m
+++ b/Code/Network/RKRequestQueue.m
@@ -430,7 +430,7 @@ static const NSTimeInterval kFlushDelay = 0.3;
  * the completed request from the queue and continue processing
  */
 - (void)requestFinishedWithNotification:(NSNotification*)notification {
-    NSAssert([notification.object isKindOfClass:[RKRequest class]], @"Notification expected to contain an RKRequest, got a %@", NSStringFromClass([notification.object class]));
+    NSAssert1([notification.object isKindOfClass:[RKRequest class]], @"Notification expected to contain an RKRequest, got a %@", NSStringFromClass([notification.object class]));
     
     RKRequest* request = (RKRequest*)notification.object;
     NSDictionary* userInfo = [notification userInfo];

--- a/Code/ObjectMapping/RKDynamicObjectMapping.m
+++ b/Code/ObjectMapping/RKDynamicObjectMapping.m
@@ -117,7 +117,7 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue);
 }
 
 - (RKObjectMapping*)objectMappingForDictionary:(NSDictionary*)data {
-    NSAssert([data isKindOfClass:[NSDictionary class]], @"Dynamic object mapping can only be performed on NSDictionary mappables, got %@", NSStringFromClass([data class]));
+    NSAssert1([data isKindOfClass:[NSDictionary class]], @"Dynamic object mapping can only be performed on NSDictionary mappables, got %@", NSStringFromClass([data class]));
     RKObjectMapping* mapping = nil;
     
     RKLogTrace(@"Performing dynamic object mapping for mappable data: %@", data);
@@ -142,7 +142,7 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue);
     if (self.objectMappingForDataBlock) {        
         mapping = self.objectMappingForDataBlock(data);
         if (mapping) {
-            RKLogTrace(@"Found dynamic delegateBlock match. objectMappingForDataBlock = %@", self.objectMappingForDataBlock);
+            RKLogTrace(@"Found dynamic delegateBlock match. objectMappingForDataBlock = %@", (id)self.objectMappingForDataBlock);
         }
     }
     

--- a/Code/ObjectMapping/RKObjectMapper.m
+++ b/Code/ObjectMapping/RKObjectMapper.m
@@ -123,7 +123,7 @@
         } else if ([mapping isKindOfClass:[RKObjectMapping class]]) {
             objectMapping = (RKObjectMapping*)mapping;
         } else {
-            NSAssert(objectMapping, @"Encountered unknown mapping type '%@'", NSStringFromClass([mapping class]));
+            NSAssert1(objectMapping, @"Encountered unknown mapping type '%@'", NSStringFromClass([mapping class]));
         }        
         if (NO == [[self.targetObject class] isSubclassOfClass:objectMapping.objectClass]) {
             NSString* errorMessage = [NSString stringWithFormat:
@@ -237,7 +237,7 @@
     } else if ([mapping isKindOfClass:[RKObjectMapping class]]) {
         objectMapping = (RKObjectMapping*)mapping;
     } else {
-        NSAssert(objectMapping, @"Encountered unknown mapping type '%@'", NSStringFromClass([mapping class]));
+        NSAssert1(objectMapping, @"Encountered unknown mapping type '%@'", NSStringFromClass([mapping class]));
     }
     
     if (objectMapping) {

--- a/Code/ObjectMapping/RKObjectMappingOperation.m
+++ b/Code/ObjectMapping/RKObjectMappingOperation.m
@@ -417,7 +417,7 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue) {
                 } else if ([mapping isKindOfClass:[RKObjectMapping class]]) {
                     objectMapping = (RKObjectMapping*)mapping;
                 } else {
-                    NSAssert(objectMapping, @"Encountered unknown mapping type '%@'", NSStringFromClass([mapping class]));
+                    NSAssert1(objectMapping, @"Encountered unknown mapping type '%@'", NSStringFromClass([mapping class]));
                 }
                 id mappedObject = [objectMapping mappableObjectForData:nestedObject];
                 if ([self mapNestedObject:nestedObject toObject:mappedObject withRealtionshipMapping:relationshipMapping]) {
@@ -461,7 +461,7 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue) {
             } else if ([mapping isKindOfClass:[RKObjectMapping class]]) {
                 objectMapping = (RKObjectMapping*)mapping;
             }
-            NSAssert(objectMapping, @"Encountered unknown mapping type '%@'", NSStringFromClass([mapping class]));
+            NSAssert1(objectMapping, @"Encountered unknown mapping type '%@'", NSStringFromClass([mapping class]));
             destinationObject = [objectMapping mappableObjectForData:value];
             if ([self mapNestedObject:value toObject:destinationObject withRealtionshipMapping:relationshipMapping]) {
                 appliedMappings = YES;

--- a/Vendor/JSONKit/JSONKit.m
+++ b/Vendor/JSONKit/JSONKit.m
@@ -1624,7 +1624,7 @@ static int jk_parse_string(JKParseState *parseState) {
           break;
 
         case JSONStringStateEscapedNeedEscapeForSurrogate:
-          if((currentChar == '\\')) { stringState = JSONStringStateEscapedNeedEscapedUForSurrogate; }
+          if(currentChar == '\\') { stringState = JSONStringStateEscapedNeedEscapedUForSurrogate; }
           else { 
             if((parseState->parseOptionFlags & JKParseOptionLooseUnicode) == 0) { jk_error(parseState, @"Required a second \\u Unicode escape sequence following a surrogate \\u Unicode escape sequence."); stringState = JSONStringStateError; goto finishedParsing; }
             else { stringState = JSONStringStateParsing; atStringCharacter--;    if(jk_string_add_unicodeCodePoint(parseState, UNI_REPLACEMENT_CHAR, &tokenBufferIdx, &stringHash)) { jk_error(parseState, @"Internal error: Unable to add UTF8 sequence to internal string buffer. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); stringState = JSONStringStateError; goto finishedParsing; } }
@@ -1945,7 +1945,7 @@ static void *jk_parse_dictionary(JKParseState *parseState) {
           else {
             parseState->objectStack.keys[objectStackIndex] = key;
             if(JK_EXPECT_T(parseState->token.value.cacheItem != NULL)) {
-              if((parseState->token.value.cacheItem->cfHash == 0UL)) { parseState->token.value.cacheItem->cfHash = CFHash(key); }
+              if(parseState->token.value.cacheItem->cfHash == 0UL) { parseState->token.value.cacheItem->cfHash = CFHash(key); }
               parseState->objectStack.cfHashes[objectStackIndex] = parseState->token.value.cacheItem->cfHash;
             } else {
               parseState->objectStack.cfHashes[objectStackIndex] = CFHash(key);

--- a/Vendor/SOCKit/SOCKit.m
+++ b/Vendor/SOCKit/SOCKit.m
@@ -381,7 +381,7 @@ NSString* kTemporaryBackslashToken = @"/backslash/";
   id returnValue = nil;
 
   NSMethodSignature* sig = [object methodSignatureForSelector:selector];
-  NSAssert(nil != sig, @"%@ does not respond to selector: '%@'", object, NSStringFromSelector(selector));
+  NSAssert2(nil != sig, @"%@ does not respond to selector: '%@'", object, NSStringFromSelector(selector));
   NSInvocation* invocation = [NSInvocation invocationWithMethodSignature:sig];
   [invocation setTarget:object];
   [invocation setSelector:selector];
@@ -460,7 +460,7 @@ NSString* kTemporaryBackslashToken = @"/backslash/";
   NSMutableDictionary* parameterValues = [NSMutableDictionary dictionaryWithCapacity:[_parameters count]];
   for (SOCParameter* parameter in _parameters) {
     NSString* stringValue = [NSString stringWithFormat:@"%@", [object valueForKeyPath:parameter.string]];
-    if (nil != block) {
+    if (0 != block) {
       stringValue = block(stringValue);
     }
     if (nil != stringValue) {


### PR DESCRIPTION
This is a more targeted version of my previous pull request, and should be much more mergeable.
