### PR TITLE
Adding missing exception name

### DIFF
--- a/Code/ObjectMapping/RKObjectRouter.m
+++ b/Code/ObjectMapping/RKObjectRouter.m
@@ -124,7 +124,7 @@
         return path;
     }
 
-    [NSException raise:nil format:@"Unable to find a routable path for object of type '%@' for HTTP Method '%@'", className, methodName];
+    [NSException raise:@"Unable to find a routable path for object" format:@"Unable to find a routable path for object of type '%@' for HTTP Method '%@'", className, methodName];
     
     return nil;
 }


### PR DESCRIPTION
Adding missing exception name.  Without it, no exception is printed to the console in debug mode and no stack trace persists, which makes it very hard to debug.
