### PR TITLE
Quote path in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ namespace :spec do
   desc "Run the RestKit spec server"
   task :server do
     server_path = File.dirname(__FILE__) + '/Specs/Server/server.rb'
-    system("ruby #{server_path}")
+    system("ruby \"#{server_path}\"")
   end
 end
 


### PR DESCRIPTION
Hey all,

`rake spec:server` gives a `LoadError` when there's a space in the directory tree, e.g. `Xcode Projects/`. Quoting the path argument to `ruby` fixes the problem.

Works on my machine!
