### PR TITLE
Fix for ocassional crashes using http basic auth

### DIFF
--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -234,12 +234,15 @@
     // Add authentication headers so we don't have to deal with an extra cycle for each message requiring basic auth.
     if (self.authenticationType == RKRequestAuthenticationTypeHTTPBasic) {        
         CFHTTPMessageRef dummyRequest = CFHTTPMessageCreateRequest(kCFAllocatorDefault, (CFStringRef)[self HTTPMethod], (CFURLRef)[self URL], kCFHTTPVersion1_1);
-        
-        CFHTTPMessageAddAuthentication(dummyRequest, nil, (CFStringRef)_username, (CFStringRef)_password,kCFHTTPAuthenticationSchemeBasic, FALSE);
-        CFStringRef authorizationString = CFHTTPMessageCopyHeaderFieldValue(dummyRequest, CFSTR("Authorization"));
-        [_URLRequest setValue:(NSString *)authorizationString forHTTPHeaderField:@"Authorization"];
-        CFRelease(dummyRequest);
-        CFRelease(authorizationString);
+        if (dummyRequest) {
+          CFHTTPMessageAddAuthentication(dummyRequest, nil, (CFStringRef)_username, (CFStringRef)_password,kCFHTTPAuthenticationSchemeBasic, FALSE);
+          CFStringRef authorizationString = CFHTTPMessageCopyHeaderFieldValue(dummyRequest, CFSTR("Authorization"));
+          if (authorizationString) {
+            [_URLRequest setValue:(NSString *)authorizationString forHTTPHeaderField:@"Authorization"];
+            CFRelease(authorizationString);
+          }
+          CFRelease(dummyRequest);
+        }
     }
     
     // Add OAuth headers if is need it


### PR DESCRIPTION
Testing a server staged on Heroku, I have been getting occasional crashes with HTTP Basic Authentication even though my username/password are set.  

In my case authorizationString sometimes fails to copy the header "Authorization" and this ultimately results in a crash when CFRelease is called on a NULL authorizationString.  

```
CFStringRef authorizationString = CFHTTPMessageCopyHeaderFieldValue(dummyRequest, CFSTR("Authorization"));
```

The documentation states that CFHTTPMessageCopyHeaderValue can return NULL if the header is not found, and since CFRelease results in your program crashing when passed a NULL, I think some conditionals are appropriate.

I guess we might also consider putting in some debug logging with the expected headers are not present but I would settle for not crashing. :)
