### PR TITLE
Updated Readme for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,13 +486,13 @@ Edit your Podfile and add RestKit:
 ``` bash
 $ edit Podfile
 platform :ios, '5.0'
-dependency 'RestKit', '0.20.0'
+pod 'RestKit', :git => 'https://github.com/RestKit/RestKit.git', :branch => 'feature/reboot-networking-layer'
 ```
 
 Install into your project:
 
 ``` bash
-$ pod install MyApp.xcodeproj
+$ pod install
 ```
 
 ### From a Release Package or as a Git submodule


### PR DESCRIPTION
pod is depreciated, and no .20 tag exists this pulls the current feature branch
