### PR TITLE
Corrects test failure in testShouldConsiderADictionaryContainingOnlyNullValue...

### DIFF
--- a/Specs/ObjectMapping/RKObjectMappingNextGenSpec.m
+++ b/Specs/ObjectMapping/RKObjectMappingNextGenSpec.m
@@ -882,7 +882,7 @@
     RKObjectMappingOperation* operation = [[RKObjectMappingOperation alloc] initWithSourceObject:dictionary destinationObject:user mapping:mapping];
     BOOL success = [operation performMapping:nil];
     assertThatBool(success, is(equalToBool(YES)));
-    assertThat(user.name, is(equalTo([NSNull null])));
+    assertThat(user.name, is(nilValue()));
     [operation release];
 }
 


### PR DESCRIPTION
I am not certain what the expected behavior is.  Perhaps it actually is supposed to be returning [NSNull null].  
Maybe this test was added for the purpose of tracking down this exact issue?  (not sure)  Anyway, this change makes the test pass.

2011-12-09 14:51:05.657 otest[64680:3b03] W restkit.object_mapping:RKObjectMappingOperation.m:230 Coercing NSNull value to nil in shouldSetValue:atKeyPath: -- should be fixed.
