### PR TITLE
Take KVC scalar/structure support into account when inspecting properties.

### DIFF
--- a/Code/CoreData/RKObjectPropertyInspector+CoreData.m
+++ b/Code/CoreData/RKObjectPropertyInspector+CoreData.m
@@ -44,7 +44,11 @@ RK_FIX_CATEGORY_BUG(RKPropertyInspector_CoreData)
     for (NSString *name in [entity attributesByName]) {
         NSAttributeDescription *attributeDescription = [[entity attributesByName] valueForKey:name];
         if ([attributeDescription attributeValueClassName]) {
-            [propertyNamesAndTypes setValue:NSClassFromString([attributeDescription attributeValueClassName]) forKey:name];
+            Class cls = NSClassFromString([attributeDescription attributeValueClassName]);
+            if ([cls isSubclassOfClass:[NSNumber class]] && [attributeDescription attributeType] == NSBooleanAttributeType) {
+                cls = objc_getClass("NSCFBoolean") ?: objc_getClass("__NSCFBoolean") ?: cls;
+            }
+            [propertyNamesAndTypes setValue:cls forKey:name];
 
         } else if ([attributeDescription attributeType] == NSTransformableAttributeType &&
                    ![name isEqualToString:@"_mapkit_hasPanoramaID"]) {
@@ -53,12 +57,10 @@ RK_FIX_CATEGORY_BUG(RKPropertyInspector_CoreData)
             const char *propertyName = [name cStringUsingEncoding:NSUTF8StringEncoding];
             Class managedObjectClass = objc_getClass(className);
 
-            // property_getAttributes() returns everything we need to implement this...
-            // See: http://developer.apple.com/mac/library/DOCUMENTATION/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtPropertyIntrospection.html#//apple_ref/doc/uid/TP40008048-CH101-SW5
             objc_property_t prop = class_getProperty(managedObjectClass, propertyName);
-            NSString *attributeString = [NSString stringWithCString:property_getAttributes(prop) encoding:NSUTF8StringEncoding];
-            const char *destinationClassName = [[RKPropertyInspector propertyTypeFromAttributeString:attributeString] cStringUsingEncoding:NSUTF8StringEncoding];
-            Class destinationClass = objc_getClass(destinationClassName);
+
+            const char *attr = property_getAttributes(prop);
+            Class destinationClass = [RKPropertyInspector kvcClassFromPropertyAttributes:attr];
             if (destinationClass) {
                 [propertyNamesAndTypes setObject:destinationClass forKey:name];
             }

--- a/Code/ObjectMapping/RKPropertyInspector.h
+++ b/Code/ObjectMapping/RKPropertyInspector.h
@@ -74,4 +74,23 @@
  */
 + (NSString *)propertyTypeFromAttributeString:(NSString *)attributeString;
 
+/**
+ Returns an appropriate class to use for KVC access based on the Objective C runtime type encoding.
+ 
+ Objective C Runtime type encodings: https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
+ KVC Scalar/Structure support: http://developer.apple.com/library/ios/#documentation/cocoa/conceptual/KeyValueCoding/Articles/DataTypes.html#//apple_ref/doc/uid/20002171-BAJEAIEE
+ 
+ @param type An Objective C Runtime type encoding
+ @return The class name for the property type encoded in the given attribute string, an appropriate class for wrapping/unwrapping the primitive type, or `Nil` when no transformation is required or possible.
+ */
++ (Class)kvcClassForObjCType:(const char *)type;
+
+/**
+ Returns an appropriate class to use for KVC access based on the output obtained via the `property_getAttributes` reflection API.
+ 
+ @param attributeString A c string containing encoding attribute information.
+ @return The class name for the property type encoded in the given attribute string, an appropriate class for wrapping/unwrapping the primitive type, or `Nil` when no transformation is required or possible.
+ */
++ (Class)kvcClassFromPropertyAttributes:(const char *)attr;
+
 @end


### PR DESCRIPTION
RestKit has the advantage of relying heavily on Key-Value Coding, so KVC's auto-wrapping and unwrapping can be expected and used to our benefit.

The particular implementation in this pull request was chosen mainly to touch as little as possible, but it has worked well for me as-is. Maybe the `+kvcClass...` methods should return a sentinel for `id` or for non-wrappable types like selectors, voids, and pointers, though it doesn't seem necessary. Right now `Nil` is returned for either case. The non-mappable values are left to be something else's problem and RestKit will perform no explicit transformation during a mapping operation.

This setup requires KVC compliant target object properties, though in practice I've found that only `setNilValueForKey:` needs to be implemented on the target object when supporting KVC auto-boxing for scalar properties like this.

Also while making the required changes in `RKPropertyInspector+CoreData`, I added a check for `NSBooleanAttributeType` to shuttle around wrapped boolean properties as `NSCFBoolean` wherever possible.

Anyway, thanks for taking a look at this, and thanks again for this project.
