### PR TITLE
Corrected RKURL#URLByAppendingQueryParameters: was clearing URL's resource path

### DIFF
--- a/Code/Network/RKURL.m
+++ b/Code/Network/RKURL.m
@@ -130,7 +130,7 @@
 
 - (RKURL *)URLByAppendingQueryParameters:(NSDictionary *)theQueryParameters
 {
-    return [RKURL URLWithBaseURL:self resourcePath:resourcePath queryParameters:theQueryParameters];
+    return [RKURL URLWithBaseURL:self resourcePath:self.resourcePath queryParameters:theQueryParameters];
 }
 
 - (RKURL *)URLByReplacingResourcePath:(NSString *)newResourcePath


### PR DESCRIPTION
When creating a new `RKURL` through `#URLByAppendingQueryParameters`, the `resourcePath` was set to nil.

I think this now matches the [documentation](http://restkit.org/api/0.10.3/Classes/RKURL.html#//api/name/URLByAppendingQueryParameters:).
