### PR TITLE
Fixed #855 - Params are dropped from DELETE request before it's sent

### DIFF
--- a/Code/Support/NSString+RKAdditions.h
+++ b/Code/Support/NSString+RKAdditions.h
@@ -95,6 +95,16 @@
 - (NSDictionary *)queryParametersUsingArrays:(BOOL)shouldUseArrays encoding:(NSStringEncoding)encoding;
 
 /**
+ Returns a string containing the query parameters given a URL-style query string on the receiving object.
+ For example, when given the string /contacts?foo=bar&amp;color=red, this will return the string "foo=bar&amp;color=red"
+ Returns nil if there are no query parameters in the string.
+ 
+ @param receiver A string in the form of @"/object/?sortBy=name", or @"/object/?sortBy=name&amp;color=red"
+ @return A string of query parameters: everything after the "?" in the receiver.
+ */
+- (NSString *)queryParametersString;
+
+/**
  Returns a URL encoded representation of self.
  */
 - (NSString *)stringByAddingURLEncoding;

--- a/Code/Support/NSString+RKAdditions.m
+++ b/Code/Support/NSString+RKAdditions.m
@@ -118,6 +118,17 @@ RK_FIX_CATEGORY_BUG(NSString_RKAdditions)
     return [NSDictionary dictionaryWithDictionary:pairs];
 }
 
+- (NSString *)queryParametersString {
+    NSRange chopRange = [self rangeOfString:@"?"];
+    if (chopRange.length > 0) {
+        chopRange.location+=1; // we want inclusive chopping up *through* "?"
+        if (chopRange.location < [self length]) {
+            return [self substringFromIndex:chopRange.location];
+        }
+    }
+    return nil;
+}
+
 // NOTE: See http://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters
 - (NSString *)stringByAddingURLEncoding {
     CFStringRef legalURLCharactersToBeEscaped = CFSTR(":/?#[]@!$ &'()*+,;=\"<>%{}|\\^~`\n\r");

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		032E102E15B0A38C0057D164 /* NSString+RKAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 032E102D15B0A38C0057D164 /* NSString+RKAdditionsTest.m */; };
+		032E102F15B0A4560057D164 /* NSString+RKAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 032E102D15B0A38C0057D164 /* NSString+RKAdditionsTest.m */; };
 		2501405315366000004E0466 /* RKObjectiveCppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2501405215366000004E0466 /* RKObjectiveCppTest.mm */; };
 		2501405415366000004E0466 /* RKObjectiveCppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2501405215366000004E0466 /* RKObjectiveCppTest.mm */; };
 		25055B8414EEF32A00B9C4DD /* RKMappingTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 25055B8014EEF32A00B9C4DD /* RKMappingTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -775,6 +777,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		032E102D15B0A38C0057D164 /* NSString+RKAdditionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+RKAdditionsTest.m"; sourceTree = "<group>"; };
 		2501405215366000004E0466 /* RKObjectiveCppTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RKObjectiveCppTest.mm; sourceTree = "<group>"; };
 		25055B8014EEF32A00B9C4DD /* RKMappingTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RKMappingTest.h; path = Testing/RKMappingTest.h; sourceTree = "<group>"; };
 		25055B8114EEF32A00B9C4DD /* RKMappingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKMappingTest.m; path = Testing/RKMappingTest.m; sourceTree = "<group>"; };
@@ -1958,6 +1961,7 @@
 				252A2033153477870078F8AD /* NSArray+RKAdditionsTest.m */,
 				2501405215366000004E0466 /* RKObjectiveCppTest.mm */,
 				25A2476D153E667E003240B6 /* RKCacheTest.m */,
+				032E102D15B0A38C0057D164 /* NSString+RKAdditionsTest.m */,
 			);
 			name = Support;
 			path = Logic/Support;
@@ -2894,6 +2898,7 @@
 				25A2476E153E667E003240B6 /* RKCacheTest.m in Sources */,
 				259D985A1550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m in Sources */,
 				259D986415521B20008C90F5 /* RKEntityCacheTest.m in Sources */,
+				032E102E15B0A38C0057D164 /* NSString+RKAdditionsTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3084,6 +3089,7 @@
 				25A2476F153E667E003240B6 /* RKCacheTest.m in Sources */,
 				259D985B1550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m in Sources */,
 				259D986515521B20008C90F5 /* RKEntityCacheTest.m in Sources */,
+				032E102F15B0A4560057D164 /* NSString+RKAdditionsTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Logic/Support/NSString+RKAdditionsTest.m
+++ b/Tests/Logic/Support/NSString+RKAdditionsTest.m
@@ -1,0 +1,35 @@
+//
+//  NSString+RKAdditionsTest.m
+//  RestKit
+//
+//  Created by Josh Brown on 7/13/12.
+//  Copyright (c) 2012 RestKit. All rights reserved.
+//
+
+#import "RKTestEnvironment.h"
+#import "NSString+RKAdditions.h"
+
+@interface NSString_RKAdditionsTest : RKTestCase
+@end
+
+@implementation NSString_RKAdditionsTest
+
+- (void)testReturnsNilWhenReceiverHasNoQueryParameters
+{
+    NSString *string = @"/path";
+    assertThat([string queryParametersString], is(equalTo(nil)));
+}
+
+- (void)testReturnsQueryParametersStringWhenReceiverHasSingleKeyValuePair
+{
+    NSString *string = @"/path?foo=bar";
+    assertThat([string queryParametersString], is(equalTo(@"foo=bar")));
+}
+
+- (void)testReturnsQueryParametersStringWhenReceiverHasTwoKeyValuePairs
+{
+    NSString *string = @"/path?foo=bar&this=that";
+    assertThat([string queryParametersString], is(equalTo(@"foo=bar&this=that")));    
+}
+
+@end


### PR DESCRIPTION
Fixed the issue with params being dropped by switching from dictionaries to strings.
