### PR TITLE
Fix #786 ARC error when importing RKXMLParserXMLReader

### DIFF
--- a/Code/Support/Parsers/XML/RKXMLParserXMLReader.h
+++ b/Code/Support/Parsers/XML/RKXMLParserXMLReader.h
@@ -22,7 +22,6 @@
  the parsed dictionary at the `@"text"` key.
  */
 
-#import "XMLReader.h"
 #import "RKParser.h"
 
 @interface RKXMLParserXMLReader : NSObject <RKParser> {

--- a/Code/Support/Parsers/XML/RKXMLParserXMLReader.m
+++ b/Code/Support/Parsers/XML/RKXMLParserXMLReader.m
@@ -7,6 +7,7 @@
 //
 
 #import "RKXMLParserXMLReader.h"
+#import "XMLReader.h"
 
 @implementation RKXMLParserXMLReader
 


### PR DESCRIPTION
https://github.com/RestKit/RestKit/issues/786 
Importing RKXMLParserXMLReader in an ARC project cause following compiler error  .

```
 XMLReader.h: Pointer to non-const type 'NSError *' with no explicit ownership
```

Fixed by importing XMLReader in .m instead of .h.
