### PR TITLE
Pull request for issue 825

### DIFF
--- a/Code/UI/RKFetchedResultsTableController.m
+++ b/Code/UI/RKFetchedResultsTableController.m
@@ -243,6 +243,10 @@
         [fetchRequest setSortDescriptors:_sortDescriptors];
     }
     
+    [_fetchedResultsController setDelegate:nil];
+    [_fetchedResultsController release];
+    _fetchedResultsController = nil;
+    
     _fetchedResultsController = [[NSFetchedResultsController alloc] initWithFetchRequest:fetchRequest
                                                                         managedObjectContext:[NSManagedObjectContext contextForCurrentThread]
                                                                           sectionNameKeyPath:_sectionNameKeyPath


### PR DESCRIPTION
I had a look at an older commit of  Restkit and it has these 3 extra lies for the load table method which basically nils out the delegate and the fetchrequestcontroller. this makes sure that the tableview is always using a fresh copy of these and hence avoids any assertion errors
