### PR TITLE
RKAbstractTableController tableControllerDidFinishFinalLoad

### DIFF
--- a/Code/UI/RKAbstractTableController.m
+++ b/Code/UI/RKAbstractTableController.m
@@ -749,8 +749,9 @@ static NSString* lastUpdatedDateDictionaryKey = @"lastUpdatedDateDictionaryKey";
 
     [self resetOverlayView];
 
-    if (self.delegate && [_delegate respondsToSelector:@selector(tableControllerDidFinishFinalLoad:)])
-        [_delegate performSelector:@selector(tableControllerDidFinishFinalLoad:)];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(tableControllerDidFinishFinalLoad:)]) {
+        [self.delegate tableControllerDidFinishFinalLoad:self];      
+    }
 }
 
 #pragma mark - Table Overlay Views


### PR DESCRIPTION
The following code will not notify the delegate as per the specification, but result in a runtime memory access exception:
    if (self.delegate && [_delegate respondsToSelector:@selector(tableControllerDidFinishFinalLoad:)])
        [_delegate performSelector:@selector(tableControllerDidFinishFinalLoad:)];

May I suggest notifying the delegate the same way all the other invocations on this class do it?
E.g.

```
if (self.delegate && [self.delegate respondsToSelector:@selector(tableControllerDidFinishFinalLoad:)]) {
    [self.delegate tableControllerDidFinishFinalLoad:self];      
}
```
