### PR TITLE
support for mapping -> to many relationships by primary key

### DIFF
--- a/Code/CoreData/RKManagedObjectMapping.m
+++ b/Code/CoreData/RKManagedObjectMapping.m
@@ -138,7 +138,7 @@
     
     // If we have found the primary key attribute & value, try to find an existing instance to update
     if (primaryKeyAttribute && primaryKeyValue) {                
-        object = [objectStore findOrCreateInstanceOfEntity:entity withPrimaryKeyAttribute:primaryKeyAttribute andValue:primaryKeyValue];
+        object = [objectStore findInstanceOfEntity:entity withPrimaryKeyAttribute:primaryKeyAttribute andValue:primaryKeyValue create:YES];
         NSAssert2(object, @"Failed creation of managed object with entity '%@' and primary key value '%@'", entity.name, primaryKeyValue);
     } else {
         object = [[[NSManagedObject alloc] initWithEntity:entity

--- a/Code/CoreData/RKManagedObjectStore.h
+++ b/Code/CoreData/RKManagedObjectStore.h
@@ -136,7 +136,7 @@ extern NSString* const RKManagedObjectStoreDidFailSaveNotification;
  * the primary key attribute and value for the desired object. Internally, this method
  * constructs a thread-local cache of managed object instances to avoid repeated fetches from the store
  */
-- (NSManagedObject*)findOrCreateInstanceOfEntity:(NSEntityDescription*)entity withPrimaryKeyAttribute:(NSString*)primaryKeyAttribute andValue:(id)primaryKeyValue;
+- (NSManagedObject*)findInstanceOfEntity:(NSEntityDescription*)entity withPrimaryKeyAttribute:(NSString*)primaryKeyAttribute andValue:(id)primaryKeyValue create:(BOOL)create;
 
 /**
  * Returns an array of objects that the 'live' at the specified resource path. Usage of this

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -339,7 +339,7 @@ static NSString* const RKManagedObjectStoreThreadDictionaryEntityCacheKey = @"RK
 	return objectArray;
 }
 
-- (NSManagedObject*)findOrCreateInstanceOfEntity:(NSEntityDescription*)entity withPrimaryKeyAttribute:(NSString*)primaryKeyAttribute andValue:(id)primaryKeyValue {
+- (NSManagedObject*)findInstanceOfEntity:(NSEntityDescription*)entity withPrimaryKeyAttribute:(NSString*)primaryKeyAttribute andValue:(id)primaryKeyValue create:(BOOL)create {
     NSAssert(entity, @"Cannot instantiate managed object without a target class");
     NSAssert(primaryKeyAttribute, @"Cannot find existing managed object instance without a primary key attribute");
     NSAssert(primaryKeyValue, @"Cannot find existing managed object by primary key without a value");
@@ -382,7 +382,7 @@ static NSString* const RKManagedObjectStoreThreadDictionaryEntityCacheKey = @"RK
     NSAssert1(dictionary, @"Thread local cache of %@ objects should not be nil", entityName);
     object = [dictionary objectForKey:lookupValue];
     
-    if (object == nil) {
+    if (object == nil && create) {
         object = [[[NSManagedObject alloc] initWithEntity:entity insertIntoManagedObjectContext:self.managedObjectContext] autorelease];
         [dictionary setObject:object forKey:lookupValue];
     }


### PR DESCRIPTION
This makes the connectRelationship:withObjectForPrimaryKeyAttribute: work when the attribute is an array of ids.
It also changes how the relationship is done so that objects that have only just been created can be connected to.
For a structure such as
{
  items: [{id: 1}, {id: 2}, {id: 3}],
  itemgroups: [{items: [1, 2]}, {items:[2, 3]}]
}
