### PR TITLE
Silence a warning from the static analyzer.

### DIFF
--- a/Code/Network/RKOAuthClient.h
+++ b/Code/Network/RKOAuthClient.h
@@ -32,7 +32,8 @@ typedef enum RKOAuthClientErrors {
     RKOAuthClientErrorInvalidRequest            = 3004,     // 
     RKOAuthClientErrorUnsupportedGrantType      = 3005,     // 
     RKOAuthClientErrorInvalidScope              = 3006,     // 
-    RKOAuthClientErrorRequestError              = 3007      // 
+    RKOAuthClientErrorRequestError              = 3007,     //
+    RKOAuthClientErrorUnknownErrorResponse      = 0         // Error was encountered but error_response invalid
 } RKOAuthClientErrorCode;
 
 @protocol RKOAuthClientDelegate;

--- a/Code/Network/RKOAuthClient.m
+++ b/Code/Network/RKOAuthClient.m
@@ -92,7 +92,7 @@
             // Heads-up! There is an error in the response
             // The possible errors are defined in the OAuth2 Protocol
             
-            RKOAuthClientErrorCode errorCode;
+            RKOAuthClientErrorCode errorCode = RKOAuthClientErrorUnknownErrorResponse;
             NSString *errorDescription = [oauthResponse objectForKey:@"error_description"];
             
             if ([errorResponse isEqualToString:@"invalid_grant"]) {


### PR DESCRIPTION
Add a OAuth2 error code to be explicit about the
uninitialized state of the client error code.
