### PR TITLE
Correctly ignore unknown key paths

### DIFF
--- a/Code/ObjectMapping/RKObjectMappingOperation.m
+++ b/Code/ObjectMapping/RKObjectMappingOperation.m
@@ -463,6 +463,11 @@ BOOL RKObjectIsValueEqualToValue(id sourceValue, id destinationValue) {
     id destinationObject = nil;
 
     for (RKObjectRelationshipMapping *relationshipMapping in [self relationshipMappings]) {
+        if(self.objectMapping.ignoreUnknownKeyPaths && ![self.sourceObject respondsToSelector:NSSelectorFromString(relationshipMapping.sourceKeyPath)]) {
+            RKLogDebug(@"Source object is not key-value coding compliant for the keyPath '%@', skipping...", relationshipMapping.sourceKeyPath);
+            continue;
+        }
+
         id value = nil;
         @try {
             value = [self.sourceObject valueForKeyPath:relationshipMapping.sourceKeyPath];


### PR DESCRIPTION
I made two changes in order to make object mapping's ignoreUnknownKeyPaths=YES behave as expected:
1. Previously, if ignoreUnknownKeyPaths was YES and an attributeMapping from an empty string was specified, the attribute was not mapped because no source object would respond to a message with an empty string as name. This is fixed in the first commit by first checking the empty string attribute, and then checking for ignoreUnknownKeyPaths etc..
2. When mapping relationships, ignoreUnknownKeyPaths was not checked before trying to resolve the key path. This resulted in an annoying warning message for each such relationship. In the second commit, I matched the behaviour with the original attribute mapping behaviour: if ignoreUnknownKeyPaths is YES, it first checks whether the source object responds to the key path selector before actually resolving the key path.

I hope you find this useful.
If there are any issues with this pull request, please let me know.
Cheers,
Lysann
