### PR TITLE
This fixes a bug where attributes of a object would also get added to parent object.

### DIFF
--- a/Code/Support/Parsers/XML/RKXMLParserLibXML.m
+++ b/Code/Support/Parsers/XML/RKXMLParserLibXML.m
@@ -37,6 +37,8 @@
                     // Assume that empty strings are irrelevant and go for an attribute-collection instead
                     if ([val length] == 0) {
                         val = [NSMutableDictionary dictionary];
+                        attrs = [NSMutableDictionary dictionary];
+                        oldVal = [attrs valueForKey:nodeName];
                         NSMutableDictionary* elem = [NSMutableDictionary dictionaryWithObject:val forKey:nodeName];
                         [nodes addObject:elem];
                     } else {
@@ -50,7 +52,7 @@
                 }
                 
                 // Only add attributes to nodes if there actually is one.
-                if (![nodes containsObject:attrs]) {
+                if (![nodes containsObject:attrs] && [attrs count] > 0) {
                     [nodes addObject:attrs];
                 }
             } else {

--- a/Specs/Support/RKXMLParserSpec.m
+++ b/Specs/Support/RKXMLParserSpec.m
@@ -110,7 +110,8 @@
     NSDictionary* exchangeRate = [result objectForKey:@"exchange_rate"];
     assertThat(exchangeRate, is(notNilValue()));
     assertThat([exchangeRate objectForKey:@"type"], is(equalTo(@"XML_RATE_TYPE_EBNK_MIDDLE")));
-    assertThat([exchangeRate objectForKey:@"valid_from"], is(equalTo(@"2011-08-03 00:00:00.0")));    
+    assertThat([exchangeRate objectForKey:@"valid_from"], is(equalTo(@"2011-08-03 00:00:00.0")));
+    assertThat([exchangeRate objectForKey:@"name"], nilValue()); // This is to test for bug in parsing
     NSArray* currency = [exchangeRate objectForKey:@"currency"];
     assertThat(currency, hasCountOf(3));
     NSDictionary* firstCurrency = [currency objectAtIndex:0];


### PR DESCRIPTION
XML to parse

```
<exchange_rate type="XML_RATE_TYPE_EBNK_MIDDLE" valid_from="2011-08-03 00:00:00.0">
    <currency name="AUD" quota="1" rate="18.416"/>
    <currency name="HRK" quota="1" rate="3.25017"/>
    <currency name="DKK" quota="1" rate="3.251"/>
</exchange_rate>
```

BEFORE FIX

```
<CFBasicHash 0xab93140 [0x520b38]>{type = mutable dict, count = 1,
entries =>
    0 : <CFString 0xabacac0 [0x520b38]>{contents = "exchange_rate"} = <CFBasicHash 0xaba99e0 [0x520b38]>{type = mutable dict, count = 6,
entries =>
    0 : <CFString 0xabc1e40 [0x520b38]>{contents = "currency"} = (
        {
        name = AUD;
        quota = 1;
        rate = "18.416";
    },
        {
        name = HRK;
        quota = 1;
        rate = "3.25017";
    },
        {
        name = DKK;
        quota = 1;
        rate = "3.251";
    }
)
    1 : <CFString 0xaba9940 [0x520b38]>{contents = "name"} = <CFString 0xaba9960 [0x520b38]>{contents = "DKK"}
    2 : <CFString 0xaba9990 [0x520b38]>{contents = "rate"} = <CFString 0xaba99c0 [0x520b38]>{contents = "3.251"}
    3 : <CFString 0xaba9980 [0x520b38]>{contents = "quota"} = <CFString 0xaba99a0 [0x520b38]>{contents = "1"}
    4 : <CFString 0xab93180 [0x520b38]>{contents = "type"} = <CFString 0xab931b0 [0x520b38]>{contents = "XML_RATE_TYPE_EBNK_MIDDLE"}
    5 : <CFString 0xab93190 [0x520b38]>{contents = "valid_from"} = <CFString 0xab93220 [0x520b38]>{contents = "2011-08-03 00:00:00.0"}
}

}
```

AFTER FIX

```
<CFBasicHash 0xa689830 [0x520b38]>{type = mutable dict, count = 1,
entries =>
    0 : <CFString 0xa6816a0 [0x520b38]>{contents = "exchange_rate"} = <CFBasicHash 0xa6897c0 [0x520b38]>{type = mutable dict, count = 3,
entries =>
    0 : <CFString 0xa692100 [0x520b38]>{contents = "valid_from"} = <CFString 0xa692190 [0x520b38]>{contents = "2011-08-03 00:00:00.0"}
    1 : <CFString 0xa680860 [0x520b38]>{contents = "currency"} = (
        {
        name = AUD;
        quota = 1;
        rate = "18.416";
    },
        {
        name = HRK;
        quota = 1;
        rate = "3.25017";
    },
        {
        name = DKK;
        quota = 1;
        rate = "3.251";
    }
)
    2 : <CFString 0xa6920f0 [0x520b38]>{contents = "type"} = <CFString 0xa692120 [0x520b38]>{contents = "XML_RATE_TYPE_EBNK_MIDDLE"}
}

}
```
