### PR TITLE
No real reason why we need to warn on null collections

### DIFF
--- a/Code/ObjectMapping/RKObjectMapper.m
+++ b/Code/ObjectMapping/RKObjectMapper.m
@@ -101,7 +101,7 @@
     
     if ([object respondsToSelector:@selector(countForObject:)] && [object count] > 0) {        
         if ([object countForObject:[NSNull null]] == [object count]) {
-            RKLogLevelDebug(@"Found a collection containing only NSNull values, considering the collection unmappable...");
+            RKLogDebug(@"Found a collection containing only NSNull values, considering the collection unmappable...");
             return YES;
         }
     }


### PR DESCRIPTION
No real reason why we need to warn on null collections, debug level logging will do just fine. Inspired by the answer here: http://stackoverflow.com/questions/7064233/restkit-warning-found-a-collection-containing-only-nsnull-values
