### PR TITLE
Missing Release For Object store

### DIFF
--- a/Code/CoreData/RKManagedObjectLoader.m
+++ b/Code/CoreData/RKManagedObjectLoader.m
@@ -64,6 +64,7 @@
     _targetObjectID = nil;
     _deleteObjectOnFailure = NO;
     [_managedObjectKeyPaths release];
+    [_objectStore release];
     
     [super dealloc];
 }


### PR DESCRIPTION
I noticed that when an ObjectManager is deallocated its object store was not.  Looks like RKManagedObjectLoader is not correctly releasing its retained reference to the object store.  With the attached patch, the object store was correctly deallocated when its parent object manager was deallocated.

Thanks - Charlie
