### PR TITLE
string format and casting changes to remove warnings

### DIFF
--- a/Code/CoreData/NSManagedObject+ActiveRecord.m
+++ b/Code/CoreData/NSManagedObject+ActiveRecord.m
@@ -295,7 +295,7 @@ RK_FIX_CATEGORY_BUG(NSManagedObject_ActiveRecord)
             }
             else
             {
-                RKLogError(@"Property '%@' not found in %d properties for %@", propertyName, [propDict count], NSStringFromClass(self));
+                RKLogError(@"Property '%@' not found in %lu properties for %@", propertyName, (unsigned long)[propDict count], NSStringFromClass(self));
             }
         }
     }

--- a/Code/Network/RKRequest.m
+++ b/Code/Network/RKRequest.m
@@ -321,7 +321,7 @@ RKRequestMethod RKRequestMethodTypeFromName(NSString *methodName) {
             [_URLRequest setValue:[_params performSelector:@selector(ContentTypeHTTPHeader)] forHTTPHeaderField:@"Content-Type"];
         }
         if ([_params respondsToSelector:@selector(HTTPHeaderValueForContentLength)]) {
-            [_URLRequest setValue:[NSString stringWithFormat:@"%d", [_params HTTPHeaderValueForContentLength]] forHTTPHeaderField:@"Content-Length"];
+            [_URLRequest setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[_params HTTPHeaderValueForContentLength]] forHTTPHeaderField:@"Content-Length"];
         }
     } else {
         [_URLRequest setValue:@"0" forHTTPHeaderField:@"Content-Length"];

--- a/Code/Network/RKRequestQueue.m
+++ b/Code/Network/RKRequestQueue.m
@@ -198,9 +198,9 @@ static const NSTimeInterval kFlushDelay = 0.3;
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p name=%@ suspended=%@ requestCount=%d loadingCount=%d/%d>",
+    return [NSString stringWithFormat:@"<%@: %p name=%@ suspended=%@ requestCount=%lu loadingCount=%lu/%lu>",
             NSStringFromClass([self class]), self, self.name, self.suspended ? @"YES" : @"NO",
-            self.count, self.loadingCount, self.concurrentRequestsLimit];
+            (unsigned long)self.count, (unsigned long)self.loadingCount, (unsigned long)self.concurrentRequestsLimit];
 }
 
 - (NSUInteger)loadingCount

--- a/Code/ObjectMapping/RKObjectMappingProviderContextEntry.m
+++ b/Code/ObjectMapping/RKObjectMappingProviderContextEntry.m
@@ -44,7 +44,7 @@
 - (NSUInteger)hash
 {
     int prime = 31;
-    int result = 1;
+    NSUInteger result = 1;
     result = prime *[self.userData hash] ? [self.mapping hash] : [self.userData hash];
     return result;
 }

--- a/Code/ObjectMapping/RKObjectPropertyInspector.m
+++ b/Code/ObjectMapping/RKObjectPropertyInspector.m
@@ -108,7 +108,7 @@ static RKObjectPropertyInspector *sharedInspector = nil;
         currentClass = [currentClass superclass];
     }
 
-    [_cachedPropertyNamesAndTypes setObject:propertyNames forKey:theClass];
+    [_cachedPropertyNamesAndTypes setObject:propertyNames forKey:(id)theClass];
     RKLogDebug(@"Cached property names and types for Class '%@': %@", NSStringFromClass(theClass), propertyNames);
     return propertyNames;
 }

--- a/Code/ObjectMapping/RKObjectRouter.m
+++ b/Code/ObjectMapping/RKObjectRouter.m
@@ -44,7 +44,7 @@
     NSString *className = NSStringFromClass(theClass);
     if (nil == [_routes objectForKey:theClass]) {
         NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
-        [_routes setObject:dictionary forKey:theClass];
+        [_routes setObject:dictionary forKey:(id)theClass];
     }
 
     NSMutableDictionary *classRoutes = [_routes objectForKey:theClass];

--- a/Vendor/iso8601parser/ISO8601DateFormatter.m
+++ b/Vendor/iso8601parser/ISO8601DateFormatter.m
@@ -25,7 +25,7 @@ unichar ISO8601DefaultTimeSeparatorCharacter = DEFAULT_TIME_SEPARATOR;
 #define ISO_TIME_WITH_TIMEZONE_FORMAT  ISO_TIME_FORMAT @"Z"
 //printf formats.
 #define ISO_TIMEZONE_UTC_FORMAT @"Z"
-#define ISO_TIMEZONE_OFFSET_FORMAT @"%+.2d%.2d"
+#define ISO_TIMEZONE_OFFSET_FORMAT @"%+.2ld%.2ld"
 
 @interface ISO8601DateFormatter(UnparsingPrivate)
 
@@ -674,7 +674,7 @@ static BOOL is_leap_year(NSUInteger year);
 		case ISO8601DateFormatOrdinal:
 			return [self stringFromDate:date formatString:ISO_ORDINAL_DATE_FORMAT timeZone:timeZone];
 		default:
-			[NSException raise:NSInternalInconsistencyException format:@"self.format was %d, not calendar (%d), week (%d), or ordinal (%d)", self.format, ISO8601DateFormatCalendar, ISO8601DateFormatWeek, ISO8601DateFormatOrdinal];
+			[NSException raise:NSInternalInconsistencyException format:@"self.format was %lu, not calendar (%d), week (%d), or ordinal (%d)", (unsigned long)self.format, ISO8601DateFormatCalendar, ISO8601DateFormatWeek, ISO8601DateFormatOrdinal];
 			return nil;
 	}
 }
@@ -708,7 +708,7 @@ static BOOL is_leap_year(NSUInteger year);
 		if (offset == 0)
 			str = [str stringByAppendingString:ISO_TIMEZONE_UTC_FORMAT];
 		else
-			str = [str stringByAppendingFormat:ISO_TIMEZONE_OFFSET_FORMAT, offset / 60, offset % 60];
+			str = [str stringByAppendingFormat:ISO_TIMEZONE_OFFSET_FORMAT, (long)offset / 60, (long)offset % 60];
 	}
     
 	//Undo the change we made earlier


### PR DESCRIPTION
On different systems, NS(U)Integer maps to a long or an int, and according to Apple, best practice for string formatting is to cast up to long. ([source](https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html#//apple_ref/doc/uid/TP40004265-SW5))

Existing code used %d in several format strings. Changed to %ld or %lu (depending on signed-ness) and casted arguments to long or unsigned long respectively, thus removing warnings on systems where NS(U)Integer maps to a long, and not introducing warnings on systems where it maps to an int.

[Sample of Warnings (that are now removed)](http://cl.ly/image/2x1T0s0e2D46)
