### PR TITLE
Download progress for RKRequest

### DIFF
--- a/Code/Network/RKRequest.h
+++ b/Code/Network/RKRequest.h
@@ -445,6 +445,11 @@ typedef enum {
 - (void)request:(RKRequest *)request didSendBodyData:(NSInteger)bytesWritten totalBytesWritten:(NSInteger)totalBytesWritten totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite;
 
 /**
+ * Sent when request has received data from remote site
+ */
+- (void)request:(RKRequest*)request didReceivedData:(NSInteger)bytesReceived totalBytesReceived:(NSInteger)totalBytesReceived totalBytesExectedToReceive:(NSInteger)totalBytesExpectedToReceive;
+
+/**
  * Sent to the delegate when a request was cancelled
  */
 - (void)requestDidCancelLoad:(RKRequest *)request;

--- a/Code/Network/RKResponse.m
+++ b/Code/Network/RKResponse.m
@@ -187,6 +187,9 @@ extern NSString* cacheURLKey;
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
 	[_body appendData:data];
+    if ([[_request delegate] respondsToSelector:@selector(request:didReceivedData:totalBytesReceived:totalBytesExectedToReceive:)]) {
+        [[_request delegate] request:_request didReceivedData:[data length] totalBytesReceived:[_body length] totalBytesExectedToReceive:_httpURLResponse.expectedContentLength];
+    }
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSHTTPURLResponse *)response {	


### PR DESCRIPTION
Adds optional request:didReceivedData:totalBytesReceived:totalBytesExectedToReceive: to RQRequestDelegate. It will be called each time when part if data is received from server. Method signature is similar to request:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite:. It can be useful when downloading large amount of data
