### PR TITLE
Fixing missing override of stringForObjectValue in RKDotNetDateFormatter.m

### DIFF
--- a/Code/Support/RKDotNetDateFormatter.m
+++ b/Code/Support/RKDotNetDateFormatter.m
@@ -60,9 +60,7 @@ NSTimeInterval millisecondsFromSeconds(NSTimeInterval seconds);
         RKLogError(@"Attempted to represent an invalid date: %@", date);
         return nil;
     }
-    NSTimeInterval milliseconds = millisecondsFromSeconds([date timeIntervalSince1970]);
-    NSString *timeZoneOffset = [super stringFromDate:date];
-    return [NSString stringWithFormat:@"/Date(%1.0lf%@)/", milliseconds, timeZoneOffset];
+    return [self stringForObjectValue:date];
 }
 
 - (BOOL)getObjectValue:(id *)outValue forString:(NSString *)string errorDescription:(NSString **)error {

--- a/Tests/Logic/Support/RKDotNetDateFormatterTest.m
+++ b/Tests/Logic/Support/RKDotNetDateFormatterTest.m
@@ -89,4 +89,20 @@
     assertThat([date description], is(equalTo(@"2001-09-11 12:46:00 +0000")));
 }
 
+- (void)testShouldCreateADotNetStringWithStringForObjectValueFromADateWithATimeZone {
+    NSTimeZone *timeZoneEST = [NSTimeZone timeZoneWithAbbreviation:@"EST"];
+    RKDotNetDateFormatter *formatter = [RKDotNetDateFormatter dotNetDateFormatterWithTimeZone:timeZoneEST];
+    NSDate *referenceDate = [NSDate dateWithTimeIntervalSince1970:1000212360];
+    NSString *string = [formatter stringForObjectValue:referenceDate];
+    assertThat(formatter.timeZone, is(equalTo(timeZoneEST)));
+    assertThat(string, is(equalTo(@"/Date(1000212360000-0400)/")));
+}
+
+- (void)testShouldCreateADotNetStringWithStringForObjectValueFromADateBefore1970WithoutAnOffset {
+    RKDotNetDateFormatter *formatter = [RKDotNetDateFormatter dotNetDateFormatter];
+    NSDate *referenceDate = [NSDate dateWithTimeIntervalSince1970:-1000212360];
+    NSString *string = [formatter stringForObjectValue:referenceDate];
+    assertThat(string, is(equalTo(@"/Date(-1000212360000+0000)/")));
+}
+
 @end


### PR DESCRIPTION
See https://github.com/RestKit/RestKit/issues/726
