### PR TITLE
Ability to supply predicate creation block when mapping CoreData relationships

### DIFF
--- a/Code/CoreData/RKManagedObjectMapping.h
+++ b/Code/CoreData/RKManagedObjectMapping.h
@@ -153,8 +153,22 @@
  */
 - (void)connectRelationship:(NSString *)relationshipName usingForeignKeyAttribute:(NSString *)keyAttribute mapping:(RKManagedObjectMapping *)mapping usingEvaluationBlock:(BOOL (^)(id data))block;
 
-
-
+/**
+ Connect a relationship of the object being mapped by using a predicate to lookup the related object.
+ The predicate is created by a createPredicateBlock supplied, allowing the predicate to vary depending
+ on other values of the object being mapped.
+ 
+ ^NSPredicate*(NSString* relationshipName, id keyValue, id object, RKObjectMapping* mapping) = ...;
+ 
+ The block can return nil to cancel connection of the relationship, otherwise it should return a 
+ predicate that looks up an entity/entities depending on whether this is a one-to-many or one-to-one relationship.
+ The keyValue will be the value of the foreignKeyAttribute on object that should correspond
+ to the primaryKey value of the related object the predicate will locate.
+ The object will typically be an NSManagedObject subclass and the mapping an RKManagedObjectMapping.
+ 
+ @see connectRelationship:usingForeignKeyAttribute:mapping
+ */
+- (void)connectRelationship:(NSString *)relationshipName usingForeignKeyAttribute:(NSString *)keyAttribute mapping:(RKManagedObjectMapping *)mapping usingCreatePredicateBlock:(NSPredicate*(^)(NSString*,id,id,RKObjectMapping*))block;
 
 // Deprecated
 /**

--- a/Code/CoreData/RKManagedObjectMapping.m
+++ b/Code/CoreData/RKManagedObjectMapping.m
@@ -104,11 +104,13 @@
     [_relationshipToPrimaryKeyMappings setObject:keyAttribute forKey:relationshipName];
 }
 
+//DEPRECATED
 - (void)connectRelationship:(NSString*)relationshipName withObjectForPrimaryKeyAttribute:(NSString*)primaryKeyAttribute {
     NSAssert([_relationshipToPrimaryKeyMappings objectForKey:relationshipName] == nil, @"Cannot add connect relationship %@ by primary key, a mapping already exists.", relationshipName);
     [_relationshipToPrimaryKeyMappings setObject:primaryKeyAttribute forKey:relationshipName];
 }
 
+//DEPRECATED
 - (void)connectRelationshipsWithObjectsForPrimaryKeyAttributes:(NSString*)firstRelationshipName, ... {
     va_list args;
     va_start(args, firstRelationshipName);
@@ -129,6 +131,7 @@
     [matcher release];
 }
 
+//DEPRECATED
 - (void)connectRelationship:(NSString*)relationshipName withObjectForPrimaryKeyAttribute:(NSString*)primaryKeyAttribute whenValueOfKeyPath:(NSString*)keyPath isEqualTo:(id)value {
     NSAssert([_relationshipToPrimaryKeyMappings objectForKey:relationshipName] == nil, @"Cannot add connect relationship %@ by primary key, a mapping already exists.", relationshipName);
     RKDynamicObjectMappingMatcher* matcher = [[RKDynamicObjectMappingMatcher alloc] initWithKey:keyPath value:value primaryKeyAttribute:primaryKeyAttribute];
@@ -144,9 +147,18 @@
     [matcher release];
 }
 
+//DEPRECATED
 - (void)connectRelationship:(NSString*)relationshipName withObjectForPrimaryKeyAttribute:(NSString*)primaryKeyAttribute usingEvaluationBlock:(BOOL (^)(id data))block {
     NSAssert([_relationshipToPrimaryKeyMappings objectForKey:relationshipName] == nil, @"Cannot add connect relationship %@ by primary key, a mapping already exists.", relationshipName);
     RKDynamicObjectMappingMatcher* matcher = [[RKDynamicObjectMappingMatcher alloc] initWithPrimaryKeyAttribute:primaryKeyAttribute evaluationBlock:block];
+    [_relationshipToPrimaryKeyMappings setObject:matcher forKey:relationshipName];
+    [matcher release];
+}
+
+- (void)connectRelationship:(NSString *)relationshipName usingForeignKeyAttribute:(NSString *)keyAttribute mapping:(RKManagedObjectMapping *)mapping usingCreatePredicateBlock:(NSPredicate*(^)(NSString*,id,id,RKObjectMapping*))block
+{
+    NSAssert([_relationshipToPrimaryKeyMappings objectForKey:relationshipName] == nil, @"Cannot add connect relationship %@ by primary key, a mapping already exists.", relationshipName);
+    RKDynamicObjectMappingMatcher* matcher = [[RKDynamicObjectMappingMatcher alloc] initWithPrimaryKeyAttribute:keyAttribute createPredicateBlock:block];
     [_relationshipToPrimaryKeyMappings setObject:matcher forKey:relationshipName];
     [matcher release];
 }

--- a/Code/ObjectMapping/RKDynamicObjectMappingMatcher.h
+++ b/Code/ObjectMapping/RKDynamicObjectMappingMatcher.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "RKObjectMapping.h"
 
+typedef NSPredicate*(^RKDynamicObjectCreatePredicateBlock)(NSString*,id,id,RKObjectMapping*);
 
 @interface RKDynamicObjectMappingMatcher : NSObject {
     NSString* _keyPath;
@@ -16,15 +17,20 @@
     RKObjectMapping* _objectMapping;
     NSString* _primaryKeyAttribute;
     BOOL (^_isMatchForDataBlock)(id data);
+    RKDynamicObjectCreatePredicateBlock _createPredicateBlock;
 }
 
 @property (nonatomic, readonly) RKObjectMapping* objectMapping;
 @property (nonatomic, readonly) NSString* primaryKeyAttribute;
+@property (nonatomic, readonly) RKDynamicObjectCreatePredicateBlock createPredicateBlock;
+@property (nonatomic, readonly) BOOL usePredicate;
 
 - (id)initWithKey:(NSString*)key value:(id)value objectMapping:(RKObjectMapping*)objectMapping;
 - (id)initWithKey:(NSString*)key value:(id)value primaryKeyAttribute:(NSString*)primaryKeyAttribute;
 - (id)initWithPrimaryKeyAttribute:(NSString*)primaryKeyAttribute evaluationBlock:(BOOL (^)(id data))block;
+- (id)initWithPrimaryKeyAttribute:(NSString*)primaryKeyAttribute createPredicateBlock:(RKDynamicObjectCreatePredicateBlock)block;
 - (BOOL)isMatchForData:(id)data;
 - (NSString*)matchDescription;
+
 
 @end

--- a/Code/ObjectMapping/RKDynamicObjectMappingMatcher.m
+++ b/Code/ObjectMapping/RKDynamicObjectMappingMatcher.m
@@ -18,6 +18,7 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue);
 
 @synthesize objectMapping = _objectMapping;
 @synthesize primaryKeyAttribute = _primaryKeyAttribute;
+@synthesize createPredicateBlock = _createPredicateBlock;
 
 - (id)initWithKey:(NSString*)key value:(id)value objectMapping:(RKObjectMapping*)objectMapping {
     self = [super init];
@@ -25,6 +26,7 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue);
         _keyPath = [key retain];
         _value = [value retain];
         _objectMapping = [objectMapping retain];
+        _createPredicateBlock = NULL;
     }
 
     return self;
@@ -36,6 +38,7 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue);
         _keyPath = [key retain];
         _value = [value retain];
         _primaryKeyAttribute = [primaryKeyAttribute retain];
+        _createPredicateBlock = NULL;
     }
 
     return self;
@@ -46,6 +49,16 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue);
     if (self) {
         _primaryKeyAttribute = [primaryKeyAttribute retain];
         _isMatchForDataBlock = Block_copy(block);
+        _createPredicateBlock = NULL;
+    }
+    return self;
+}
+
+- (id)initWithPrimaryKeyAttribute:(NSString*)primaryKeyAttribute createPredicateBlock:(RKDynamicObjectCreatePredicateBlock)block {
+    if((self = [super init]))
+    {
+        _primaryKeyAttribute = [primaryKeyAttribute retain];
+        _createPredicateBlock = Block_copy(block);
     }
     return self;
 }
@@ -58,10 +71,14 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue);
     if (_isMatchForDataBlock) {
         Block_release(_isMatchForDataBlock);
     }
+    if(_createPredicateBlock) {
+        Block_release(_createPredicateBlock);
+    }
     [super dealloc];
 }
 
 - (BOOL)isMatchForData:(id)data {
+    NSAssert(!self.usePredicate, @"Cannot call isMatchForData on a predicate-yielding dynamic matcher - call predicateForRelationship instead");
     if (_isMatchForDataBlock) {
         return _isMatchForDataBlock(data);
     }
@@ -74,5 +91,10 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue);
     }
     return [NSString stringWithFormat:@"%@ == %@", _keyPath, _value];
 }
+
+- (BOOL)usePredicate {
+    return _createPredicateBlock != NULL;
+}
+
 
 @end


### PR DESCRIPTION
Related to issue #593 this adds the ability to specify a block that creates an NSPredicate which then locates the destination of the relationship. This gives full control over how the relationship ends up being mapped.

```
- (void)connectRelationship:(NSString *)relationshipName usingForeignKeyAttribute:(NSString *)keyAttribute 
    mapping:(RKManagedObjectMapping *)mapping 
    usingCreatePredicateBlock:(NSPredicate*(^)(NSString*,id,id,RKObjectMapping*))block;
```
