### PR TITLE
Always call objectLoaderDidFinishLoading

### DIFF
--- a/Code/CoreData/RKManagedObjectLoader.m
+++ b/Code/CoreData/RKManagedObjectLoader.m
@@ -171,6 +171,13 @@
             [invocation setSelector:@selector(informDelegateOfError:)];
             [invocation setArgument:&error atIndex:2];
             [invocation invokeOnMainThread];
+
+            signature = [(NSObject *)self methodSignatureForSelector:@selector(finalizeLoad:)];
+            invocation = [RKManagedObjectThreadSafeInvocation invocationWithMethodSignature:signature];
+            [invocation setTarget:self];
+            [invocation setSelector:@selector(finalizeLoad:)];
+            [invocation setArgument:&success atIndex:2];
+            [invocation invokeOnMainThread];
             return;
         }
     }


### PR DESCRIPTION
As part of our RKObjectLoaderDelegate, we rely on objectLoaderDidFinishLoading to do some house cleaning.  objectLoaderDidFinishLoading is called whether a request is a success or failure, except in one case.  This commit fixes that case.

The case happens when a failure occurs in processMappingResult.  On success, processMappingResult already indirectly calls objectLoaderDidFinishLoading.  This patch simply also calls it when a failure occurs.  The end result is that objectLoaderDidFinishLoading is always called.

Let me know if you have questions

Thanks  - Charlie
