### PR TITLE
Fix static analayzer warning for uninitialized variable

### DIFF
--- a/Code/Network/RKOAuthClient.h
+++ b/Code/Network/RKOAuthClient.h
@@ -32,7 +32,8 @@ typedef enum RKOAuthClientErrors {
     RKOAuthClientErrorInvalidRequest            = 3004,     // 
     RKOAuthClientErrorUnsupportedGrantType      = 3005,     // 
     RKOAuthClientErrorInvalidScope              = 3006,     // 
-    RKOAuthClientErrorRequestError              = 3007      // 
+    RKOAuthClientErrorRequestError              = 3007,     //
+    RKOAuthClientErrorUnknownErrorDescription   = 0         // Error was encountered and error_description unknown
 } RKOAuthClientErrorCode;
 
 @protocol RKOAuthClientDelegate;

--- a/Code/Network/RKOAuthClient.m
+++ b/Code/Network/RKOAuthClient.m
@@ -92,7 +92,7 @@
             // Heads-up! There is an error in the response
             // The possible errors are defined in the OAuth2 Protocol
             
-            RKOAuthClientErrorCode errorCode;
+            RKOAuthClientErrorCode errorCode = RKOAuthClientErrorUnknownErrorDescription;
             NSString *errorDescription = [oauthResponse objectForKey:@"error_description"];
             
             if ([errorResponse isEqualToString:@"invalid_grant"]) {


### PR DESCRIPTION
Sorry to be so noisy about this somewhat trivial issue.  I am still getting used to how github works for collaboration.  This patch is pretty much the same thing as pull-request/issue #449 except this time I put the change on a branch so I can work on some other things without polluting the change set.  I also think I made the variable name a little better.

The issue is that if you run the analyzer you get an initialized variable warning.  It is most likely a false positive (assuming the server conforms correctly to the OAuth2 spec) but I think it is better to get rid of the warning clutter.

```
RestKit/Code/Network/RKOAuthClient.m:119:30:{119:81-119:90}: warning: Argument in message expression is an uninitialized value
                          NSError *error = [NSError errorWithDomain:RKRestKitErrorDomain code:errorCode userInfo:userInfo];
                                           ^                                                  ~~~~~~~~~
             1 warning generated.
```

If this change turns out to be unacceptable, that is fine.  I'm in it for the learning experience of it.
