### PR TITLE
Reset isLoading *after* calling delegates on errors

### DIFF
--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -649,8 +649,6 @@ RKRequestMethod RKRequestMethodTypeFromName(NSString *methodName) {
 
 		[self didFinishLoad:[self loadResponseFromCache]];
 	} else {
-		_isLoading = NO;
-
 		if ([_delegate respondsToSelector:@selector(request:didFailLoadWithError:)]) {
 			[_delegate request:self didFailLoadWithError:error];
 		}
@@ -664,6 +662,7 @@ RKRequestMethod RKRequestMethodTypeFromName(NSString *methodName) {
 		[[NSNotificationCenter defaultCenter] postNotificationName:RKRequestDidFailWithErrorNotification
                                                             object:self
                                                           userInfo:userInfo];
+		_isLoading = NO;
 	}
 
     // NOTE: This notification must be posted last as the request queue releases the request when it


### PR DESCRIPTION
This commit sets isLoading to NO after calling delegates.  This solves the following issue in our app:
- Make request to server, but iPhone is offline, so an error happens
- In our delegate we check that the phone is offline and show the user an alert 
- However, since isLoading is set to NO before that alert, the request if executed over and over again while the alter is being shown
- This results in the alert being shown multiple times, you have to click through them all which is very confusing (not too mention annoying)

By moving isLoading down, only one error message is displayed.  Then once RestKit leaves this messages, it will clear the request out of the queue so its only executed once.

Let me know if you have any questions - but this small changes makes a big difference for our app.

Thanks - Charlie
