### PR TITLE
Request delegate can learn of authentication failures

### DIFF
--- a/Code/Network/RKRequest.h
+++ b/Code/Network/RKRequest.h
@@ -469,4 +469,9 @@ typedef enum {
  */
 - (void)requestDidTimeout:(RKRequest *)request;
 
+/**
+ * Sent when a request fails authentication
+ */
+- (void)requestDidFailAuthenticationChallenge:(RKRequest *)request;
+
 @end

--- a/Code/Network/RKResponse.m
+++ b/Code/Network/RKResponse.m
@@ -51,9 +51,7 @@ extern NSString* cacheURLKey;
 - (id)initWithRequest:(RKRequest*)request {
     self = [self init];
 	if (self) {
-		// We don't retain here as we're letting RKRequestQueue manage
-		// request ownership
-		_request = request;
+		_request = [request retain];
 	}
 
 	return self;
@@ -73,7 +71,7 @@ extern NSString* cacheURLKey;
 - (id)initWithSynchronousRequest:(RKRequest*)request URLResponse:(NSHTTPURLResponse*)URLResponse body:(NSData*)body error:(NSError*)error {
     self = [super init];
 	if (self) {
-		_request = request;
+		_request = [request retain];
 		_httpURLResponse = [URLResponse retain];
 		_failureError = [error retain];
         _body = [[NSMutableData dataWithData:body] retain];
@@ -84,6 +82,8 @@ extern NSString* cacheURLKey;
 }
 
 - (void)dealloc {
+	[_request release];
+	_request = nil;
 	[_httpURLResponse release];
 	_httpURLResponse = nil;
 	[_body release];
@@ -153,6 +153,9 @@ extern NSString* cacheURLKey;
 	} else {
 	    RKLogWarning(@"Failed authentication challenge after %d failures", [challenge previousFailureCount]);
 		[[challenge sender] cancelAuthenticationChallenge:challenge];
+		if ([[_request delegate] respondsToSelector:@selector(requestDidFailAuthenticationChallenge:)]) {
+			[[_request delegate] requestDidFailAuthenticationChallenge:_request];
+		}
 	}
 }
 


### PR DESCRIPTION
c.f. [Antonio Mancina's request on the mailing list](http://groups.google.com/group/restkit/browse_thread/thread/239d35efdf9e16a5/839b84452f4b3e26)

Unfortunately, I found that the request queue was releasing the request by the time the response wanted to send to the request's delegate. Given the comment in RKResponse.m about not retaining the request, I assume that had some good reasoning behind it. I'm not sure what that reasoning is, though, so I'm not sure what else to do about it. Thoughts?
