### PR TITLE
Add isCancelled Mapping Guard

### DIFF
--- a/Code/ObjectMapping/RKObjectLoader.m
+++ b/Code/ObjectMapping/RKObjectLoader.m
@@ -278,7 +278,7 @@
 {
     NSAssert(self.mappingQueue, @"mappingQueue cannot be nil");
     [self.mappingQueue addOperationWithBlock:^{
-        if (self.cancelled) {
+        if (self.isCancelled) {
             RKLogDebug(@"Cancelled object mapping activities within GCD queue labeled: %@", self.mappingQueue.name);
         } else {
             RKLogDebug(@"Beginning object mapping activities within GCD queue labeled: %@", self.mappingQueue.name);


### PR DESCRIPTION
This patch adds a guard, as recommend by Apple, for any background mapping operation that checks that the operation has not been cancelled.  If the request has been cancelled, then the mapping operation should not proceed.

Note this is obviously not fool-proof since the background thread could have gotten past the guard before the request is cancelled.  However, this is still useful in that it makes it quicker to clean up RestKit if needed.

For my app, this comes into play because when a user logouts the local Core datastore should be deleted.  Here is similar use case:

https://groups.google.com/forum/?fromgroups#!searchin/restkit/delete$20store$20background$20mapping/restkit/CX3gIEoWdtw/bh3JsjkVsswJ

The naive approach of deleting the file, even after canceling all requests in the queue, causes the app to crash because of background mapping tasks.    That can be solved by waiting for the background queue to finish - the guard above makes the process a lot quicker because it potentially skips a lot of unnecessary mapping for requests that have been fulfilled but have not yet been mapped (so its dependent on the RKQueue size).

Thank - Charlie
