### PR TITLE
Allow tokens in resource path query strings.

### DIFF
--- a/Code/ObjectMapping/RKObjectMappingProvider.m
+++ b/Code/ObjectMapping/RKObjectMappingProvider.m
@@ -324,7 +324,7 @@
     NSAssert(contextValue, @"Attempted to retrieve mapping from undefined context: %d", context);
     for (NSString *pattern in contextValue) {
         RKPathMatcher *pathMatcher = [RKPathMatcher matcherWithPattern:pattern];
-        if ([pathMatcher matchesPath:string tokenizeQueryStrings:NO parsedArguments:nil]) {
+        if ([pathMatcher matchesPath:string tokenizeQueryStrings:YES parsedArguments:nil]) {
             RKObjectMappingProviderContextEntry *entry = [contextValue objectForKey:pattern];
             return entry.mapping;
         }


### PR DESCRIPTION
I was trying to use the object loader on URLs with tokens but my mappings weren't being used. I wrote up a stackoverflow question that provides more detail:
  http://stackoverflow.com/questions/11583418/how-do-you-use-restkit-resource-path-mappings-with-query-strings

Eventually I traced it down to this option. It fixed my issue and seemed like a clean approach. I'm curious if there's a reason this was disabled.
