### PR TITLE
Fixed: RKResponse parsedBody will fail when encountering a parsing error if it was called with a nil NSError pointer

### DIFF
--- a/Code/Network/RKResponse.m
+++ b/Code/Network/RKResponse.m
@@ -244,7 +244,7 @@ extern NSString* cacheURLKey;
     }
     id object = [parser objectFromString:[self bodyAsString] error:error];
     if (object == nil) {
-        if (*error) {
+        if (error && *error) {
             RKLogError(@"Unable to parse response body: %@", [*error localizedDescription]);
         }
         return nil;


### PR DESCRIPTION
Minimal change, but worth the effort.  I checked but didn't see any similar errors in the rest of the library.
