### PR TITLE
Fix RKRequestSpec#testShouldCreateOneTimeoutTimer

### DIFF
--- a/Specs/Network/RKRequestSpec.m
+++ b/Specs/Network/RKRequestSpec.m
@@ -109,7 +109,7 @@
 
 - (void)testShouldCreateOneTimeoutTimer {
     RKSpecResponseLoader* loader = [RKSpecResponseLoader responseLoader];
-    RKURL* url = RKSpecGetBaseURL();
+    RKURL* url = [RKURL URLWithString:RKSpecGetBaseURL()];
     RKRequest* request = [[RKRequest alloc] initWithURL:url];
     request.delegate = loader;
     id requestMock = [OCMockObject partialMockForObject:request];


### PR DESCRIPTION
This test method had an obvious bug; a NSString was used where a RKURL was expected.
