### PR TITLE
Fix base URL in failing timeout test

### DIFF
--- a/Specs/Network/RKRequestSpec.m
+++ b/Specs/Network/RKRequestSpec.m
@@ -95,7 +95,7 @@
 - (void)testShouldTimeoutAtInterval {
     RKSpecResponseLoader* loader = [RKSpecResponseLoader responseLoader];
     id loaderMock = [OCMockObject partialMockForObject:loader];
-    NSString* url = [NSString stringWithFormat:@"%@/timeout", RKSpecGetBaseURL()];
+    NSString* url = [NSString stringWithFormat:@"%@/timeout", RKSpecGetBaseURLString()];
     NSURL* URL = [NSURL URLWithString:url];
     RKRequest* request = [[RKRequest alloc] initWithURL:URL];
     request.delegate = loaderMock;


### PR DESCRIPTION
It looks like there were some changes that caused this to start failing.  I've fixed the test to build its URL properly so that testShouldTimeoutAtInterval passes again.
