### PR TITLE
Fixing RKFetchRequestMappingCache

### DIFF
--- a/Code/CoreData/RKFetchRequestMappingCache.m
+++ b/Code/CoreData/RKFetchRequestMappingCache.m
@@ -33,7 +33,8 @@
     NSFetchRequest* fetchRequest = [[NSFetchRequest alloc] init];
     [fetchRequest setEntity:entity];
     [fetchRequest setFetchLimit:1];
-    [fetchRequest setPredicate:[NSPredicate predicateWithFormat:@"%@ = %@", mapping.primaryKeyAttribute, lookupValue]];
+    NSString *predicateString = [mapping.primaryKeyAttribute stringByAppendingString:@" = %@"];
+    [fetchRequest setPredicate:[NSPredicate predicateWithFormat:predicateString, lookupValue]];
     NSArray *objects = [NSManagedObject executeFetchRequest:fetchRequest];
     RKLogDebug(@"Found objects '%@' using fetchRequest '%@'", objects, fetchRequest);
 


### PR DESCRIPTION
The current implementation creates a predicate that incorrectly quotes the attribute name (i.e. "railsID" == "1" vs railsID == "1") therefore the objects are never fetched from the cache and duplicates are created

Signed-off-by: Juan C. Méndez jcmendez@alum.mit.edu
