### PR TITLE
Fixed issue with logging request HTTP body

### DIFF
--- a/Code/Network/RKHTTPRequestOperation.m
+++ b/Code/Network/RKHTTPRequestOperation.m
@@ -142,7 +142,7 @@ static void *RKHTTPRequestOperationStartDate = &RKHTTPRequestOperationStartDate;
     if ((_RKlcl_component_level[(__RKlcl_log_symbol(RKlcl_cRestKitNetwork))]) >= (__RKlcl_log_symbol(RKlcl_vTrace))) {
         NSString *body = nil;
         if ([operation.request HTTPBody]) {
-            body = RKLogTruncateString([NSString stringWithUTF8String:[[operation.request HTTPBody] bytes]]);
+            body = RKLogTruncateString([[NSString alloc] initWithData:[operation.request HTTPBody] encoding:NSUTF8StringEncoding]);
         } else if ([operation.request HTTPBodyStream]) {
             body = RKStringDescribingStream([operation.request HTTPBodyStream]);
         }


### PR DESCRIPTION
[NSString stringWithUTF8String] accept NULL terminated C array of UTF8-encoded
bytes. But NSData stores encoded data not like NULL terminated string.
There is no problem on simulator, but on device HTTP body logging as (null)
