### PR TITLE
Fix test: date conversion failure

### DIFF
--- a/Specs/ObjectMapping/RKObjectMappingNextGenSpec.m
+++ b/Specs/ObjectMapping/RKObjectMappingNextGenSpec.m
@@ -964,6 +964,8 @@
 #pragma mark - Attribute Mapping
 
 - (void)testShouldMapAStringToADateAttribute {
+    [RKObjectMapping setDefaultDateFormatters:nil];
+
     RKObjectMapping* mapping = [RKObjectMapping mappingForClass:[RKExampleUser class]];
     RKObjectAttributeMapping* birthDateMapping = [RKObjectAttributeMapping mappingFromKeyPath:@"birthdate" toKeyPath:@"birthDate"];
     [mapping addAttributeMapping:birthDateMapping];


### PR DESCRIPTION
Default date formatters need to be reset.    Without it, it doesn't have the formatter to understand mm/dd/yyyy.

This makes the test pass.
