### PR TITLE
RKDotNetDateFormatter not mapping correctly

### DIFF
--- a/Code/Support/RKDotNetDateFormatter.m
+++ b/Code/Support/RKDotNetDateFormatter.m
@@ -65,6 +65,12 @@ NSTimeInterval millisecondsFromSeconds(NSTimeInterval seconds);
     return [NSString stringWithFormat:@"/Date(%1.0lf%@)/", milliseconds, timeZoneOffset];
 }
 
+- (BOOL)getObjectValue:(id *)outValue forString:(NSString *)string errorDescription:(NSString **)error {
+	NSDate *date = [self dateFromString:string];
+	if (outValue)
+		*outValue = date;
+	return (date != nil);
+}
 
 - (id)init {
     self = [super init];

--- a/Tests/Logic/Support/RKDotNetDateFormatterTest.m
+++ b/Tests/Logic/Support/RKDotNetDateFormatterTest.m
@@ -77,5 +77,16 @@
     assertThat(string, is(equalTo(@"/Date(-1000212360000+0000)/")));
 }
 
+- (void)testShouldCreateADateWithGetObjectValueForString {
+    RKDotNetDateFormatter *formatter = [RKDotNetDateFormatter dotNetDateFormatter];
+    NSString *dotNetString = @"/Date(1000212360000-0400)/";
+    
+    NSDate *date = nil;
+    NSString *errorDescription = nil;    
+    BOOL success = [formatter getObjectValue:&date forString:dotNetString errorDescription:&errorDescription];
+    
+    assertThatBool(success, is(equalToBool(YES)));
+    assertThat([date description], is(equalTo(@"2001-09-11 12:46:00 +0000")));
+}
 
 @end


### PR DESCRIPTION
I added a test to demonstrate it not working and the code to fix it.  The issue was that dateFromString was not getting called and the RKISO8601DateFormatter was eventually matching and parsing the string incorrectly.
