### PR TITLE
Changed seeder to accept URLs (including non-bundle file paths)

### DIFF
--- a/Code/CoreData/RKManagedObjectSeeder.h
+++ b/Code/CoreData/RKManagedObjectSeeder.h
@@ -25,8 +25,16 @@ extern NSString * const RKDefaultSeedDatabaseFileName;
 
 @protocol RKManagedObjectSeederDelegate
 @required
+// Invoked when the seeder creates a new object from a URL
+- (void)didSeedObject:(NSManagedObject *)object fromURL:(NSURL *)url;
 
-// Invoked when the seeder creates a new object
+/**
+ * Invoked when the seeder creates a new object from a file.
+ *
+ * Note that if you pass a file URL to `seedObjectsFromURL:objectMapping:`, this delegate 
+ * method will still be called.  This is for backwards compatability as well as because it 
+ * is indeed a file.
+ */
 - (void)didSeedObject:(NSManagedObject *)object fromFile:(NSString *)fileName;
 @end
 
@@ -61,18 +69,34 @@ extern NSString * const RKDefaultSeedDatabaseFileName;
 
 /**
  * Seed the database with objects from the specified file(s). The list must be terminated by nil
+ *
+ * The data in the file must be in UTF-8 encoding.
  */
 - (void)seedObjectsFromFiles:(NSString *)fileName, ...;
 
 /**
  * Seed the database with objects from the specified file using the supplied object mapping.
+ *
+ * The data in the file must be in UTF-8 encoding.
  */
 - (void)seedObjectsFromFile:(NSString *)fileName withObjectMapping:(RKObjectMapping *)nilOrObjectMapping;
 
 /**
  * Seed the database with objects from the specified file, from the specified bundle, using the supplied object mapping.
+ *
+ * The data in the file must be in UTF-8 encoding.
  */
 - (void)seedObjectsFromFile:(NSString *)fileName withObjectMapping:(RKObjectMapping *)nilOrObjectMapping bundle:(NSBundle *)nilOrBundle;
+
+/**
+ * Seed the database with objects from the specified URL using the supplied object mapping.
+ *
+ * The data returned at the URL must be in UTF-8 encoding.
+ *
+ * @warning This method uses `stringWithContentsOfURL:encoding:error` on `NSString` to load 
+ * the URL, which is synchronous. This method will block until the network request is complete.
+ */
+- (void)seedObjectsFromURL:(NSURL *)url withObjectMapping:(RKObjectMapping *)nilOrObjectMapping;
 
 /**
  * Completes a seeding session by persisting the store, outputing an informational message


### PR DESCRIPTION
I use RKManagedObjectSeeder as a separate build step in releasing my app -- it is not used in production code.

I rely on a remote server for up-to-date data; with the current implementation, I was always `curl`ing JSON files locally and then running -- I wanted to automate the process and go out and get the URLs directly.

This change enables this, as well as enables you to load files that are not in the bundle.

The delegates are a bit wonky now (see the comments) -- if people think this patch is useful I'm happy to change it a bit to match the needs.

I don't think I'm the only one who has been limited by this, though:

https://groups.google.com/forum/#!searchin/restkit/RKManagedObjectSeeder/restkit/ch4CatH_8EU/pLit_ueKUTQJ
