### PR TITLE
Support RestKit issuing new requests as background operations (background task)

### DIFF
--- a/Code/Network/RKRequestQueue.h
+++ b/Code/Network/RKRequestQueue.h
@@ -200,6 +200,11 @@
 @property (nonatomic) BOOL suspended;
 
 /**
+ Sets the flag that determines if subsequent requests added to the queue while already backgrounded may be processed.
+ */
+@property (nonatomic) BOOL suspendInBackground;
+
+/**
  Returns the total number of requests that are currently loading.
  */
 @property (nonatomic, readonly) NSUInteger loadingCount;


### PR DESCRIPTION
Implemented changes as per https://groups.google.com/forum/#!msg/restkit/l_zWrC-TLgw/EJo7yNtA4isJ along with minor tweaks.

This allows RestKit to optionally process its request queue when backgrounded if suspendInBackground = NO.
