### PR TITLE
 Enabled RKClient and RKQuest to change network activity indicator on requests

### DIFF
--- a/Code/Network/RKClient.h
+++ b/Code/Network/RKClient.h
@@ -447,6 +447,14 @@
 @property (nonatomic, assign) BOOL serviceUnavailableAlertEnabled;
 
 
+/**
+ Flag that determines whether requests made by this client will show the
+ the networking activity indicator in the status bar.
+ 
+ *Default*: _NO_
+ */
+@property (nonatomic, assign) BOOL showNetworkActivity;
+
 ///-----------------------------------------------------------------------------
 /// @name Reachability helpers
 ///-----------------------------------------------------------------------------

--- a/Code/Network/RKClient.m
+++ b/Code/Network/RKClient.m
@@ -89,6 +89,7 @@ NSString *RKPathAppendQueryParams(NSString *resourcePath, NSDictionary *queryPar
 @synthesize serviceUnavailableAlertTitle = _serviceUnavailableAlertTitle;
 @synthesize serviceUnavailableAlertMessage = _serviceUnavailableAlertMessage;
 @synthesize serviceUnavailableAlertEnabled = _serviceUnavailableAlertEnabled;
+@synthesize showNetworkActivity = _showNetworkActivity;
 @synthesize requestCache = _requestCache;
 @synthesize cachePolicy = _cachePolicy;
 @synthesize requestQueue = _requestQueue;
@@ -222,7 +223,8 @@ NSString *RKPathAppendQueryParams(NSString *resourcePath, NSDictionary *queryPar
     request.queue = self.requestQueue;
     request.reachabilityObserver = self.reachabilityObserver;
     request.defaultHTTPEncoding = self.defaultHTTPEncoding;
-
+    request.showNetworkActivity = self.showNetworkActivity;
+  
     request.additionalRootCertificates = self.additionalRootCertificates;
     request.disableCertificateValidation = self.disableCertificateValidation;
     request.runLoopMode = self.runLoopMode;

--- a/Code/Network/RKRequest.h
+++ b/Code/Network/RKRequest.h
@@ -285,6 +285,14 @@ typedef void(^RKRequestDidFailLoadWithErrorBlock)(NSError *error);
  */
 @property (nonatomic, assign) NSStringEncoding defaultHTTPEncoding;
 
+/**
+ Determines whether the request will display network activity on application 
+     status bar when a request is made
+ 
+ *Default*: No network activity indicator will be displayed
+ */
+@property (nonatomic, assign) BOOL showNetworkActivity;
+
 ///-----------------------------------------------------------------------------
 /// @name Working with the HTTP Body
 ///-----------------------------------------------------------------------------

--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -118,6 +118,7 @@ RKRequestMethod RKRequestMethodTypeFromName(NSString *methodName) {
 @synthesize timeoutInterval = _timeoutInterval;
 @synthesize reachabilityObserver = _reachabilityObserver;
 @synthesize defaultHTTPEncoding = _defaultHTTPEncoding;
+@synthesize showNetworkActivity = _showNetworkActivity;
 @synthesize configurationDelegate = _configurationDelegate;
 @synthesize onDidLoadResponse;
 @synthesize onDidFailLoadWithError;
@@ -425,6 +426,11 @@ RKRequestMethod RKRequestMethodTypeFromName(NSString *methodName) {
 // NOTE: We could factor the knowledge about the queue out of RKRequest entirely, but it will break behavior.
 - (void)send {
     NSAssert(NO == self.isLoading || NO == self.isLoaded, @"Cannot send a request that is loading or loaded without resetting it first.");
+  
+    if (self.showNetworkActivity) {
+      [[UIApplication sharedApplication] pushNetworkActivity];
+    }
+    
     if (self.queue) {
         [self.queue addRequest:self];
     } else {
@@ -677,6 +683,10 @@ RKRequestMethod RKRequestMethodTypeFromName(NSString *methodName) {
     RKLogDebug(@"Body: %@", [response bodyAsString]);
 
     self.response = response;
+  
+    if (_showNetworkActivity) {
+      [[UIApplication sharedApplication] popNetworkActivity];
+    }
 
     if ((_cachePolicy & RKRequestCachePolicyEtag) && [response isNotModified]) {
         self.response = [self loadResponseFromCache];


### PR DESCRIPTION
Added flag to enable RKClient and RKRequest to show network activity indicator when performing a request.

This is useful when the user is not using RKObjectManager when performing requests since RKRequest doesn't handle it automatically.
