### PR TITLE
Implemented Proposed Fix for #548

### DIFF
--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -441,17 +441,18 @@
             RKLogInfo(@"Beginning background task to perform processing...");
             
             // Fork a background task for continueing a long-running request
+            __block RKRequest* weakSelf = self;
+            __block id<RKRequestDelegate> weakDelegate = _delegate;
             _backgroundTaskIdentifier = [app beginBackgroundTaskWithExpirationHandler:^{
                 RKLogInfo(@"Background request time expired, canceling request.");
                 
-                [self cancelAndInformDelegate:NO];
-                [self cleanupBackgroundTask];
+                [weakSelf cancelAndInformDelegate:NO];
+                [weakSelf cleanupBackgroundTask];
                 
-                if ([_delegate respondsToSelector:@selector(requestDidTimeout:)]) {
-                    [_delegate requestDidTimeout:self];
+                if ([weakDelegate respondsToSelector:@selector(requestDidTimeout:)]) {
+                    [weakDelegate requestDidTimeout:weakSelf];
                 }
-            }];
-            
+            }];           
             // Start the potentially long-running request
             [self fireAsynchronousRequest];
         }


### PR DESCRIPTION
I was having the same problem as sylvainlaurent and implemented the fix suggested in the comments.

Tested uploading several images and they no longer remain allocated after the request completes.

It does, however, seem to be the case that if the application goes into the background before completion, the memory is not released until the app is relaunched - but it will release.
