### PR TITLE
Fixed glitch in pull to refresh arrow animations

### DIFF
--- a/Code/UI/RKRefreshGestureRecognizer.m
+++ b/Code/UI/RKRefreshGestureRecognizer.m
@@ -164,7 +164,8 @@ static CGFloat const kDefaultTriggerViewHeight = 64.f;
     animation.delegate = self;
     animation.duration = kFlipArrowAnimationTime;
     animation.toValue = [NSNumber numberWithDouble:0];
-    animation.removedOnCompletion = YES;
+    animation.fillMode = kCAFillModeForwards;
+    animation.removedOnCompletion = NO;
     return animation;
 }
 


### PR DESCRIPTION
 - Fixed glitch in the animation of the pull to refresh arrow
 - The `idlingAnimation` previously would briefly flash the starting state of the image after the animation completed.
