### PR TITLE
Treating dates before January 1st 1970 on RKDotNetDateFormatter

### DIFF
--- a/Code/Support/RKDotNetDateFormatter.h
+++ b/Code/Support/RKDotNetDateFormatter.h
@@ -42,8 +42,9 @@
  Acceptable examples are:
     /Date(1112715000000-0500)/
     /Date(1112715000000)/
+    /Date(-1112715000000)/
  Where 1112715000000 is the number of milliseconds since January 1, 1970 00:00 GMT/UTC, and -0500 represents the
- timezone offset from GMT in 24-hour time.  
+ timezone offset from GMT in 24-hour time. Negatives milliseconds are treated as dates before January 1, 1970.
  
  *NOTE* NSDate objects do not have timezones, and you should never change an actual date value based on a
  timezone offset.  However, timezones are important when presenting dates to the user.  Therefore,

--- a/Code/Support/RKDotNetDateFormatter.m
+++ b/Code/Support/RKDotNetDateFormatter.m
@@ -58,7 +58,7 @@ NSTimeInterval millisecondsFromSeconds(NSTimeInterval seconds);
         self.locale = [[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"] autorelease];
         self.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
         [self setDateFormat:@"ZZ"]; // GMT offset, like "-0500"
-        NSString *pattern = @"\\/Date\\((\\d+)((?:[\\+\\-]\\d+)?)\\)\\/"; // /Date(mSecs)/ or /Date(mSecs-0400)/
+        NSString *pattern = @"\\/Date\\((-?\\d+)((?:[\\+\\-]\\d+)?)\\)\\/"; // /Date(mSecs)/ or /Date(-mSecs)/ or /Date(mSecs-0400)/
         dotNetExpression = [[NSRegularExpression alloc] initWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:NULL];
     }
     return self;

--- a/Specs/Support/RKDotNetDateFormatterSpec.m
+++ b/Specs/Support/RKDotNetDateFormatterSpec.m
@@ -44,6 +44,13 @@
     assertThat([date description], is(equalTo(@"2005-04-05 15:30:00 +0000")));
 }
 
+- (void)testShouldCreateADateFromDotNetBefore1970WithoutAnOffset {
+    NSString *dotNetString = @"/Date(-864000000000)/";
+    RKDotNetDateFormatter *formatter = [RKDotNetDateFormatter dotNetDateFormatter];
+    NSDate *date = [formatter dateFromString:dotNetString];
+    assertThat([date description], is(equalTo(@"1942-08-16 00:00:00 +0000")));
+}
+
 - (void)testShouldFailToCreateADateFromInvalidStrings {
     RKDotNetDateFormatter *formatter = [RKDotNetDateFormatter dotNetDateFormatter];
     NSDate *date = [formatter dateFromString:nil];
@@ -61,6 +68,13 @@
     NSString *string = [formatter stringFromDate:referenceDate];
     assertThat(formatter.timeZone, is(equalTo(timeZoneEST)));
     assertThat(string, is(equalTo(@"/Date(1000212360000-0400)/")));
+}
+
+- (void)testShouldCreateADotNetStringFromADateBefore1970WithoutAnOffset {
+    RKDotNetDateFormatter *formatter = [RKDotNetDateFormatter dotNetDateFormatter];
+    NSDate *referenceDate = [NSDate dateWithTimeIntervalSince1970:-1000212360];
+    NSString *string = [formatter stringFromDate:referenceDate];
+    assertThat(string, is(equalTo(@"/Date(-1000212360000+0000)/")));
 }
 
 


### PR DESCRIPTION
Dates before 1970 are generate on .net with a negative number of milliseconds so I added that to the regex that parses those dates.
