### PR TITLE
Fixing bad output for empty date string

### DIFF
--- a/Code/ObjectMapping/RKObjectMappingOperation.m
+++ b/Code/ObjectMapping/RKObjectMappingOperation.m
@@ -123,7 +123,7 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue) {
     
     if (numeric) {
         date = [NSDate dateWithTimeIntervalSince1970:[numeric doubleValue]];
-    } else {
+    } else if(![string isEqualToString:@""]) {
         for (NSFormatter *dateFormatter in self.objectMapping.dateFormatters) {
             BOOL success;
 		@synchronized(dateFormatter) {

--- a/Tests/Logic/ObjectMapping/RKObjectMappingNextGenTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectMappingNextGenTest.m
@@ -1782,6 +1782,23 @@
     assertThat(dateFormatter.timeZone, is(equalTo(EDTTimeZone)));
 }
 
+- (void)testShouldReturnNilForEmptyDateValues {
+    RKObjectMapping* mapping = [RKObjectMapping mappingForClass:[RKTestUser class]];
+    RKObjectAttributeMapping* birthDateMapping = [RKObjectAttributeMapping mappingFromKeyPath:@"birthdate" toKeyPath:@"birthDate"];
+    [mapping addAttributeMapping:birthDateMapping];
+    
+    NSDictionary* dictionary = [RKTestFixture parsedObjectWithContentsOfFixture:@"user.json"];
+    NSMutableDictionary *mutableDictionary = [dictionary mutableCopy];
+    [mutableDictionary setValue:@"" forKey:@"birthdate"];
+    RKTestUser* user = [RKTestUser user];
+    RKObjectMappingOperation* operation = [[RKObjectMappingOperation alloc] initWithSourceObject:mutableDictionary destinationObject:user mapping:mapping];
+    [mutableDictionary release];
+    NSError* error = nil;
+    [operation performMapping:&error];
+    
+    assertThat(user.birthDate, is(equalTo(nil)));
+}
+
 - (void)testShouldConfigureANewDateFormatterInTheUTCTimeZoneIfPassedANilTimeZone {
     [RKObjectMapping setDefaultDateFormatters:nil];
     assertThat([RKObjectMapping defaultDateFormatters], hasCountOf(3));


### PR DESCRIPTION
Added test and fix for empty date @"" being set to a very strange date by the default ISO date formatter. This fixes #619.
