### PR TITLE
Add RKLogConfigureFromEnvironment() to RKLog.m.

### DIFF
--- a/Code/Support/RKLog.h
+++ b/Code/Support/RKLog.h
@@ -83,6 +83,7 @@ lcl_log(RKLogComponent, lcl_vTrace, @"" __VA_ARGS__)
  
  These aliases simply map the log levels defined within LibComponentLogger to something more friendly
  */
+#define RKLogLevelOff       lcl_vOff
 #define RKLogLevelCritical  lcl_vCritical
 #define RKLogLevelError     lcl_vError
 #define RKLogLevelWarning   lcl_vWarning
@@ -137,13 +138,23 @@ lcl_configure_by_name("App", level);
         }                                                                               \
     } while(false);
 
+
 /**
  Temporarily changes the logging level for the configured RKLogComponent and executes the block. Any logging
  statements executed within the body of the block for the current logging component will log at the new
- logging level. After the block has finished excution, the logging level is restored to its previous state.
+ logging level. After the block has finished execution, the logging level is restored to its previous state.
  */
 #define RKLogWithLevelWhileExecutingBlock(_level, _block)                               \
     RKLogToComponentWithLevelWhileExecutingBlock(RKLogComponent, _level, _block)
+
+
+/**
+ Temporarily turns off logging for the execution of the block.
+ After the block has finished execution, the logging level is restored to its previous state.
+ */
+#define RKLogSilenceWhileExecutingBlock(_block)                                        \
+    RKLogToComponentWithLevelWhileExecutingBlock(RKLogComponent, RKLogLevelOff, _block)
+
 
 /**
  Set the Default Log Level
@@ -165,3 +176,26 @@ lcl_configure_by_name("App", level);
  Initialize the logging environment
  */
 void RKLogInitialize(void);
+
+
+/**
+ Configure RestKit logging from environment variables.
+ (Use Option + Command + R to set Environment Variables prior to run.)
+
+ For example to configure the equivalent of setting the following in code:
+ RKLogConfigureByName("RestKit/Network", RKLogLevelTrace);
+
+ Define an environment variable named RKLogLevel.RestKit.Network and set its value to "Trace"
+
+ See lcl_config_components.h for configurable RestKit logging components.
+
+ Valid values are the following:
+    Default  or 0
+    Critical or 1
+    Error    or 2
+    Warning  or 3
+    Info     or 4
+    Debug    or 5
+    Trace    or 6
+ */
+void RKLogConfigureFromEnvironment(void);

--- a/Code/Support/RKLog.m
+++ b/Code/Support/RKLog.m
@@ -21,6 +21,8 @@
 #import "RKLog.h"
 #import "lcl.h"
 
+int logLevelForString(NSString *, NSString *);
+
 static BOOL loggingInitialized = NO;
 
 void RKLogInitialize(void) {
@@ -29,5 +31,98 @@ void RKLogInitialize(void) {
         lcl_configure_by_name("App", RKLogLevelDefault);
         RKLogInfo(@"RestKit initialized...");
         loggingInitialized = YES;
+    }
+}
+
+
+void RKLogConfigureFromEnvironment(void) {
+
+    NSOrderedSet *validEnvVariables = [NSOrderedSet orderedSetWithObjects:
+                                       @"RKLogLevel.App",
+                                       @"RKLogLevel.RestKit",
+                                       @"RKLogLevel.RestKit.CoreData",
+                                       @"RKLogLevel.RestKit.CoreData.SearchEngine",
+                                       @"RKLogLevel.RestKit.Network",
+                                       @"RKLogLevel.RestKit.Network.Cache",
+                                       @"RKLogLevel.RestKit.Network.Queue",
+                                       @"RKLogLevel.RestKit.Network.Reachability",
+                                       @"RKLogLevel.RestKit.ObjectMapping",
+                                       @"RKLogLevel.RestKit.Support",
+                                       @"RKLogLevel.RestKit.Support.Parsers",
+                                       @"RKLogLevel.RestKit.Testing",
+                                       @"RKLogLevel.RestKit.Three20",
+                                       @"RKLogLevel.RestKit.UI",
+                                       nil];
+
+    static NSString *logComponentPrefix = @"RKLogLevel.";
+
+    NSDictionary *envVars = [[NSProcessInfo processInfo] environment];
+
+    for (NSString *envVarName in [envVars allKeys]) {
+        if ([envVarName hasPrefix:logComponentPrefix]) {
+            if (![validEnvVariables containsObject:envVarName]) {
+                 @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"The RKLogLevel Environment Variable name must be one of the following: %@", validEnvVariables] userInfo:nil];
+            }
+            NSString *logLevel = [envVars valueForKey:envVarName];
+            NSString *logComponent = [envVarName stringByReplacingOccurrencesOfString:logComponentPrefix withString:@""];
+            logComponent = [logComponent stringByReplacingOccurrencesOfString:@"." withString:@"/"];
+
+            const char* log_component_c_str = [logComponent cStringUsingEncoding:NSUTF8StringEncoding];
+            int log_level_int = logLevelForString(logLevel, envVarName);
+            RKLogConfigureByName(log_component_c_str, log_level_int);
+        }
+    }
+}
+
+
+int logLevelForString(NSString *logLevel, NSString *envVarName) {
+
+    // Forgive the user if they specify the full name for the value i.e. "RKLogLevelDebug" instead of "Debug"
+    logLevel = [logLevel stringByReplacingOccurrencesOfString:@"RKLogLevel" withString:@""];
+
+    if ([logLevel isEqualToString:@"Off"] ||
+        [logLevel isEqualToString:@"0"]) {
+        return RKLogLevelOff;
+    }
+    else if ([logLevel isEqualToString:@"Critical"] ||
+             [logLevel isEqualToString:@"1"]) {
+        return RKLogLevelCritical;
+    }
+    else if ([logLevel isEqualToString:@"Error"] ||
+             [logLevel isEqualToString:@"2"]) {
+        return RKLogLevelError;
+    }
+    else if ([logLevel isEqualToString:@"Warning"] ||
+             [logLevel isEqualToString:@"3"]) {
+        return RKLogLevelWarning;
+    }
+    else if ([logLevel isEqualToString:@"Info"] ||
+             [logLevel isEqualToString:@"4"]) {
+        return RKLogLevelInfo;
+    }
+    else if ([logLevel isEqualToString:@"Debug"] ||
+             [logLevel isEqualToString:@"5"]) {
+        return RKLogLevelDebug;
+    }
+    else if ([logLevel isEqualToString:@"Trace"] ||
+             [logLevel isEqualToString:@"6"]) {
+        return RKLogLevelTrace;
+    }
+    else if ([logLevel isEqualToString:@"Default"]) {
+        return RKLogLevelDefault;
+    }
+    else {
+        NSString *errorMessage = [NSString stringWithFormat:@"The value: \"%@\" for the environment variable: \"%@\" is invalid. \
+                                  \nThe log level must be set to one of the following values \
+                                  \n    Default  or 0 \
+                                  \n    Critical or 1 \
+                                  \n    Error    or 2 \
+                                  \n    Warning  or 3 \
+                                  \n    Info     or 4 \
+                                  \n    Debug    or 5 \
+                                  \n    Trace    or 6\n", logLevel, envVarName];
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:errorMessage userInfo:nil];
+
+        return -1;
     }
 }


### PR DESCRIPTION
Added a new RKLogConfigureFromEnvironment() function to RKLog.m to allow the configuration of logging components and logging levels via environment variables. Closes #640.
