### PR TITLE
Fix segmentation fault when requests are cancelled

### DIFF
--- a/Code/ObjectMapping/RKObjectLoader.m
+++ b/Code/ObjectMapping/RKObjectLoader.m
@@ -127,15 +127,20 @@
 // RKRequestQueue to remove requests from the queue. All requests need to be finalized.
 - (void)finalizeLoad:(BOOL)successful
 {
-    self.loading = NO;
-    self.loaded = successful;
-
     dispatch_async(dispatch_get_main_queue(), ^{
+        // First remove the request from the queue
+        [[NSNotificationCenter defaultCenter] postNotificationName:RKRequestDidFinishLoadingNotification object:self];
+
+        /* Now update the request state.  We have to do this after removing the request from the
+        queue because if successful is false then RKRequestQueue#next will rerun the request! */
+        self.loading = NO;
+        self.loaded = successful;
+        
+        // Now call the delegate
         if ([self.delegate respondsToSelector:@selector(objectLoaderDidFinishLoading:)]) {
             [(NSObject<RKObjectLoaderDelegate>*)self.delegate objectLoaderDidFinishLoading:self];
         }
 
-        [[NSNotificationCenter defaultCenter] postNotificationName:RKRequestDidFinishLoadingNotification object:self];
     });
 }
 


### PR DESCRIPTION
1. Load a number of requests (more than one)
2. Have them all get cancelled because the network connection gets cancelled
3. Now get a segmentation fault.

The segmentation fault is caused by recyling the cancelled request - it gets sent a second time.  The reason for this is that the RKObjectLoader#finalizeLoad sets self.loading to false and self.loaded to false.   But it doesn't actually remove the request from the queue, that is done via a notification that is posted to the main thread, so there is a fair bit of delay.

As a result, the next time nextInQueue is called by the RKRequestQueue, nextInQueue may return the cancelled request.  That causes the request to be sent again, resulting in a segmentation fault because in the meantime the request will be deallocated.  So when a NSURLConnection callback occurs,  RKResponse#request is a freed object.

Note that RKRequestQueue#processRequestDidLoadResponseNotification, which is called on a request failing, removes the request from the loading array but not the request array.  This kind of looks like old code to me, not sure there is any point in calling   [self removeLoadingRequest:request] anymore (it doesn't break things...just led me down the wrong track for a while).
