### PR TITLE
RKFetchedResultsControlller: Give fetchRequest property priority over Mapper

### DIFF
--- a/Code/UI/RKFetchedResultsTableController.m
+++ b/Code/UI/RKFetchedResultsTableController.m
@@ -229,10 +229,11 @@
 
 - (void)loadTable {
     NSFetchRequest *fetchRequest = nil;
-    if (_resourcePath) {
-        fetchRequest = [self.objectManager.mappingProvider fetchRequestForResourcePath:self.resourcePath];
-    } else {
+    if (_fetchRequest) {
         fetchRequest = _fetchRequest;
+    }
+    else if (_resourcePath) {
+        fetchRequest = [self.objectManager.mappingProvider fetchRequestForResourcePath:self.resourcePath];
     }
     NSAssert(fetchRequest != nil, @"Attempted to load RKFetchedResultsTableController with nil fetchRequest for resourcePath %@, fetchRequest %@", _resourcePath, _fetchRequest);
 


### PR DESCRIPTION
As it stands, if you attempt to use this code, it will not work:

``` objective-c
    self.tableController.resourcePath = @"/projects";
    self.tableController.fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Project"];
```

This is because the RKFetchedResultsController is giving priority to the resourcePath (mapper) instead of the fetchRequest property.  Even worse, if the mapper does not implement a fetchRequest block for the given resourcePath, the program will crash.

In this PR, I modified the conditional to give priority to a manually set fetchRequest instead of giving priority to the mapper.
