### PR TITLE
* Implement paginator construction relative to a path resolved from an object

### DIFF
--- a/Code/Network/RKObjectManager.h
+++ b/Code/Network/RKObjectManager.h
@@ -829,6 +829,11 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  */
 - (RKPaginator *)paginatorWithPathPattern:(NSString *)pathPattern;
 
+- (RKPaginator *)paginatorForObject:(id)object
+                               path:(NSString *)path
+                         parameters:(NSDictionary *)parameters
+            withRelativePathPattern:(NSString *)paginatorPathPattern;
+
 @end
 
 #ifdef _SYSTEMCONFIGURATION_H

--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -606,10 +606,9 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     [self enqueueObjectRequestOperation:operation];
 }
 
-- (RKPaginator *)paginatorWithPathPattern:(NSString *)pathPattern
+- (RKPaginator *)paginatorForRequest:(NSURLRequest *)request
 {
     NSAssert(self.paginationMapping, @"Cannot instantiate a paginator when `paginationMapping` is nil.");
-    NSMutableURLRequest *request = [self requestWithMethod:@"GET" path:pathPattern parameters:nil];
     RKPaginator *paginator = [[RKPaginator alloc] initWithRequest:request paginationMapping:self.paginationMapping responseDescriptors:self.responseDescriptors];
     paginator.managedObjectContext = self.managedObjectStore.mainQueueManagedObjectContext;
     paginator.managedObjectCache = self.managedObjectStore.managedObjectCache;
@@ -617,6 +616,25 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     paginator.operationQueue = self.operationQueue;
     if (self.HTTPOperationClass) [paginator setHTTPOperationClass:self.HTTPOperationClass];
     return paginator;
+}
+
+- (RKPaginator *)paginatorWithPathPattern:(NSString *)pathPattern
+{
+    NSMutableURLRequest *request = [self requestWithMethod:@"GET" path:pathPattern parameters:nil];
+    return [self paginatorForRequest:request];
+}
+
+- (RKPaginator *)paginatorForObject:(id)object
+                               path:(NSString *)path
+                         parameters:(NSDictionary *)parameters
+            withRelativePathPattern:(NSString *)paginatorPathPattern
+{
+    RKRequestMethod method = RKRequestMethodGET;
+    NSString *requestPath = (path) ? path : [[self.router URLForObject:object method:method] relativeString];
+    requestPath = [requestPath stringByAppendingPathComponent: paginatorPathPattern];
+    id requestParameters = [self mergedParametersWithObject:object method:method parameters:parameters];
+    NSMutableURLRequest *request = [self requestWithMethod:RKStringFromRequestMethod(method) path:requestPath parameters:requestParameters];
+    return [self paginatorForRequest: request];
 }
 
 #pragma mark - Request & Response Descriptors


### PR DESCRIPTION
This facilitates pagination URLs to be derived from parametrized URL routes. Consider, for example, the following path pattern: `@"users/:userId/articles"`

Assuming that the response can be paginated when the "page" query string parameter is supplied, the following will create a paginator for the articles of a given user:

```
RKPaginator *articlePaginator = [objectManager paginatorForObject:user path:nil parameters:nil withRelativePathPattern:@"?page=:currentPage"];
[articlePaginator setCompletionBlockWithSuccess:^(RKPaginator *paginator, NSArray *objects, NSUInteger page) {
    /* success block */
} failure:^(RKPaginator *paginator, NSError *error) {
    /* failure block */
}];
[articlePaginator loadPage: 0];
```

I wonder if there is a simpler way to achieve the same using the paginator code in the base repo. Thanks!
