### PR TITLE
Use port and not modified path in OAuth signature base calculations

### DIFF
--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -320,28 +320,28 @@ RKRequestMethod RKRequestMethodTypeFromName(NSString *methodName) {
             parameters = [_URL queryParameters];
             
         if (self.method == RKRequestMethodPUT)
-            echo = [GCOAuth URLRequestForPath:[_URL path]
+            echo = [GCOAuth URLRequestForPath:[_URL originalPath]
                                 PUTParameters:parameters
                                        scheme:[_URL scheme]
-                                         host:[_URL host]
+                                         host:[_URL hostAndPort]
                                   consumerKey:self.OAuth1ConsumerKey
                                consumerSecret:self.OAuth1ConsumerSecret
                                   accessToken:self.OAuth1AccessToken
                                   tokenSecret:self.OAuth1AccessTokenSecret];
         else if (self.method == RKRequestMethodPOST)
-            echo = [GCOAuth URLRequestForPath:[_URL path]
+            echo = [GCOAuth URLRequestForPath:[_URL originalPath]
                                POSTParameters:parameters
                                        scheme:[_URL scheme]
-                                         host:[_URL host]
+                                         host:[_URL hostAndPort]
                                   consumerKey:self.OAuth1ConsumerKey
                                consumerSecret:self.OAuth1ConsumerSecret
                                   accessToken:self.OAuth1AccessToken
                                   tokenSecret:self.OAuth1AccessTokenSecret];
         else
-            echo = [GCOAuth URLRequestForPath:[_URL path]
+            echo = [GCOAuth URLRequestForPath:[_URL originalPath]
                                 GETParameters:[_URL queryParameters]
                                        scheme:[_URL scheme]
-                                         host:[_URL host]
+                                         host:[_URL hostAndPort]
                                   consumerKey:self.OAuth1ConsumerKey
                                consumerSecret:self.OAuth1ConsumerSecret
                                   accessToken:self.OAuth1AccessToken

--- a/Vendor/cocoa-oauth/GCOAuth.h
+++ b/Vendor/cocoa-oauth/GCOAuth.h
@@ -31,6 +31,19 @@
 
 #import <Foundation/Foundation.h>
 
+@interface  NSURL  (GCOAuthURL)
+
+/*
+ Get host:port from URL unless port is 80 or 443 (http://tools.ietf.org/html/rfc5849#section-3.4.1.2). Otherwis reurn only host.
+ */
+- (NSString *)hostAndPort;
+
+/*
+ Get unmodified path component. [URL path] decodes % symbols and strips trailing slash.
+ */
+- (NSString *)originalPath;
+@end
+
 /*
  This OAuth implementation doesn't cover the whole spec (eg. it’s HMAC only).
  But you'll find it works with almost all the OAuth implementations you need

--- a/Vendor/cocoa-oauth/GCOAuth.m
+++ b/Vendor/cocoa-oauth/GCOAuth.m
@@ -182,8 +182,8 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
     NSURL *URL = self.URL;
     NSString *URLString = [NSString stringWithFormat:@"%@://%@%@",
                            [[URL scheme] lowercaseString],
-                           [[URL host] lowercaseString],
-                           [[URL path] lowercaseString]];
+                           [[URL hostAndPort] lowercaseString],
+                           [[URL originalPath] lowercaseString]];
     
     // create components
     NSArray *components = [NSArray arrayWithObjects:
@@ -421,3 +421,20 @@ static BOOL GCOAuthUseHTTPSCookieStorage = YES;
     return [(NSString *)string autorelease];
 }
 @end
+
+@implementation NSURL  (GCOAuthURL)
+
+- (NSString *)hostAndPort {
+    if ([self port] != nil && [[self port] intValue] != 80 && [[self port] intValue] != 443) {
+        return [NSString stringWithFormat:@"%@:%@", [self host], [self port]];
+    } else {
+        return [self host];
+    }
+}
+
+- (NSString *)originalPath {
+    return (NSString*)CFURLCopyPath((CFURLRef)self);
+}
+
+@end
+


### PR DESCRIPTION
Curent oauth code does not include port into account when calculating signature base string. Also, [NSURL path] method used in calculations returns modified path with % symbols decoded and trailing slash stripped. This commit fixes both problems by adding two utility methods to NSURL.
