### PR TITLE
Added default date formatter to start of NSArray

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -376,7 +376,7 @@ static NSDateFormatter *preferredDateFormatter = nil;
 
 + (void)addDefaultDateFormatter:(id)dateFormatter {
     [self defaultDateFormatters];
-    [defaultDateFormatters addObject:dateFormatter];
+    [defaultDateFormatters insertObject:dateFormatter atIndex:0];
 }
 
 + (void)addDefaultDateFormatterForString:(NSString *)dateFormatString inTimeZone:(NSTimeZone *)nilOrTimeZone {


### PR DESCRIPTION
Always add default date formatters to start of array to be tried first. RKISO8601DateFormatter will match a lot of different dates and most likely your default date formatter was not getting hit since it was last in the list.
