### PR TITLE
Use 'Bearer' in Authorization HTTP Header

### DIFF
--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -353,7 +353,7 @@ RKRequestMethod RKRequestMethodTypeFromName(NSString *methodName) {
     
     // OAuth 2 valid request
     if(self.authenticationType == RKRequestAuthenticationTypeOAuth2) {
-        NSString *authorizationString = [NSString stringWithFormat:@"OAuth2 %@",self.OAuth2AccessToken];
+        NSString *authorizationString = [NSString stringWithFormat:@"Bearer %@",self.OAuth2AccessToken];
         [_URLRequest setValue:authorizationString forHTTPHeaderField:@"Authorization"];
     }
     

--- a/Tests/Logic/Network/RKRequestTest.m
+++ b/Tests/Logic/Network/RKRequestTest.m
@@ -819,6 +819,16 @@ request.timeoutInterval = 1.0;
     assertThat(authorization, isNot(nilValue()));
 }
 
+- (void)testShouldBuildAProperAuthorizationHeaderForOAuth2 {
+    RKRequest *request = [RKRequest requestWithURL:[RKURL URLWithString:@"http://restkit.org/this?that=foo&bar=word"]];
+    request.authenticationType = RKRequestAuthenticationTypeOAuth2;
+    request.OAuth2AccessToken = @"12345";
+    [request prepareURLRequest];
+    NSString *authorization = [request.URLRequest valueForHTTPHeaderField:@"Authorization"];
+    assertThat(authorization, isNot(nilValue()));
+    assertThat(authorization, is(equalTo(@"Bearer 12345")));
+}
+
 - (void)testOnDidLoadResponseBlockInvocation {
     RKURL *URL = [[RKTestFactory baseURL] URLByAppendingResourcePath:@"/200"];
     RKTestResponseLoader* loader = [RKTestResponseLoader responseLoader];


### PR DESCRIPTION
Changes 'OAuth2' to 'Bearer'.

Fixes https://github.com/RestKit/RestKit/issues/643
