### PR TITLE
Let RKManagedObjectMappingProvider do the parsing boilerplate

### DIFF
--- a/Code/CoreData/RKObjectMappingProvider+CoreData.h
+++ b/Code/CoreData/RKObjectMappingProvider+CoreData.h
@@ -10,6 +10,7 @@
 #import <CoreData/CoreData.h>
 
 typedef NSFetchRequest *(^RKObjectMappingProviderFetchRequestBlock)(NSString *resourcePath);
+typedef NSFetchRequest *(^RKObjectMappingProviderSimpleFetchRequestBlock)(NSDictionary *pathParameters);
 
 /**
  Provides extensions to RKObjectMappingProvider to support Core Data specific
@@ -42,6 +43,33 @@ typedef NSFetchRequest *(^RKObjectMappingProviderFetchRequestBlock)(NSString *re
  @see RKObjectLoader
  */
 - (void)setObjectMapping:(RKObjectMappingDefinition *)objectMapping forResourcePathPattern:(NSString *)resourcePathPattern withFetchRequestBlock:(RKObjectMappingProviderFetchRequestBlock)fetchRequestBlock;
+
+/**
+ Configures an object mapping to be used when during a load event where the resourcePath of
+ the RKObjectLoader instance matches resourcePathPattern.
+ 
+ The resourcePathPattern is a SOCKit pattern matching property names preceded by colons within
+ a path. For example, if a collection of reviews for a product were loaded from a remote system
+ at the resourcePath @"/products/1234/reviews", object mapping could be configured to handle
+ this request with a resourcePathPattern of @"/products/:productID/reviews".
+ 
+ **NOTE** that care must be taken when configuring patterns within the provider. The patterns
+ will be evaluated in the order they are added to the provider, so more specific patterns must
+ precede more general patterns where either would generate a match.
+ 
+ @param objectMapping The object mapping to use when the resourcePath matches the specified
+ resourcePathPattern.
+ @param resourcePathPattern A pattern to be evaluated using an RKPathMatcher against a resourcePath
+ to determine if objectMapping is the appropriate mapping.
+ @param fetchRequestBlock A block that accepts a dictionary of parsed parameters and returns an NSFetchRequest
+ that should be used to fetch the local objects associated with resourcePath from CoreData, for use in
+ properly processing local deletes. This version does the parsing work for you by using RKPathMatcher
+ to parse the concrete resourcePath, using the resourcePattern from resourcePathPattern.
+ @see RKPathMatcher
+ @see RKURL
+ @see RKObjectLoader
+ */
+- (void)setObjectMapping:(RKObjectMappingDefinition *)objectMapping forResourcePathPattern:(NSString *)resourcePathPattern withSimpleFetchRequestBlock:(RKObjectMappingProviderSimpleFetchRequestBlock)fetchRequestBlock;
 
 /**
  Retrieves the NSFetchRequest object that will retrieve cached objects for a given resourcePath.

--- a/Code/CoreData/RKObjectMappingProvider+CoreData.m
+++ b/Code/CoreData/RKObjectMappingProvider+CoreData.m
@@ -9,20 +9,42 @@
 #import "RKObjectMappingProvider+CoreData.h"
 #import "RKOrderedDictionary.h"
 #import "RKFixCategoryBug.h"
+#import "RKPathMatcher.h"
+#import <objc/runtime.h>
+
 
 RK_FIX_CATEGORY_BUG(RKObjectMappingProvider_CoreData)
 @implementation RKObjectMappingProvider (CoreData)
+
+const NSString *RK_OBJECT_MAPPING_PROVIDER_IS_SIMPLE_BLOCK = @"RKObjectMappingProvider_IsSimpleBlock";
+const NSString *RK_OBJECT_MAPPING_PROVIDER_RESOURCE_PATTERN = @"RKObjectMappingProvider_ResourcePattern";
 
 - (void)setObjectMapping:(RKObjectMappingDefinition *)objectMapping forResourcePathPattern:(NSString *)resourcePath withFetchRequestBlock:(RKObjectMappingProviderFetchRequestBlock)fetchRequestBlock {
     [self setEntry:[RKObjectMappingProviderContextEntry contextEntryWithMapping:objectMapping
                                                                        userData:fetchRequestBlock] forResourcePathPattern:resourcePath];
 }
 
+- (void)setObjectMapping:(RKObjectMappingDefinition *)objectMapping forResourcePathPattern:(NSString *)resourcePath withSimpleFetchRequestBlock:(RKObjectMappingProviderSimpleFetchRequestBlock)fetchRequestBlock {
+    objc_setAssociatedObject(fetchRequestBlock, RK_OBJECT_MAPPING_PROVIDER_IS_SIMPLE_BLOCK, [NSNumber numberWithBool:YES], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(fetchRequestBlock, RK_OBJECT_MAPPING_PROVIDER_RESOURCE_PATTERN, resourcePath, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [self setEntry:[RKObjectMappingProviderContextEntry contextEntryWithMapping:objectMapping userData:fetchRequestBlock] forResourcePathPattern:resourcePath];
+}
+
 - (NSFetchRequest *)fetchRequestForResourcePath:(NSString *)resourcePath {
     RKObjectMappingProviderContextEntry *entry = [self entryForResourcePath:resourcePath];
     if (entry.userData) {
-        NSFetchRequest *(^fetchRequestBlock)(NSString *) = entry.userData;
-        return fetchRequestBlock(resourcePath);
+        BOOL isSimpleBlock = [objc_getAssociatedObject(entry.userData, RK_OBJECT_MAPPING_PROVIDER_IS_SIMPLE_BLOCK) boolValue];
+        if(isSimpleBlock) {
+            NSFetchRequest *(^simpleFetchRequestBlock)(NSDictionary*) = entry.userData;
+            NSString *resourcePattern = objc_getAssociatedObject(entry.userData, RK_OBJECT_MAPPING_PROVIDER_RESOURCE_PATTERN);
+            NSDictionary *parsed = nil;
+            RKPathMatcher *matcher = [RKPathMatcher matcherWithPath:resourcePath];
+            [matcher matchesPattern:resourcePattern tokenizeQueryStrings:YES parsedArguments:&parsed];
+            return simpleFetchRequestBlock(parsed);
+        } else {
+            NSFetchRequest *(^fetchRequestBlock)(NSString *) = entry.userData;
+            return fetchRequestBlock(resourcePath);
+        }
     }
 
     return nil;


### PR DESCRIPTION
Adds ability to let it do the parsing boilerplate and just hand back a dictionary of values, to avoid having to repeat the RKPathMatcher logic all over the place.
