### PR TITLE
Add indexes to URL encoded arrays

### DIFF
--- a/Code/Support/NSDictionary+RKAdditions.m
+++ b/Code/Support/NSDictionary+RKAdditions.m
@@ -92,13 +92,14 @@ RK_FIX_CATEGORY_BUG(NSDictionary_RKAdditions)
         NSString *path = inPath ? [inPath stringByAppendingFormat:@"[%@]", encodedKey] : encodedKey;
         
         if ([value isKindOfClass:[NSArray class]]) {
+            NSUInteger index = 0;
 			for (id item in value) {
                 if ([item isKindOfClass:[NSDictionary class]] || [item isKindOfClass:[NSMutableDictionary class]]) {
-                    [item URLEncodeParts:parts path:[path stringByAppendingString:@"[]"]];
+                    [item URLEncodeParts:parts path:[path stringByAppendingFormat:@"[%d]", index]];
                 } else {
-                    [self URLEncodePart:parts path:[path stringByAppendingString:@"[]"] value:item];
+                    [self URLEncodePart:parts path:[path stringByAppendingFormat:@"[%d]", index] value:item];
                 }
-                
+                ++index;
             }
         } else if([value isKindOfClass:[NSDictionary class]] || [value isKindOfClass:[NSMutableDictionary class]]) {
             [value URLEncodeParts:parts path:path];

--- a/Tests/Logic/ObjectMapping/RKObjectSerializerTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectSerializerTest.m
@@ -135,9 +135,9 @@
 
     assertThat(error, is(nilValue()));
     #if TARGET_OS_IPHONE
-    assertThat(data, is(equalTo(@"key1-form-name=value1&relationship1-form-name[r1k1][]=relationship1Value1&relationship1-form-name[r1k1][]=relationship1Value2&key2-form-name=value2&relationship2-form-name[subKey1]=subValue1")));
+    assertThat(data, is(equalTo(@"key1-form-name=value1&relationship1-form-name[r1k1][0]=relationship1Value1&relationship1-form-name[r1k1][1]=relationship1Value2&key2-form-name=value2&relationship2-form-name[subKey1]=subValue1")));
     #else
-    assertThat(data, is(equalTo(@"relationship1-form-name[r1k1][]=relationship1Value1&relationship1-form-name[r1k1][]=relationship1Value2&key2-form-name=value2&key1-form-name=value1&relationship2-form-name[subKey1]=subValue1")));
+    assertThat(data, is(equalTo(@"relationship1-form-name[r1k1][0]=relationship1Value1&relationship1-form-name[r1k1][1]=relationship1Value2&key2-form-name=value2&key1-form-name=value1&relationship2-form-name[subKey1]=subValue1")));
     #endif
 }
 

--- a/Tests/Logic/Support/NSDictionary+RKRequestSerializationTest.m
+++ b/Tests/Logic/Support/NSDictionary+RKRequestSerializationTest.m
@@ -52,7 +52,7 @@
 - (void)testShouldEncodeArrays {
     NSArray *array = [NSArray arrayWithObjects:@"item1", @"item2", nil];
     NSDictionary *dictionary = [NSDictionary dictionaryWithObject:array forKey:@"anArray"];
-    NSString *validArray = @"anArray[]=item1&anArray[]=item2";
+    NSString *validArray = @"anArray[0]=item1&anArray[1]=item2";
     assertThat([dictionary stringWithURLEncodedEntries], is(equalTo(validArray)));
 }
 
@@ -70,7 +70,7 @@
     NSArray * array = [NSArray arrayWithObjects: dictA, dictB, nil];
     NSDictionary * dictRoot = [NSDictionary dictionaryWithKeysAndObjects:@"root", array, nil];
 
-    NSString * validString = @"root[][a]=x&root[][b]=y&root[][a]=1&root[][b]=2";
+    NSString * validString = @"root[0][a]=x&root[0][b]=y&root[1][a]=1&root[1][b]=2";
     assertThat([dictRoot stringWithURLEncodedEntries], is(equalTo(validString)));
 }
 
@@ -79,7 +79,7 @@
     NSArray *recursiveArray2 = [NSArray arrayWithObject:recursiveArray3];
     NSArray *recursiveArray1 = [NSArray arrayWithObject:recursiveArray2];
     NSDictionary *dictionary = [NSDictionary dictionaryWithObject:recursiveArray1 forKey:@"recursiveArray"];
-    NSString *validRecursion = @"recursiveArray[]=%28%0A%20%20%20%20%20%20%20%20%28%0A%20%20%20%20%20%20%20%20item1%2C%0A%20%20%20%20%20%20%20%20item2%0A%20%20%20%20%29%0A%29";
+    NSString *validRecursion = @"recursiveArray[0]=%28%0A%20%20%20%20%20%20%20%20%28%0A%20%20%20%20%20%20%20%20item1%2C%0A%20%20%20%20%20%20%20%20item2%0A%20%20%20%20%29%0A%29";
     assertThat([dictionary stringWithURLEncodedEntries], is(equalTo(validRecursion)));
 }
 


### PR DESCRIPTION
Currently, when form encoding dictionaries, RestKit encodes array elements with empty brackets.  For example, given an array of the following object:

```
@interface Blob
@property NSString *foo;
@property NSString *bar;
@end
```

might be encoded as:

```
blobs[][foo]=alpha&blobs[][bar]=beta&blobs[][bar]=gamma&blobs[][foo]=delta
```

which in Rails evaluates to:

```
{"blobs"=>[{"foo"=>"alpha", "bar"=>"beta"}, {"bar"=>"gamma", "foo"=>"delta"}]}
```

---

Here is some [prior discussion](https://github.com/RestKit/RestKit/commit/d6e26a6f9dc0242e670833ee27b010f8bd554f9f).  The judgement there seemed to be that Rails does it this way, so RestKit should follow.  But sometimes this breaks down.  Consider the case where some fields are optional:

```
blobs[][foo]=alpha&blobs[][bar]=gamma&blobs[][foo]=delta
```

which in Rails evaluates to:

```
{"blobs"=>[{"foo"=>"alpha", "bar"=>"gamma"}, {"foo"=>"delta"}]}
```

when I was expecting:

```
{"blobs"=>[{"foo"=>"alpha"}, {"bar"=>"gamma", "foo"=>"delta"}]}
```

---

If we add indexes to the parameters, the proper grouping can be maintained:

```
blobs[0][foo]=alpha&blobs[1][bar]=gamma&blobs[1][foo]=delta
```

evaluates to:

```
{"blobs"=>{"0"=>{"foo"=>"alpha"}, "1"=>{"bar"=>"gamma", "foo"=>"delta"}}}
```

---

I realize this change may not be appealing to everyone.  I'm open to suggestions on alternative solutions.  Given that this feature is implemented in a category on NSDictionary, there's no easy way to override it without changing RestKit.
