### PR TITLE
Fixes crash when seeing if it should map NSNull value

### DIFF
--- a/Code/ObjectMapping/RKObjectMappingOperation.m
+++ b/Code/ObjectMapping/RKObjectMappingOperation.m
@@ -213,6 +213,9 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue) {
     if (currentValue == [NSNull null] || [currentValue isEqual:[NSNull null]]) {
         currentValue = nil;
     }
+    if (value == [NSNull null] || [value isEqual:[NSNull null]]) {
+        value = nil;
+    }
     
 	if (nil == currentValue && nil == value) {
 		// Both are nil


### PR DESCRIPTION
Fixes crash when checking to see if you should set value to the new value for a keypath. If the new value is NSNull it will change it to nil to avoid crash.
