### PR TITLE
Proposal: Use the RKResponse and not only the MIMEtype to determinate the Parser to be used.

### DIFF
--- a/Code/Network/RKResponse.m
+++ b/Code/Network/RKResponse.m
@@ -244,7 +244,7 @@ extern NSString* cacheURLKey;
 }
 
 - (id)parsedBody:(NSError**)error {
-    id<RKParser> parser = [[RKParserRegistry sharedRegistry] parserForMIMEType:[self MIMEType]];
+    id<RKParser> parser = [[RKParserRegistry sharedRegistry] parserForResponse:self];
     if (! parser) {
         RKLogWarning(@"Unable to parse response body: no parser registered for MIME Type '%@'", [self MIMEType]);
         return nil;

--- a/Code/ObjectMapping/RKObjectLoader.m
+++ b/Code/ObjectMapping/RKObjectLoader.m
@@ -153,7 +153,7 @@
 #pragma mark - Response Object Mapping
 
 - (RKObjectMappingResult*)mapResponseWithMappingProvider:(RKObjectMappingProvider*)mappingProvider toObject:(id)targetObject error:(NSError**)error {
-    id<RKParser> parser = [[RKParserRegistry sharedRegistry] parserForMIMEType:self.response.MIMEType];
+    id<RKParser> parser = [[RKParserRegistry sharedRegistry] parserForResponse:self.response];
     NSAssert1(parser, @"Cannot perform object load without a parser for MIME Type '%@'", self.response.MIMEType);
     
     // Check that there is actually content in the response body for mapping. It is possible to get back a 200 response
@@ -235,7 +235,7 @@
 }
 
 - (BOOL)canParseMIMEType:(NSString*)MIMEType {
-    if ([[RKParserRegistry sharedRegistry] parserForMIMEType:self.response.MIMEType]) {
+    if ([[RKParserRegistry sharedRegistry] parserForResponse:self.response]) {
         return YES;
     }
     

--- a/Code/ObjectMapping/RKParserRegistry.h
+++ b/Code/ObjectMapping/RKParserRegistry.h
@@ -20,6 +20,7 @@
 
 #import "../Support/RKMIMETypes.h"
 #import "../Support/RKParser.h"
+#import "../Network/RKResponse.h"
 
 /**
  The Parser Registry provides for the registration of RKParser classes
@@ -49,6 +50,18 @@
  for a given MIME Type
  */
 - (Class<RKParser>)parserClassForMIMEType:(NSString *)MIMEType;
+
+/**
+ Instantiate and return a Parser for the given Response
+ */
+- (id<RKParser>)parserForResponse:(RKResponse *)response;
+
+/**
+ Return the class registered for handling parser/encoder operations
+ for a given Response
+ */
+- (Class<RKParser>)parserClassForResponse:(RKResponse *)response;
+
 
 /**
  Registers an RKParser conformant class as the handler for the specified MIME Type

--- a/Code/ObjectMapping/RKParserRegistry.m
+++ b/Code/ObjectMapping/RKParserRegistry.m
@@ -57,6 +57,11 @@ RKParserRegistry* gSharedRegistry;
     return [_MIMETypeToParserClasses objectForKey:MIMEType];
 }
 
+- (id<RKParser>)parserForResponse:(RKResponse *)response {
+    return [self parserForMIMEType:response.MIMEType];
+}
+
+
 - (void)setParserClass:(Class<RKParser>)parserClass forMIMEType:(NSString*)MIMEType {
     [_MIMETypeToParserClasses setObject:parserClass forKey:MIMEType];
 }
@@ -68,6 +73,10 @@ RKParserRegistry* gSharedRegistry;
     }
     
     return nil;
+}
+
+- (Class<RKParser>)parserClassForResponse:(RKResponse *)response {
+    return [self parserClassForMIMEType:response.MIMEType];
 }
 
 - (void)autoconfigure {


### PR DESCRIPTION
This allows implementations of RKParserRegistry which provide different Parsers i.e. depending on the url etc. 
