### PR TITLE
No-content mapping should report client error.

### DIFF
--- a/Code/Network/RKResponseMapperOperation.m
+++ b/Code/Network/RKResponseMapperOperation.m
@@ -172,13 +172,18 @@ NSError *RKErrorFromMappingResult(RKMappingResult *mappingResult)
 
     // Object map the response
     self.mappingResult = [self performMappingWithObject:parsedBody error:&error];
-    if (! self.mappingResult) {
+
+    // If the response is a client error return either the mapping error or the mapped result to the caller as the error
+    if (isClientError) {
+        if (! error) error = RKErrorFromMappingResult(self.mappingResult);
         self.error = error;
         return;
     }
 
-    // If the response is a client error and we mapped the payload, return it to the caller as the error
-    if (isClientError) self.error = RKErrorFromMappingResult(self.mappingResult);
+    if (! self.mappingResult) {
+        self.error = error;
+        return;
+    }
 }
 
 @end


### PR DESCRIPTION
Fixes #978.

If we receive a response which isn't empty, but the response object (e.g. JSON {}) has no content then a client error status code should be reported as an error rather than being handled with the success callback queue as if there was no error.
