### PR TITLE
connectRelationship Using Incorrect ManagedObjectContext

### DIFF
--- a/Code/CoreData/RKManagedObjectMappingOperation.m
+++ b/Code/CoreData/RKManagedObjectMappingOperation.m
@@ -68,11 +68,11 @@
         if ([valueOfLocalPrimaryKeyAttribute conformsToProtocol:@protocol(NSFastEnumeration)]) {
             RKLogTrace(@"Connecting has-many relationship at keyPath '%@' to object with primaryKey attribute '%@'", relationshipName, primaryKeyAttributeOfRelatedObject);
             NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K IN %@", primaryKeyAttributeOfRelatedObject, valueOfLocalPrimaryKeyAttribute];
-            NSArray *objects = [objectMapping.objectClass findAllWithPredicate:predicate];
+            NSArray *objects = [objectMapping.objectClass findAllWithPredicate:predicate inContext:[self.destinationObject managedObjectContext]];
             relatedObject = [NSSet setWithArray:objects];
         } else {
             RKLogTrace(@"Connecting has-one relationship at keyPath '%@' to object with primaryKey attribute '%@'", relationshipName, primaryKeyAttributeOfRelatedObject);
-            relatedObject = [objectMapping.objectClass findFirstByAttribute:primaryKeyAttributeOfRelatedObject withValue:valueOfLocalPrimaryKeyAttribute];
+            relatedObject = [objectMapping.objectClass findFirstByAttribute:primaryKeyAttributeOfRelatedObject withValue:valueOfLocalPrimaryKeyAttribute inContext:[self.destinationObject managedObjectContext]];
         }      
         if (relatedObject) {                
             RKLogDebug(@"Connected relationship '%@' to object with primary key value '%@': %@", relationshipName, valueOfLocalPrimaryKeyAttribute, relatedObject);


### PR DESCRIPTION
I have an application that has two Core Data databases (sqllite) open at the same time.  The changes to the development branch over the last few months have made this much easier to support.

However, connectRelatonship still makes an assumption about which managedObjectContext to use.  In my case, it guesses wrong, using a managedObjectContext for the wrong database.

This patch fixes the issue by having connectRelationship use the managedObjectContext associated with the destination object, since that is the correct managedObjectContext.

Thanks - Charlie
