### PR TITLE
Fix NSBundle+RKAdditions compile error by checking import headers

### DIFF
--- a/Code/Support/NSBundle+RKAdditions.m
+++ b/Code/Support/NSBundle+RKAdditions.m
@@ -20,7 +20,9 @@
 
 #import "NSBundle+RKAdditions.h"
 #import "NSString+RKAdditions.h"
+#if RestKit_UI_h
 #import "UIImage+RKAdditions.h"
+#endif
 #import "RKLog.h"
 #import "RKParser.h"
 #import "RKParserRegistry.h"


### PR DESCRIPTION
Check if RestKit_UI_h was defined before NSBundle+RKAdditions imports a header (UIImage+RKAdditions) from UI.
