### PR TITLE
Add additional quick start installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ button and confirm that your "Build Location" is the "Derived Data Location".
 1. Add cross-project reference by dragging **RestKit.xcodeproj** to your project
 1. Open build settings editor for your project
 1. Add **Other Linker Flags** for `-ObjC -all_load`
+1. Add **Header Search Paths** for `"$(SOURCE_ROOT)/RestKit/Build"` (including the surrounding quotes -- they are important!)
 1. Open target settings editor for the target you want to link RestKit into
 1. Add direct dependency on the **RestKit** aggregate target
 1. Link against required frameworks:


### PR DESCRIPTION
The wiki installation guide includes a step for adding header search path.  I've added a shortened version of this step to the quick start guide in the README.
