### PR TITLE
Nil out targetObjectID if targetObject is set to an unmanaged object

### DIFF
--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -396,6 +396,8 @@ static NSURL *RKRelativeURLFromURLAndResponseDescriptors(NSURL *URL, NSArray *re
 
     if ([targetObject isKindOfClass:[NSManagedObject class]]) {
         self.targetObjectID = [targetObject objectID];
+    } else {
+        self.targetObject = nil
     }
 }
 


### PR DESCRIPTION
In particular, if the user sets targetObject to nil (as is advised for multiple root objects) then targetObjectId should also be nil.
