### PR TITLE
Add support to RKObjectManager to use RKDynamicMapping as a container for RKEntityMappings.

### DIFF
--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -31,6 +31,7 @@
 #import "RKPathMatcher.h"
 #import "RKMappingErrors.h"
 #import "RKPaginator.h"
+#import "RKDynamicMapping.h"
 
 #if !__has_feature(objc_arc)
 #error RestKit must be built with ARC.
@@ -91,6 +92,15 @@ static BOOL RKDoesArrayOfResponseDescriptorsContainEntityMapping(NSArray *respon
     for (RKResponseDescriptor *responseDescriptor in responseDescriptors) {
         if ([responseDescriptor.mapping isKindOfClass:[RKEntityMapping class]]) {
             return YES;
+        }
+      
+        if ([responseDescriptor.mapping isKindOfClass:[RKDynamicMapping class]]) {
+            RKDynamicMapping *dynamicMapping = (RKDynamicMapping *)responseDescriptor.mapping;
+            for (RKMapping *mapping in dynamicMapping.objectMappings) {
+                if ([mapping isKindOfClass:[RKEntityMapping class]]) {
+                  return YES;
+                }
+            }
         }
     }
     

--- a/Code/ObjectMapping.h
+++ b/Code/ObjectMapping.h
@@ -25,3 +25,4 @@
 #import "RKObjectParameterization.h"
 #import "RKMappingResult.h"
 #import "RKMapperOperation.h"
+#import "RKDynamicMapping.h"


### PR DESCRIPTION
Currently, RKObjectManager ignores RKDynamicMapping as a container for RKEntityMappings.

This results in the instantiation of Core Data objects w/o using their associated NSEntityDescriptions.

Support has been added to the RKObjectManager to address this.
