### PR TITLE
on CoreData mapping failure also call RKObjectLoader error block

### DIFF
--- a/Code/CoreData/RKManagedObjectLoader.m
+++ b/Code/CoreData/RKManagedObjectLoader.m
@@ -165,12 +165,11 @@
         BOOL success = [self.objectStore save:&error];
         if (! success) {
             RKLogError(@"Failed to save managed object context after mapping completed: %@", [error localizedDescription]);
-            NSMethodSignature* signature = [(NSObject *)self.delegate methodSignatureForSelector:@selector(objectLoader:didFailWithError:)];
+            NSMethodSignature* signature = [(NSObject *)self methodSignatureForSelector:@selector(informDelegateOfError:)];
             RKManagedObjectThreadSafeInvocation* invocation = [RKManagedObjectThreadSafeInvocation invocationWithMethodSignature:signature];
             [invocation setTarget:self.delegate];
-            [invocation setSelector:@selector(objectLoader:didFailWithError:)];
-            [invocation setArgument:&self atIndex:2];
-            [invocation setArgument:&error atIndex:3];
+            [invocation setSelector:@selector(informDelegateOfError:)];
+            [invocation setArgument:&error atIndex:2];
             [invocation invokeOnMainThread];
             return;
         }


### PR DESCRIPTION
Right now as it is coded, if there is a mapping failure the delegate method is called, however on non-CoreData methods, both the delegate and, if present, the block is called.  This commit will allow for the calling of both.
