### PR TITLE
Fixes issue with looking up cached objects when a different object store is used in RKManagedObjectLoader.

### DIFF
--- a/Code/CoreData/RKManagedObjectLoader.m
+++ b/Code/CoreData/RKManagedObjectLoader.m
@@ -123,7 +123,7 @@
 - (NSArray *)cachedObjects {
     NSFetchRequest *fetchRequest = [self.mappingProvider fetchRequestForResourcePath:self.resourcePath];
     if (fetchRequest) {
-        return [NSManagedObject objectsWithFetchRequest:fetchRequest];
+        return [[self.objectStore managedObjectContextForCurrentThread] executeFetchRequest:fetchRequest error:NULL];
     }
 
     return nil;


### PR DESCRIPTION
If a different object store is used in RKManagedObjectStore, the lookup for cached objects will fail due to trying to used the default object store's primary object context. This fixes that.

Let me know if you have questions. :)
