### PR TITLE
Fix for #805 Incompatible types between RKObjectLoader sourceObject and _sourceObject confuses lldb 

### DIFF
--- a/Code/ObjectMapping/RKObjectLoader.h
+++ b/Code/ObjectMapping/RKObjectLoader.h
@@ -136,8 +136,8 @@ typedef void(^RKObjectLoaderDidLoadObjectsDictionaryBlock)(NSDictionary *diction
  * includes Core Data specific mapping logic.
  */
 @interface RKObjectLoader : RKRequest {
-    id _sourceObject;
-    id _targetObject;
+    NSObject* _sourceObject;
+    NSObject* _targetObject;
     dispatch_queue_t _mappingQueue;
 }
 


### PR DESCRIPTION
https://github.com/RestKit/RestKit/issues/805: Incompatible types between RKObjectLoader sourceObject and _sourceObject confuses lldb

With unmatched type between property and storage, lldb gets confused when printing the object.

Error is: instance method ''sourceObject' has incompatible result types in different translation units ('NSObject *' vs. 'id')

Signed-off-by: Roger Nolan rog@hatbat.net
