### PR TITLE
Map array to NSData

### DIFF
--- a/Code/ObjectMapping/RKObjectMappingOperation.m
+++ b/Code/ObjectMapping/RKObjectMappingOperation.m
@@ -209,6 +209,10 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue) {
         if (orderedSetClass && [destinationType isSubclassOfClass:orderedSetClass]) {
             return [orderedSetClass orderedSetWithArray:value];
         }
+        // Array -> NSData
+        if ([destinationType isSubclassOfClass:[NSData class]]) {
+            return [NSKeyedArchiver archivedDataWithRootObject:value];
+        }
     } else if ([sourceType isSubclassOfClass:[NSNumber class]] && [destinationType isSubclassOfClass:[NSDate class]]) {
         // Number -> Date
         if ([destinationType isSubclassOfClass:[NSDate class]]) {


### PR DESCRIPTION
I needed to store an array of strings in Core Data, so I tried to map the array to an NSData attribute in my Core Data object graph.
I received the following error: `No strategy for transforming from 'JKArray' to 'NSData'
Hence my three little lines of code.

Allows one to map an array to an NSData attribute.
The NSArray is archived with [NSKeyedArchiver archivedDataWithRootObject:value].
One can retrieve the NSArray with a simple [NSKeyedUnarchiver unarchiveObjectWithData:data].

By the way, thanks for writing RestKit, it really is amazing.
