### PR TITLE
Log much-needed info when context fails to save

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -119,17 +119,45 @@ static NSString* const RKManagedObjectStoreThreadDictionaryEntityCacheKey = @"RK
  */
 - (NSError*)save {
 	NSManagedObjectContext* moc = [self managedObjectContext];
-    NSError *error = nil;
-	
+	NSError *error;
 	@try {
 		if (![moc save:&error]) {
 			if (self.delegate != nil && [self.delegate respondsToSelector:@selector(managedObjectStore:didFailToSaveContext:error:exception:)]) {
 				[self.delegate managedObjectStore:self didFailToSaveContext:moc error:error exception:nil];
 			}
-			
+
 			NSDictionary* userInfo = [NSDictionary dictionaryWithObject:error forKey:@"error"];
 			[[NSNotificationCenter defaultCenter] postNotificationName:RKManagedObjectStoreDidFailSaveNotification object:self userInfo:userInfo];
-			
+
+			if ([[error domain] isEqualToString:@"NSCocoaErrorDomain"]) {
+				NSDictionary *userInfo = [error userInfo];
+				NSArray *errors = [userInfo valueForKey:@"NSDetailedErrors"];
+				if (errors) {
+					for (NSError *detailedError in errors) {
+						NSDictionary *subUserInfo = [detailedError userInfo];
+						RKLogError(@"Core Data Save Error\n \
+							  NSLocalizedDescription:\t\t%@\n \
+							  NSValidationErrorKey:\t\t\t%@\n \
+							  NSValidationErrorPredicate:\t%@\n \
+							  NSValidationErrorObject:\n%@\n",
+							  [subUserInfo valueForKey:@"NSLocalizedDescription"], 
+							  [subUserInfo valueForKey:@"NSValidationErrorKey"], 
+							  [subUserInfo valueForKey:@"NSValidationErrorPredicate"], 
+							  [subUserInfo valueForKey:@"NSValidationErrorObject"]);
+					}
+				}
+				else {
+					RKLogError(@"Core Data Save Error\n \
+							   NSLocalizedDescription:\t\t%@\n \
+							   NSValidationErrorKey:\t\t\t%@\n \
+							   NSValidationErrorPredicate:\t%@\n \
+							   NSValidationErrorObject:\n%@\n", 
+							   [userInfo valueForKey:@"NSLocalizedDescription"],
+							   [userInfo valueForKey:@"NSValidationErrorKey"], 
+							   [userInfo valueForKey:@"NSValidationErrorPredicate"], 
+							   [userInfo valueForKey:@"NSValidationErrorObject"]);
+				}
+			} 
 			return error;
 		}
 	}


### PR DESCRIPTION
- Makes it much easier to debug Core Data validation problems
- Adapted from code by Chris Lozach
- See: http://stackoverflow.com/questions/1283960/iphone-core-data-unresolved-error-while-saving
