### PR TITLE
 Refactored RKConnectionDescription for improved encapsulation and subclassing

### DIFF
--- a/Code/CoreData.h
+++ b/Code/CoreData.h
@@ -27,6 +27,7 @@
 #import "RKManagedObjectCaching.h"
 #import "RKInMemoryManagedObjectCache.h"
 #import "RKFetchRequestManagedObjectCache.h"
+#import "RKConnectionDescriptionFactory.h"
 
 #import "RKPropertyInspector+CoreData.h"
 #import "NSManagedObjectContext+RKAdditions.h"

--- a/Code/CoreData/RKConnectionDescription.m
+++ b/Code/CoreData/RKConnectionDescription.m
@@ -19,124 +19,41 @@
 //
 
 #import "RKConnectionDescription.h"
-
-static NSSet *RKSetWithInvalidAttributesForEntity(NSArray *attributes, NSEntityDescription *entity)
-{
-    NSMutableSet *attributesSet = [NSMutableSet setWithArray:attributes];
-    NSSet *validAttributeNames = [NSSet setWithArray:[[entity attributesByName] allKeys]];
-    [attributesSet minusSet:validAttributeNames];
-    return attributesSet;
-}
-
-// Provides support for connecting a relationship by
-@interface RKForeignKeyConnectionDescription : RKConnectionDescription
-@end
-
-// Provides support for connecting a relationship by traversing the object graph
-@interface RKKeyPathConnectionDescription : RKConnectionDescription
-@end
-
-@interface RKConnectionDescription ()
-@property (nonatomic, strong, readwrite) NSRelationshipDescription *relationship;
-@property (nonatomic, copy, readwrite) NSDictionary *attributes;
-@property (nonatomic, copy, readwrite) NSString *keyPath;
-@end
+#import "RKConnectionDescriptionSubclass.h"
 
 @implementation RKConnectionDescription
-
-- (id)initWithRelationship:(NSRelationshipDescription *)relationship attributes:(NSDictionary *)attributes
-{
-    NSParameterAssert(relationship);
-    NSParameterAssert(attributes);
-    NSAssert([attributes count], @"Cannot connect a relationship without at least one pair of attributes describing the connection");
-    NSSet *invalidSourceAttributes = RKSetWithInvalidAttributesForEntity([attributes allKeys], [relationship entity]);
-    NSAssert([invalidSourceAttributes count] == 0, @"Cannot connect relationship: invalid attributes given for source entity '%@': %@", [[relationship entity] name], [[invalidSourceAttributes allObjects] componentsJoinedByString:@", "]);
-    NSSet *invalidDestinationAttributes = RKSetWithInvalidAttributesForEntity([attributes allValues], [relationship destinationEntity]);
-    NSAssert([invalidDestinationAttributes count] == 0, @"Cannot connect relationship: invalid attributes given for destination entity '%@': %@", [[relationship destinationEntity] name], [[invalidDestinationAttributes allObjects] componentsJoinedByString:@", "]);
-    
-    self = [[RKForeignKeyConnectionDescription alloc] init];
-    if (self) {
-        self.relationship = relationship;
-        self.attributes = attributes;
-        self.includesSubentities = YES;
-    }
-    return self;
-}
-
-- (id)initWithRelationship:(NSRelationshipDescription *)relationship keyPath:(NSString *)keyPath
-{
-    NSParameterAssert(relationship);
-    NSParameterAssert(keyPath);
-    self = [[RKKeyPathConnectionDescription alloc] init];
-    if (self) {
-        self.relationship = relationship;
-        self.keyPath = keyPath;
-    }
-    return self;
-}
 
 - (id)init
 {
     if ([self class] == [RKConnectionDescription class]) {
         @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                        reason:[NSString stringWithFormat:@"%@ Failed to call designated initializer. "
-                                               "Invoke initWithRelationship:attributes: instead.",
+                                               "Use concrete subclass instead.",
                                                NSStringFromClass([self class])]
                                      userInfo:nil];
     }
     return [super init];
 }
 
+- (id)findRelatedObjectFor:(NSManagedObject *)managedObject inManagedObjectCache:(id<RKManagedObjectCaching>)managedObjectCache {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"%@ Don't call super implemenentation for %@. "
+                                           "Use concrete subclass instead.",
+                                           NSStringFromClass([self class]), NSStringFromSelector(_cmd)]
+                                 userInfo:nil];
+}
+
 - (id)copyWithZone:(NSZone *)zone
 {
-    if ([self isForeignKeyConnection]) {
-        return [[[self class] allocWithZone:zone] initWithRelationship:self.relationship attributes:self.attributes];
-    } else if ([self isKeyPathConnection]) {
-        return [[[self class] allocWithZone:zone] initWithRelationship:self.relationship keyPath:self.keyPath];
+    if ([self class] == [RKConnectionDescription class]) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                       reason:[NSString stringWithFormat:@"%@ Failed to call designated initializer. "
+                                               "Use concrete subclass instead.",
+                                               NSStringFromClass([self class])]
+                                     userInfo:nil];
     }
     
     return nil;
-}
-
-- (BOOL)isForeignKeyConnection
-{
-    return NO;
-}
-
-- (BOOL)isKeyPathConnection
-{
-    return NO;
-}
-
-@end
-
-@implementation RKForeignKeyConnectionDescription
-
-- (BOOL)isForeignKeyConnection
-{
-    return YES;
-}
-
-- (NSString *)description
-{
-    return [NSString stringWithFormat:@"<%@:%p connecting Relationship '%@' from Entity '%@' to Destination Entity '%@' with attributes=%@>",
-            NSStringFromClass([self class]), self, [self.relationship name], [[self.relationship entity] name],
-            [[self.relationship destinationEntity] name], self.attributes];
-}
-
-@end
-
-@implementation RKKeyPathConnectionDescription
-
-- (BOOL)isKeyPathConnection
-{
-    return YES;
-}
-
-- (NSString *)description
-{
-    return [NSString stringWithFormat:@"<%@:%p connecting Relationship '%@' of Entity '%@' with keyPath=%@>",
-            NSStringFromClass([self class]), self, [self.relationship name], [[self.relationship entity] name], self.keyPath];
 }
 
 @end

--- a/Code/CoreData/RKConnectionDescriptionFactory.h
+++ b/Code/CoreData/RKConnectionDescriptionFactory.h
@@ -1,0 +1,47 @@
+//
+//  RKConnectionDescriptionFactory.h
+//  RestKit
+//
+//  Created by Marius Rackwitz on 21.01.13.
+//  Copyright (c) 2013 RestKit. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <CoreData/CoreData.h>
+#import "RKForeignKeyConnectionDescription.h"
+#import "RKKeyPathConnectionDescription.h"
+
+@interface RKConnectionDescriptionFactory : NSObject
+
++ (instancetype)sharedInstance;
+
+/**
+ Initializes the receiver with a given relationship and a dictionary of attributes specifying how to connect the relationship.
+ 
+ @param relationship The relationship to be connected.
+ @param sourceToDestinationEntityAttributes A dictionary specifying how attributes on the source entity correspond to attributes on the destination entity.
+ @return The receiver, initialized with the given relationship and attributes.
+ */
+- (RKForeignKeyConnectionDescription *)connectionWithRelationship:(NSRelationshipDescription *)relationship attributes:(NSDictionary *)sourceToDestinationEntityAttributes;
+
+/**
+ Initializes the receiver with a given relationship and key path.
+ 
+ @param relationship The relationship to be connected.
+ @param keyPath The key path from which to read the value that is to be set for the relationship.
+ @return The receiver, initialized with the given relationship and key path.
+ */
+- (RKKeyPathConnectionDescription *)connectionWithRelationship:(NSRelationshipDescription *)relationship keyPath:(NSString *)keyPath;
+
+@end

--- a/Code/CoreData/RKConnectionDescriptionFactory.m
+++ b/Code/CoreData/RKConnectionDescriptionFactory.m
@@ -1,0 +1,45 @@
+//
+//  RKConnectionDescriptionFactory.m
+//  RestKit
+//
+//  Created by Marius Rackwitz on 21.01.13.
+//  Copyright (c) 2013 RestKit. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "RKConnectionDescriptionFactory.h"
+
+@implementation RKConnectionDescriptionFactory
+
+static RKConnectionDescriptionFactory *sharedInstance;
+
++ (instancetype)sharedInstance
+{
+    if (!sharedInstance) {
+        sharedInstance = [self new];
+    }
+    return sharedInstance;
+}
+
+- (RKForeignKeyConnectionDescription *)connectionWithRelationship:(NSRelationshipDescription *)relationship attributes:(NSDictionary *)attributes
+{
+    return [[RKForeignKeyConnectionDescription alloc] initWithRelationship:relationship attributes:attributes];
+}
+
+- (RKKeyPathConnectionDescription *)connectionWithRelationship:(NSRelationshipDescription *)relationship keyPath:(NSString *)keyPath
+{
+    return [[RKKeyPathConnectionDescription alloc] initWithRelationship:relationship keyPath:keyPath];
+}
+
+@end

--- a/Code/CoreData/RKConnectionDescriptionSubclass.h
+++ b/Code/CoreData/RKConnectionDescriptionSubclass.h
@@ -1,9 +1,9 @@
 //
-//  ObjectMapping.h
+//  RKConnectionDescriptionSubclass.h
 //  RestKit
 //
-//  Created by Blake Watters on 9/30/10.
-//  Copyright (c) 2009-2012 RestKit. All rights reserved.
+//  Created by Marius Rackwitz on 21.01.13.
+//  Copyright (c) 2013 RestKit. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -18,11 +18,13 @@
 //  limitations under the License.
 //
 
-#import "RKObjectManager.h"
-#import "RKObjectMapping.h"
-#import "RKAttributeMapping.h"
-#import "RKRelationshipMapping.h"
-#import "RKObjectParameterization.h"
-#import "RKMappingResult.h"
-#import "RKMapperOperation.h"
-#import "RKDynamicMapping.h"
+#import "RKConnectionDescription.h"
+
+/*
+ The extensions to the `RKConnectionDescription` class declared here are to be used by subclasses implementations only. Code that uses `RKConnectionDescription` objects must never call these methods.
+ */
+@interface RKConnectionDescription ()
+
+@property (nonatomic, strong, readwrite) NSRelationshipDescription *relationship;
+
+@end

--- a/Code/CoreData/RKEntityMapping.h
+++ b/Code/CoreData/RKEntityMapping.h
@@ -20,7 +20,7 @@
 
 #import <CoreData/CoreData.h>
 #import "RKObjectMapping.h"
-#import "RKConnectionDescription.h"
+#import "RKConnectionDescriptionFactory.h"
 #import "RKMacros.h"
 
 @class RKManagedObjectStore;
@@ -122,6 +122,11 @@
 /**
  Returns the array of `RKConnectionDescripton` objects configured for connecting relationships during object mapping.
  */
+@property (nonatomic, retain) RKConnectionDescriptionFactory *connectionFactory;
+
+/**
+ Returns the array of `RKConnectionDescripton` objects configured for connecting relationships during object mapping.
+ */
 @property (nonatomic, copy, readonly) NSArray *connections;
 
 /**
@@ -155,7 +160,7 @@
  
  When the connection is attempted to be established by an instance of `RKRelationshipConnectionOperation`, the value for the 'userID' attribute will be read from the Project (in this case, @1234) and the managed object context will be searched for a managed object for the 'User' entity with a corresponding value for its 'userID' attribute.
  
- When the `connectionSpecifier` is an `NSArray` object, it is interpretted as containing the names of attributes in the specified relationship's entity. Just as with a stirng value, the corresponding destination attributes are determined by invoking the source to destination key transformation block or they are assumed to have matching names.
+ When the `connectionSpecifier` is an `NSArray` object, it is interpretted as containing the names of attributes in the specified relationship's entity. Just as with a string value, the corresponding destination attributes are determined by invoking the source to destination key transformation block or they are assumed to have matching names.
  
  When the `connectionSpecifier` is an `NSDictionary` object, the keys are interpretted as containing the names of attributes on the source entity the values are interpretted as the names of attributes on the destination entity. For example:
     

--- a/Code/CoreData/RKEntityMapping.m
+++ b/Code/CoreData/RKEntityMapping.m
@@ -162,6 +162,7 @@ static BOOL entityIdentificationInferenceEnabled = YES;
     if (self) {
         self.entity = entity;
         if ([RKEntityMapping isEntityIdentificationInferenceEnabled]) self.identificationAttributes = RKIdentificationAttributesInferredFromEntity(entity);
+        [self commonInit];
     }
 
     return self;
@@ -172,9 +173,15 @@ static BOOL entityIdentificationInferenceEnabled = YES;
     self = [super initWithClass:objectClass];
     if (self) {
         self.mutableConnections = [NSMutableArray array];
+        [self commonInit];
     }
 
     return self;
+}
+
+- (void)commonInit
+{
+    _connectionFactory = [RKConnectionDescriptionFactory sharedInstance];
 }
 
 - (id)copyWithZone:(NSZone *)zone
@@ -240,16 +247,16 @@ static BOOL entityIdentificationInferenceEnabled = YES;
     if ([connectionSpecifier isKindOfClass:[NSString class]]) {
         NSString *sourceAttribute = connectionSpecifier;
         NSString *destinationAttribute = [self transformSourceKeyPath:sourceAttribute];
-        connection = [[RKConnectionDescription alloc] initWithRelationship:relationship attributes:@{ sourceAttribute: destinationAttribute }];
+        connection = [_connectionFactory connectionWithRelationship:relationship attributes:@{ sourceAttribute: destinationAttribute }];
     } else if ([connectionSpecifier isKindOfClass:[NSArray class]]) {
         NSMutableDictionary *attributes = [NSMutableDictionary dictionaryWithCapacity:[connectionSpecifier count]];
         for (NSString *sourceAttribute in connectionSpecifier) {
             NSString *destinationAttribute = [self transformSourceKeyPath:sourceAttribute];
             [attributes setObject:destinationAttribute forKey:sourceAttribute];
         }
-        connection = [[RKConnectionDescription alloc] initWithRelationship:relationship attributes:attributes];
+        connection = [_connectionFactory connectionWithRelationship:relationship attributes:attributes];
     } else if ([connectionSpecifier isKindOfClass:[NSDictionary class]]) {
-        connection = [[RKConnectionDescription alloc] initWithRelationship:relationship attributes:connectionSpecifier];
+        connection = [_connectionFactory connectionWithRelationship:relationship attributes:connectionSpecifier];
     } else {
         [NSException raise:NSInvalidArgumentException format:@"Connections can only be described using `NSString`, `NSArray`, or `NSDictionary` objects. Instead, got: %@", connectionSpecifier];
     }

--- a/Code/CoreData/RKEntityMapping.m
+++ b/Code/CoreData/RKEntityMapping.m
@@ -19,6 +19,8 @@
 //
 
 #import "RKEntityMapping.h"
+#import "RKObjectMappingSubclass.h"
+#import "RKEntityMappingSubclass.h"
 #import "RKManagedObjectStore.h"
 #import "RKObjectMappingMatcher.h"
 #import "RKPropertyInspector+CoreData.h"
@@ -126,15 +128,6 @@ NSArray *RKIdentificationAttributesInferredFromEntity(NSEntityDescription *entit
 }
 
 static BOOL entityIdentificationInferenceEnabled = YES;
-
-@interface RKObjectMapping (Private)
-- (NSString *)transformSourceKeyPath:(NSString *)keyPath;
-@end
-
-@interface RKEntityMapping ()
-@property (nonatomic, weak, readwrite) Class objectClass;
-@property (nonatomic, strong) NSMutableArray *mutableConnections;
-@end
 
 @implementation RKEntityMapping
 

--- a/Code/CoreData/RKEntityMappingSubclass.h
+++ b/Code/CoreData/RKEntityMappingSubclass.h
@@ -1,8 +1,8 @@
 //
-//  RKObjectMappingSubclass.h
+//  RKEntityMappingSubclass.h
 //  RestKit
 //
-//  Created by Marius Rackwitz on 21.01.13.
+//  Created by Marius Rackwitz on 22.01.13.
 //  Copyright (c) 2013 RestKit. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,11 +19,11 @@
 //
 
 /**
- The extensions to the `RKObjectMapping` class declared in the `ForSubclassEyesOnly` category are to be used by subclasses implementations only. Code that uses `RKObjectMapping` objects must never call these methods.
+ The extensions to the `RKEntityMapping` class declared here are to be used by subclasses implementations only. Code that uses `RKEntityMapping` objects must never call these methods.
  */
-@interface RKObjectMapping (ForSubclassEyesOnly)
+@interface RKEntityMapping ()
 
-- (NSString *)transformSourceKeyPath:(NSString *)keyPath;
-- (void)copyPropertiesFromMapping:(RKObjectMapping *)mapping;
+@property (nonatomic, weak, readwrite) Class objectClass;
+@property (nonatomic, strong) NSMutableArray *mutableConnections;
 
 @end

--- a/Code/CoreData/RKForeignKeyConnectionDescription.h
+++ b/Code/CoreData/RKForeignKeyConnectionDescription.h
@@ -1,0 +1,46 @@
+//
+//  RKForeignKeyConnectionDescription.h
+//  RestKit
+//
+//  Created by Marius Rackwitz on 21.01.13.
+//  Copyright (c) 2013 RestKit. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "RKConnectionDescription.h"
+
+///-----------------------------------------------
+/// @name Connecting Relationships by Foreign Keys
+///-----------------------------------------------
+
+/**
+ Provides support for connecting a relationship by keeping relational backend connections synchronized
+ */
+@interface RKForeignKeyConnectionDescription : RKConnectionDescription
+
+/**
+ The dictionary of attributes specifying how attributes on the source entity for the relationship correspond to attributes on the destination entity.
+ */
+@property (nonatomic, copy, readonly) NSDictionary *attributes;
+
+/**
+ Initializes the receiver with a given relationship and a dictionary of attributes specifying how to connect the relationship.
+ 
+ @param relationship The relationship to be connected.
+ @param sourceToDestinationEntityAttributes A dictionary specifying how attributes on the source entity correspond to attributes on the destination entity.
+ @return The receiver, initialized with the given relationship and attributes.
+ */
+- (id)initWithRelationship:(NSRelationshipDescription *)relationship attributes:(NSDictionary *)attributes;
+
+@end

--- a/Code/CoreData/RKForeignKeyConnectionDescription.m
+++ b/Code/CoreData/RKForeignKeyConnectionDescription.m
@@ -1,0 +1,111 @@
+//
+//  RKForeignKeyConnectionDescription.m
+//  RestKit
+//
+//  Created by Marius Rackwitz on 21.01.13.
+//  Copyright (c) 2013 RestKit. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "RKForeignKeyConnectionDescription.h"
+#import "RKConnectionDescriptionSubclass.h"
+#import "RKLog.h"
+
+static NSSet *RKSetWithInvalidAttributesForEntity(NSArray *attributes, NSEntityDescription *entity)
+{
+    NSMutableSet *attributesSet = [NSMutableSet setWithArray:attributes];
+    NSSet *validAttributeNames = [NSSet setWithArray:[[entity attributesByName] allKeys]];
+    [attributesSet minusSet:validAttributeNames];
+    return attributesSet;
+}
+
+static BOOL RKConnectionAttributeValuesIsNotConnectable(NSDictionary *attributeValues)
+{
+    return [[NSSet setWithArray:[attributeValues allValues]] isEqualToSet:[NSSet setWithObject:[NSNull null]]];
+}
+
+@interface RKForeignKeyConnectionDescription ()
+@property (nonatomic, copy, readwrite) NSDictionary *attributes;
+@end
+
+@implementation RKForeignKeyConnectionDescription
+
+- (id)initWithRelationship:(NSRelationshipDescription *)relationship attributes:(NSDictionary *)attributes
+{
+    NSParameterAssert(relationship);
+    NSParameterAssert(attributes);
+    NSAssert([attributes count], @"Cannot connect a relationship without at least one pair of attributes describing the connection");
+    NSSet *invalidSourceAttributes = RKSetWithInvalidAttributesForEntity([attributes allKeys], [relationship entity]);
+    NSAssert([invalidSourceAttributes count] == 0, @"Cannot connect relationship: invalid attributes given for source entity '%@': %@", [[relationship entity] name], [[invalidSourceAttributes allObjects] componentsJoinedByString:@", "]);
+    NSSet *invalidDestinationAttributes = RKSetWithInvalidAttributesForEntity([attributes allValues], [relationship destinationEntity]);
+    NSAssert([invalidDestinationAttributes count] == 0, @"Cannot connect relationship: invalid attributes given for destination entity '%@': %@", [[relationship destinationEntity] name], [[invalidDestinationAttributes allObjects] componentsJoinedByString:@", "]);
+    
+    self = [[RKForeignKeyConnectionDescription alloc] init];
+    if (self) {
+        self.relationship = relationship;
+        self.attributes = attributes;
+        self.includesSubentities = YES;
+    }
+    return self;
+}
+
+- (NSDictionary *)attributeValuesWithObject:(NSManagedObject *)managedObject
+{
+    NSMutableDictionary *destinationEntityAttributeValues = [NSMutableDictionary dictionaryWithCapacity:[self.attributes count]];
+    for (NSString *sourceAttribute in self.attributes) {
+        NSString *destinationAttribute = [self.attributes objectForKey:sourceAttribute];
+        id sourceValue = [managedObject valueForKey:sourceAttribute];
+        [destinationEntityAttributeValues setValue:sourceValue ?: [NSNull null] forKey:destinationAttribute];
+    }
+    return RKConnectionAttributeValuesIsNotConnectable(destinationEntityAttributeValues) ? nil : destinationEntityAttributeValues;
+}
+
+
+- (id)findRelatedObjectFor:(NSManagedObject *)managedObject inManagedObjectCache:(id<RKManagedObjectCaching>)managedObjectCache
+{
+    NSDictionary *attributeValues = [self attributeValuesWithObject:managedObject];
+    // If there are no attribute values available for connecting, skip the connection entirely
+    if (! attributeValues) {
+        return nil;
+    }
+    NSSet *managedObjects = [managedObjectCache managedObjectsWithEntity:[self.relationship destinationEntity]
+                                                         attributeValues:attributeValues
+                                                  inManagedObjectContext:managedObject.managedObjectContext];
+    if (self.destinationPredicate) managedObjects = [managedObjects filteredSetUsingPredicate:self.destinationPredicate];
+    if (!self.includesSubentities) managedObjects = [managedObjects filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"entity == %@", [self.relationship destinationEntity]]];
+    if ([self.relationship isToMany]) {
+        return managedObjects;
+    } else {
+        if ([managedObjects count] > 1) RKLogWarning(@"Retrieved %ld objects satisfying connection criteria for one-to-one relationship connection: only object will be connected.", (long) [managedObjects count]);
+        if ([managedObjects count]) {
+            return [managedObjects anyObject];
+        }
+    }
+    
+    return nil;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@:%p connecting Relationship '%@' from Entity '%@' to Destination Entity '%@' with attributes=%@>",
+            NSStringFromClass([self class]), self, [self.relationship name], [[self.relationship entity] name],
+            [[self.relationship destinationEntity] name], self.attributes];
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return [[[self class] allocWithZone:zone] initWithRelationship:self.relationship attributes:self.attributes];
+}
+
+@end

--- a/Code/CoreData/RKKeyPathConnectionDescription.h
+++ b/Code/CoreData/RKKeyPathConnectionDescription.h
@@ -1,0 +1,46 @@
+//
+//  RKKeyPathConnectionDescription.h
+//  RestKit
+//
+//  Created by Marius Rackwitz on 21.01.13.
+//  Copyright (c) 2013 RestKit. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "RKConnectionDescription.h"
+
+///-------------------------------------------
+/// @name Connecting Relationships by Key Path
+///-------------------------------------------
+
+/**
+ Provides support for connecting a relationship by traversing the object graph
+ */
+@interface RKKeyPathConnectionDescription : RKConnectionDescription
+
+/**
+ The key path that is to be evaluated to obtain the value for the relationship.
+ */
+@property (nonatomic, copy, readonly) NSString *keyPath;
+
+/**
+ Initializes the receiver with a given relationship and key path.
+ 
+ @param relationship The relationship to be connected.
+ @param keyPath The key path from which to read the value that is to be set for the relationship.
+ @return The receiver, initialized with the given relationship and key path.
+ */
+- (id)initWithRelationship:(NSRelationshipDescription *)relationship keyPath:(NSString *)keyPath;
+
+@end

--- a/Code/CoreData/RKKeyPathConnectionDescription.m
+++ b/Code/CoreData/RKKeyPathConnectionDescription.m
@@ -1,0 +1,58 @@
+//
+//  RKKeyPathConnectionDescription.m
+//  RestKit
+//
+//  Created by Marius Rackwitz on 21.01.13.
+//  Copyright (c) 2013 RestKit. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "RKKeyPathConnectionDescription.h"
+#import "RKConnectionDescriptionSubclass.h"
+
+@interface RKKeyPathConnectionDescription ()
+@property (nonatomic, copy, readwrite) NSString *keyPath;
+@end
+
+@implementation RKKeyPathConnectionDescription
+
+- (id)initWithRelationship:(NSRelationshipDescription *)relationship keyPath:(NSString *)keyPath
+{
+    NSParameterAssert(relationship);
+    NSParameterAssert(keyPath);
+    self = [[RKKeyPathConnectionDescription alloc] init];
+    if (self) {
+        self.relationship = relationship;
+        self.keyPath = keyPath;
+    }
+    return self;
+}
+
+- (id)findRelatedObjectFor:(NSManagedObject *)managedObject inManagedObjectCache:(id<RKManagedObjectCaching>)managedObjectCache
+{
+    return [managedObject valueForKeyPath:self.keyPath];
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@:%p connecting Relationship '%@' of Entity '%@' with keyPath=%@>",
+            NSStringFromClass([self class]), self, [self.relationship name], [[self.relationship entity] name], self.keyPath];
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return [[[self class] allocWithZone:zone] initWithRelationship:self.relationship keyPath:self.keyPath];
+}
+
+@end

--- a/Code/Network/RKManagedObjectRequestOperation.h
+++ b/Code/Network/RKManagedObjectRequestOperation.h
@@ -103,7 +103,8 @@
 
  ## Limitations and Caveats
 
- @warning `RKManagedObjectRequestOperation` **does NOT** support object mapping that targets an `NSManagedObjectContext` with a `concurrencyType` of `NSConfinementConcurrencyType`.
+ 1. `RKManagedObjectRequestOperation` **does NOT** support object mapping that targets an `NSManagedObjectContext` with a `concurrencyType` of `NSConfinementConcurrencyType`.
+ 1. `RKManagedObjectRequestOperation` can become deadlocked if configured to perform mapping onto an `NSManagedObjectContext` with the `NSMainQueueConcurrencyType` and is invoked synchronously from the main thread via `start` or an attempt is made to await completion of the operation via `waitUntilFinished`. This occurs because managed object contexts with the `NSMainQueueConcurrencyType` are dependent upon the execution of the main thread's run loop to perform their work and `waitUntilFinished` blocks the calling thread, leading to a deadlock when called from the main thread. Rather than awaiting completion of the operation via `waitUntilFinishes`, consider using a completion block, key-value observation, or spinning the run-loop via `[[NSRunLoop currentRunLoop] runUntilDate:]`.
 
  @see `RKObjectRequestOperation`
  @see `RKEntityMapping`

--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -20,6 +20,7 @@
 
 #import <CoreFoundation/CoreFoundation.h>
 #import "RKObjectMapping.h"
+#import "RKObjectMappingSubclass.h"
 #import "RKRelationshipMapping.h"
 #import "RKPropertyInspector.h"
 #import "RKLog.h"
@@ -36,10 +37,6 @@ NSString * const RKObjectMappingNestingAttributeKeyName = @"<RK_NESTING_ATTRIBUT
 NSDate *RKDateFromStringWithFormatters(NSString *dateString, NSArray *formatters);
 
 static RKSourceToDesinationKeyTransformationBlock defaultSourceToDestinationKeyTransformationBlock = nil;
-
-@interface RKObjectMapping (Copying)
-- (void)copyPropertiesFromMapping:(RKObjectMapping *)mapping;
-@end
 
 @interface RKMappingInverter : NSObject
 @property (nonatomic, strong) RKObjectMapping *mapping;
@@ -68,7 +65,7 @@ static RKSourceToDesinationKeyTransformationBlock defaultSourceToDestinationKeyT
     RKObjectMapping *inverseMapping = [self.invertedMappings objectForKey:dictionaryKey];
     if (inverseMapping) return inverseMapping;
     
-    inverseMapping = [RKObjectMapping mappingForClass:[NSMutableDictionary class]];
+    inverseMapping = [self.mapping.class mappingForClass:[NSMutableDictionary class]];
     [self.invertedMappings setObject:inverseMapping forKey:dictionaryKey];
     [inverseMapping copyPropertiesFromMapping:mapping];
     

--- a/Code/ObjectMapping/RKObjectMappingSubclass.h
+++ b/Code/ObjectMapping/RKObjectMappingSubclass.h
@@ -1,0 +1,16 @@
+//
+//  RKObjectMappingSubclass.h
+//  RestKit
+//
+//  Created by Marius Rackwitz on 21.01.13.
+//  Copyright (c) 2013 RestKit. All rights reserved.
+//
+
+/*
+ The extensions to the `RKObjectMapping` class declared in the `ForSubclassEyesOnly` category are to be used by subclasses implementations only. Code that uses `RKObjectMapping` objects must never call these methods.
+ */
+@interface RKObjectMapping (ForSubclassEyesOnly)
+
+- (void)copyPropertiesFromMapping:(RKObjectMapping *)mapping;
+
+@end

--- a/Code/Testing/RKMappingTest.m
+++ b/Code/Testing/RKMappingTest.m
@@ -28,6 +28,7 @@
 
 // Core Data
 #import "RKConnectionDescription.h"
+#import "RKForeignKeyConnectionDescription.h"
 #import "RKConnectionTestExpectation.h"
 #import "RKFetchRequestManagedObjectCache.h"
 #import "RKManagedObjectMappingOperationDataSource.h"
@@ -97,12 +98,12 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
         return [NSString stringWithFormat:@"%@ mapped sourceKeyPath '%@' => destinationKeyPath '%@' with value: %@>", [self class],
                 self.sourceKeyPath, self.destinationKeyPath, self.value];
     } else if (self.connection) {
-        if ([self.connection isForeignKeyConnection]) {
+        if ([self.connection isKindOfClass:[RKForeignKeyConnectionDescription class]]) {
             return [NSString stringWithFormat:@"%@ connected Relationship '%@' using attributes '%@' to value: %@>", [self class],
-                    [self.connection.relationship name], [self.connection.attributes valueForKey:@"name"], self.value];
-        } else if ([self.connection isKeyPathConnection]) {
+                    [self.connection.relationship name], [((RKForeignKeyConnectionDescription *)self.connection).attributes valueForKey:@"name"], self.value];
+        } else if ([self.connection isKindOfClass:[RKKeyPathConnectionDescription class]]) {
             return [NSString stringWithFormat:@"%@ connected Relationship '%@' using keyPath '%@' to value: %@>", [self class],
-                    [self.connection.relationship name], self.connection.keyPath, self.value];
+                    [self.connection.relationship name], ((RKKeyPathConnectionDescription *)self.connection).keyPath, self.value];
         }
     }
     
@@ -287,7 +288,8 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
         
         // Check that the connection attributes match
         if (connectionExpectation.attributes) {
-            RKMappingTestCondition([connectionExpectation.attributes isEqualToDictionary:event.connection.attributes], RKMappingTestValueInequalityError, error, @"established connection using unexpected attributes: %@", event.connection.attributes);
+            NSDictionary* attributes = ((RKForeignKeyConnectionDescription *)event.connection).attributes;
+            RKMappingTestCondition([connectionExpectation.attributes isEqualToDictionary:attributes], RKMappingTestValueInequalityError, error, @"established connection using unexpected attributes: %@", attributes);
         }
     
         // Wrong objects

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -571,6 +571,15 @@
 		5C927E151608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C927E131608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m */; };
 		5CCC295615B7124A0045F0F5 /* RKMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CCC295515B7124A0045F0F5 /* RKMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5CCC295715B7124A0045F0F5 /* RKMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CCC295515B7124A0045F0F5 /* RKMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		712B4F8216ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8016ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h */; };
+		712B4F8316ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 712B4F8116ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m */; };
+		71C59B8D16ADC67200A61565 /* RKForeignKeyConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B8B16ADC67100A61565 /* RKForeignKeyConnectionDescription.h */; };
+		71C59B8E16ADC67200A61565 /* RKForeignKeyConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C59B8C16ADC67100A61565 /* RKForeignKeyConnectionDescription.m */; };
+		71C59B8F16ADC67B00A61565 /* RKForeignKeyConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B8B16ADC67100A61565 /* RKForeignKeyConnectionDescription.h */; };
+		71C59B9216ADC6A600A61565 /* RKKeyPathConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B9016ADC6A400A61565 /* RKKeyPathConnectionDescription.h */; };
+		71C59B9316ADC6A600A61565 /* RKKeyPathConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B9016ADC6A400A61565 /* RKKeyPathConnectionDescription.h */; };
+		71C59B9416ADC6A600A61565 /* RKKeyPathConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C59B9116ADC6A500A61565 /* RKKeyPathConnectionDescription.m */; };
+		71C59B9516ADC6A600A61565 /* RKKeyPathConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C59B9116ADC6A500A61565 /* RKKeyPathConnectionDescription.m */; };
 		73D3907414CA1AE00093E3D6 /* parent.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907114CA19F90093E3D6 /* parent.json */; };
 		73D3907514CA1AE20093E3D6 /* parent.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907114CA19F90093E3D6 /* parent.json */; };
 		73D3907614CA1AE60093E3D6 /* child.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907314CA1A4A0093E3D6 /* child.json */; };
@@ -937,6 +946,14 @@
 		41A4EBF715374D1800740BC8 /* redirection.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = redirection.rb; sourceTree = "<group>"; };
 		5C927E131608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKDictionaryUtilitiesTest.m; sourceTree = "<group>"; };
 		5CCC295515B7124A0045F0F5 /* RKMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMacros.h; sourceTree = "<group>"; };
+		712B4F8016ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKConnectionDescriptionFactory.h; sourceTree = "<group>"; };
+		712B4F8116ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKConnectionDescriptionFactory.m; sourceTree = "<group>"; };
+		712B4F8516ADCD6000F7ED03 /* RKObjectMappingSubclass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RKObjectMappingSubclass.h; sourceTree = "<group>"; };
+		71C59B8B16ADC67100A61565 /* RKForeignKeyConnectionDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKForeignKeyConnectionDescription.h; sourceTree = "<group>"; };
+		71C59B8C16ADC67100A61565 /* RKForeignKeyConnectionDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKForeignKeyConnectionDescription.m; sourceTree = "<group>"; };
+		71C59B9016ADC6A400A61565 /* RKKeyPathConnectionDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKKeyPathConnectionDescription.h; sourceTree = "<group>"; };
+		71C59B9116ADC6A500A61565 /* RKKeyPathConnectionDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKKeyPathConnectionDescription.m; sourceTree = "<group>"; };
+		71C59B9616ADC71800A61565 /* RKConnectionDescriptionSubclass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RKConnectionDescriptionSubclass.h; sourceTree = "<group>"; };
 		7394DF3514CF157A00CE7BCE /* RKManagedObjectCaching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKManagedObjectCaching.h; sourceTree = "<group>"; };
 		7394DF3814CF168C00CE7BCE /* RKFetchRequestManagedObjectCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKFetchRequestManagedObjectCache.h; sourceTree = "<group>"; };
 		7394DF3914CF168C00CE7BCE /* RKFetchRequestManagedObjectCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKFetchRequestManagedObjectCache.m; sourceTree = "<group>"; };
@@ -1164,6 +1181,7 @@
 				25160D8B145650490060A5C5 /* RKMapperOperation_Private.h */,
 				25160D8D145650490060A5C5 /* RKObjectMapping.h */,
 				25160D8E145650490060A5C5 /* RKObjectMapping.m */,
+				712B4F8516ADCD6000F7ED03 /* RKObjectMappingSubclass.h */,
 				25160D8F145650490060A5C5 /* RKMapping.h */,
 				25CA7A8E14EC570100888FF8 /* RKMapping.m */,
 				25160D90145650490060A5C5 /* RKMappingOperation.h */,
@@ -1621,6 +1639,22 @@
 			path = PLISTs;
 			sourceTree = "<group>";
 		};
+		71C59B8916ADC63D00A61565 /* ConnectionDescription */ = {
+			isa = PBXGroup;
+			children = (
+				712B4F8016ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h */,
+				712B4F8116ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m */,
+				25E88C86165C5CC30042ABD0 /* RKConnectionDescription.h */,
+				25E88C87165C5CC30042ABD0 /* RKConnectionDescription.m */,
+				71C59B9616ADC71800A61565 /* RKConnectionDescriptionSubclass.h */,
+				71C59B8B16ADC67100A61565 /* RKForeignKeyConnectionDescription.h */,
+				71C59B8C16ADC67100A61565 /* RKForeignKeyConnectionDescription.m */,
+				71C59B9016ADC6A400A61565 /* RKKeyPathConnectionDescription.h */,
+				71C59B9116ADC6A500A61565 /* RKKeyPathConnectionDescription.m */,
+			);
+			name = ConnectionDescription;
+			sourceTree = "<group>";
+		};
 		E4081DFC15FB89DF00364948 /* ManagedObjectCaching */ = {
 			isa = PBXGroup;
 			children = (
@@ -1689,12 +1723,11 @@
 		E4081E0915FB8FD800364948 /* Mapping */ = {
 			isa = PBXGroup;
 			children = (
+				71C59B8916ADC63D00A61565 /* ConnectionDescription */,
 				25160D4C145650490060A5C5 /* RKEntityMapping.h */,
 				25160D4D145650490060A5C5 /* RKEntityMapping.m */,
 				258EA4B015A3908F007E07A6 /* RKManagedObjectMappingOperationDataSource.h */,
 				25AA23CF15AF291F006EF62D /* RKManagedObjectMappingOperationDataSource.m */,
-				25E88C86165C5CC30042ABD0 /* RKConnectionDescription.h */,
-				25E88C87165C5CC30042ABD0 /* RKConnectionDescription.m */,
 			);
 			name = Mapping;
 			sourceTree = "<group>";
@@ -1803,6 +1836,9 @@
 				25E88C88165C5CC30042ABD0 /* RKConnectionDescription.h in Headers */,
 				25019495166406E30081D68A /* RKValueTransformers.h in Headers */,
 				25A8C2341673BD480014D9A6 /* RKConnectionTestExpectation.h in Headers */,
+				71C59B8D16ADC67200A61565 /* RKForeignKeyConnectionDescription.h in Headers */,
+				71C59B9216ADC6A600A61565 /* RKKeyPathConnectionDescription.h in Headers */,
+				712B4F8216ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1907,6 +1943,8 @@
 				255893E4166BA7400010C70B /* RestKit-Prefix.pch in Headers */,
 				255893E5166BA7700010C70B /* RKTestFixture.h in Headers */,
 				25A8C2351673BD480014D9A6 /* RKConnectionTestExpectation.h in Headers */,
+				71C59B8F16ADC67B00A61565 /* RKForeignKeyConnectionDescription.h in Headers */,
+				71C59B9316ADC6A600A61565 /* RKKeyPathConnectionDescription.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2261,6 +2299,9 @@
 				25019497166406E30081D68A /* RKValueTransformers.m in Sources */,
 				25A8C2361673BD480014D9A6 /* RKConnectionTestExpectation.m in Sources */,
 				258BEA02168D058300C74C8C /* RKObjectMappingMatcher.m in Sources */,
+				71C59B8E16ADC67200A61565 /* RKForeignKeyConnectionDescription.m in Sources */,
+				71C59B9416ADC6A600A61565 /* RKKeyPathConnectionDescription.m in Sources */,
+				712B4F8316ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2413,6 +2454,7 @@
 				25019498166406E30081D68A /* RKValueTransformers.m in Sources */,
 				25A8C2371673BD480014D9A6 /* RKConnectionTestExpectation.m in Sources */,
 				258BEA03168D058300C74C8C /* RKObjectMappingMatcher.m in Sources */,
+				71C59B9516ADC6A600A61565 /* RKKeyPathConnectionDescription.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -571,21 +571,21 @@
 		5C927E151608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C927E131608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m */; };
 		5CCC295615B7124A0045F0F5 /* RKMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CCC295515B7124A0045F0F5 /* RKMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5CCC295715B7124A0045F0F5 /* RKMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CCC295515B7124A0045F0F5 /* RKMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		712B4F8216ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8016ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h */; };
+		712B4F8216ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8016ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		712B4F8316ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 712B4F8116ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m */; };
 		712B509716AEE65500F7ED03 /* RKConnectionDescriptionSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B9616ADC71800A61565 /* RKConnectionDescriptionSubclass.h */; };
-		712B509916AEE65600F7ED03 /* RKConnectionDescriptionSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B9616ADC71800A61565 /* RKConnectionDescriptionSubclass.h */; };
+		712B509916AEE65600F7ED03 /* RKConnectionDescriptionSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B9616ADC71800A61565 /* RKConnectionDescriptionSubclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		712B509A16AEE65F00F7ED03 /* RKConnectionDescriptionFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8016ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h */; };
 		712B509B16AEE66A00F7ED03 /* RKConnectionDescriptionFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 712B4F8116ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m */; };
 		712B509C16AEE67700F7ED03 /* RKForeignKeyConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C59B8C16ADC67100A61565 /* RKForeignKeyConnectionDescription.m */; };
-		712B509D16AEE68000F7ED03 /* RKEntityMappingSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B505516AEDA7100F7ED03 /* RKEntityMappingSubclass.h */; };
+		712B509D16AEE68000F7ED03 /* RKEntityMappingSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B505516AEDA7100F7ED03 /* RKEntityMappingSubclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		712B509E16AEE68100F7ED03 /* RKEntityMappingSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B505516AEDA7100F7ED03 /* RKEntityMappingSubclass.h */; };
 		712B509F16AEE69500F7ED03 /* RKObjectMappingSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8516ADCD6000F7ED03 /* RKObjectMappingSubclass.h */; };
-		712B50A016AEE69600F7ED03 /* RKObjectMappingSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8516ADCD6000F7ED03 /* RKObjectMappingSubclass.h */; };
-		71C59B8D16ADC67200A61565 /* RKForeignKeyConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B8B16ADC67100A61565 /* RKForeignKeyConnectionDescription.h */; };
+		712B50A016AEE69600F7ED03 /* RKObjectMappingSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8516ADCD6000F7ED03 /* RKObjectMappingSubclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		71C59B8D16ADC67200A61565 /* RKForeignKeyConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B8B16ADC67100A61565 /* RKForeignKeyConnectionDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		71C59B8E16ADC67200A61565 /* RKForeignKeyConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C59B8C16ADC67100A61565 /* RKForeignKeyConnectionDescription.m */; };
 		71C59B8F16ADC67B00A61565 /* RKForeignKeyConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B8B16ADC67100A61565 /* RKForeignKeyConnectionDescription.h */; };
-		71C59B9216ADC6A600A61565 /* RKKeyPathConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B9016ADC6A400A61565 /* RKKeyPathConnectionDescription.h */; };
+		71C59B9216ADC6A600A61565 /* RKKeyPathConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B9016ADC6A400A61565 /* RKKeyPathConnectionDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		71C59B9316ADC6A600A61565 /* RKKeyPathConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B9016ADC6A400A61565 /* RKKeyPathConnectionDescription.h */; };
 		71C59B9416ADC6A600A61565 /* RKKeyPathConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C59B9116ADC6A500A61565 /* RKKeyPathConnectionDescription.m */; };
 		71C59B9516ADC6A600A61565 /* RKKeyPathConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C59B9116ADC6A500A61565 /* RKKeyPathConnectionDescription.m */; };
@@ -1844,15 +1844,15 @@
 				25A226D61618A57500952D72 /* RKObjectUtilities.h in Headers */,
 				2507C327161BD5C700EA71FF /* RKTestHelpers.h in Headers */,
 				25CDA0DC161E7ED400F583F3 /* RKISO8601DateFormatter.h in Headers */,
-				25E88C88165C5CC30042ABD0 /* RKConnectionDescription.h in Headers */,
-				25019495166406E30081D68A /* RKValueTransformers.h in Headers */,
-				25A8C2341673BD480014D9A6 /* RKConnectionTestExpectation.h in Headers */,
 				71C59B8D16ADC67200A61565 /* RKForeignKeyConnectionDescription.h in Headers */,
 				71C59B9216ADC6A600A61565 /* RKKeyPathConnectionDescription.h in Headers */,
 				712B4F8216ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h in Headers */,
 				712B509916AEE65600F7ED03 /* RKConnectionDescriptionSubclass.h in Headers */,
 				712B509D16AEE68000F7ED03 /* RKEntityMappingSubclass.h in Headers */,
 				712B50A016AEE69600F7ED03 /* RKObjectMappingSubclass.h in Headers */,
+				25E88C88165C5CC30042ABD0 /* RKConnectionDescription.h in Headers */,
+				25019495166406E30081D68A /* RKValueTransformers.h in Headers */,
+				25A8C2341673BD480014D9A6 /* RKConnectionTestExpectation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -573,6 +573,15 @@
 		5CCC295715B7124A0045F0F5 /* RKMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CCC295515B7124A0045F0F5 /* RKMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		712B4F8216ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8016ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h */; };
 		712B4F8316ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 712B4F8116ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m */; };
+		712B509716AEE65500F7ED03 /* RKConnectionDescriptionSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B9616ADC71800A61565 /* RKConnectionDescriptionSubclass.h */; };
+		712B509916AEE65600F7ED03 /* RKConnectionDescriptionSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B9616ADC71800A61565 /* RKConnectionDescriptionSubclass.h */; };
+		712B509A16AEE65F00F7ED03 /* RKConnectionDescriptionFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8016ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h */; };
+		712B509B16AEE66A00F7ED03 /* RKConnectionDescriptionFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 712B4F8116ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m */; };
+		712B509C16AEE67700F7ED03 /* RKForeignKeyConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C59B8C16ADC67100A61565 /* RKForeignKeyConnectionDescription.m */; };
+		712B509D16AEE68000F7ED03 /* RKEntityMappingSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B505516AEDA7100F7ED03 /* RKEntityMappingSubclass.h */; };
+		712B509E16AEE68100F7ED03 /* RKEntityMappingSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B505516AEDA7100F7ED03 /* RKEntityMappingSubclass.h */; };
+		712B509F16AEE69500F7ED03 /* RKObjectMappingSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8516ADCD6000F7ED03 /* RKObjectMappingSubclass.h */; };
+		712B50A016AEE69600F7ED03 /* RKObjectMappingSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 712B4F8516ADCD6000F7ED03 /* RKObjectMappingSubclass.h */; };
 		71C59B8D16ADC67200A61565 /* RKForeignKeyConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B8B16ADC67100A61565 /* RKForeignKeyConnectionDescription.h */; };
 		71C59B8E16ADC67200A61565 /* RKForeignKeyConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C59B8C16ADC67100A61565 /* RKForeignKeyConnectionDescription.m */; };
 		71C59B8F16ADC67B00A61565 /* RKForeignKeyConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C59B8B16ADC67100A61565 /* RKForeignKeyConnectionDescription.h */; };
@@ -949,6 +958,7 @@
 		712B4F8016ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKConnectionDescriptionFactory.h; sourceTree = "<group>"; };
 		712B4F8116ADCBB800F7ED03 /* RKConnectionDescriptionFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKConnectionDescriptionFactory.m; sourceTree = "<group>"; };
 		712B4F8516ADCD6000F7ED03 /* RKObjectMappingSubclass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RKObjectMappingSubclass.h; sourceTree = "<group>"; };
+		712B505516AEDA7100F7ED03 /* RKEntityMappingSubclass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RKEntityMappingSubclass.h; sourceTree = "<group>"; };
 		71C59B8B16ADC67100A61565 /* RKForeignKeyConnectionDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKForeignKeyConnectionDescription.h; sourceTree = "<group>"; };
 		71C59B8C16ADC67100A61565 /* RKForeignKeyConnectionDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKForeignKeyConnectionDescription.m; sourceTree = "<group>"; };
 		71C59B9016ADC6A400A61565 /* RKKeyPathConnectionDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKKeyPathConnectionDescription.h; sourceTree = "<group>"; };
@@ -1726,6 +1736,7 @@
 				71C59B8916ADC63D00A61565 /* ConnectionDescription */,
 				25160D4C145650490060A5C5 /* RKEntityMapping.h */,
 				25160D4D145650490060A5C5 /* RKEntityMapping.m */,
+				712B505516AEDA7100F7ED03 /* RKEntityMappingSubclass.h */,
 				258EA4B015A3908F007E07A6 /* RKManagedObjectMappingOperationDataSource.h */,
 				25AA23CF15AF291F006EF62D /* RKManagedObjectMappingOperationDataSource.m */,
 			);
@@ -1839,6 +1850,9 @@
 				71C59B8D16ADC67200A61565 /* RKForeignKeyConnectionDescription.h in Headers */,
 				71C59B9216ADC6A600A61565 /* RKKeyPathConnectionDescription.h in Headers */,
 				712B4F8216ADCBB800F7ED03 /* RKConnectionDescriptionFactory.h in Headers */,
+				712B509916AEE65600F7ED03 /* RKConnectionDescriptionSubclass.h in Headers */,
+				712B509D16AEE68000F7ED03 /* RKEntityMappingSubclass.h in Headers */,
+				712B50A016AEE69600F7ED03 /* RKObjectMappingSubclass.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1945,6 +1959,10 @@
 				25A8C2351673BD480014D9A6 /* RKConnectionTestExpectation.h in Headers */,
 				71C59B8F16ADC67B00A61565 /* RKForeignKeyConnectionDescription.h in Headers */,
 				71C59B9316ADC6A600A61565 /* RKKeyPathConnectionDescription.h in Headers */,
+				712B509716AEE65500F7ED03 /* RKConnectionDescriptionSubclass.h in Headers */,
+				712B509A16AEE65F00F7ED03 /* RKConnectionDescriptionFactory.h in Headers */,
+				712B509E16AEE68100F7ED03 /* RKEntityMappingSubclass.h in Headers */,
+				712B509F16AEE69500F7ED03 /* RKObjectMappingSubclass.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2455,6 +2473,8 @@
 				25A8C2371673BD480014D9A6 /* RKConnectionTestExpectation.m in Sources */,
 				258BEA03168D058300C74C8C /* RKObjectMappingMatcher.m in Sources */,
 				71C59B9516ADC6A600A61565 /* RKKeyPathConnectionDescription.m in Sources */,
+				712B509B16AEE66A00F7ED03 /* RKConnectionDescriptionFactory.m in Sources */,
+				712B509C16AEE67700F7ED03 /* RKForeignKeyConnectionDescription.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Logic/CoreData/RKConnectionDescriptionTest.m
+++ b/Tests/Logic/CoreData/RKConnectionDescriptionTest.m
@@ -30,27 +30,27 @@
 
 - (void)testInitWithNilRelationshipRaisesError
 {
-    expect(^{ RKConnectionDescription __unused *connection = [[RKConnectionDescription alloc] initWithRelationship:nil attributes:@{ @"catID": @"catID" }]; }).to.raiseWithReason(NSInternalInconsistencyException, @"Invalid parameter not satisfying: relationship");
+    expect(^{ RKConnectionDescription __unused *connection = [[RKForeignKeyConnectionDescription alloc] initWithRelationship:nil attributes:@{ @"catID": @"catID" }]; }).to.raiseWithReason(NSInternalInconsistencyException, @"Invalid parameter not satisfying: relationship");
 }
 
 - (void)testInitWithNilAttributesRaisesError
 {
-    expect(^{ RKConnectionDescription __unused *connection = [[RKConnectionDescription alloc] initWithRelationship:self.relationship attributes:nil]; }).to.raiseWithReason(NSInternalInconsistencyException, @"Invalid parameter not satisfying: attributes");
+    expect(^{ RKConnectionDescription __unused *connection = [[RKForeignKeyConnectionDescription alloc] initWithRelationship:self.relationship attributes:nil]; }).to.raiseWithReason(NSInternalInconsistencyException, @"Invalid parameter not satisfying: attributes");
 }
 
 - (void)testInitWithEmptyAttributesDictionaryRaisesError
 {
-    expect(^{ RKConnectionDescription __unused *connection = [[RKConnectionDescription alloc] initWithRelationship:self.relationship attributes:@{}]; }).to.raiseWithReason(NSInternalInconsistencyException, @"Cannot connect a relationship without at least one pair of attributes describing the connection");
+    expect(^{ RKConnectionDescription __unused *connection = [[RKForeignKeyConnectionDescription alloc] initWithRelationship:self.relationship attributes:@{}]; }).to.raiseWithReason(NSInternalInconsistencyException, @"Cannot connect a relationship without at least one pair of attributes describing the connection");
 }
 
 - (void)testInitWithAttributeThatDoesNotExistInEntityRaisesError
 {
-    expect(^{ RKConnectionDescription __unused *connection = [[RKConnectionDescription alloc] initWithRelationship:self.relationship attributes:@{ @"invalidID": @"catID" }]; }).to.raiseWithReason(NSInternalInconsistencyException, @"Cannot connect relationship: invalid attributes given for source entity 'Human': invalidID");
+    expect(^{ RKConnectionDescription __unused *connection = [[RKForeignKeyConnectionDescription alloc] initWithRelationship:self.relationship attributes:@{ @"invalidID": @"catID" }]; }).to.raiseWithReason(NSInternalInconsistencyException, @"Cannot connect relationship: invalid attributes given for source entity 'Human': invalidID");
 }
 
 - (void)testInitWithAttributeThatDoesNotExistInDestinationEntityRaisesError
 {
-    expect(^{ RKConnectionDescription __unused *connection = [[RKConnectionDescription alloc] initWithRelationship:self.relationship attributes:@{ @"favoriteCatID": @"invalid" }]; }).to.raiseWithReason(NSInternalInconsistencyException, @"Cannot connect relationship: invalid attributes given for destination entity 'Cat': invalid");
+    expect(^{ RKConnectionDescription __unused *connection = [[RKForeignKeyConnectionDescription alloc] initWithRelationship:self.relationship attributes:@{ @"favoriteCatID": @"invalid" }]; }).to.raiseWithReason(NSInternalInconsistencyException, @"Cannot connect relationship: invalid attributes given for destination entity 'Cat': invalid");
 }
 
 @end

--- a/Tests/Logic/CoreData/RKEntityMappingTest.m
+++ b/Tests/Logic/CoreData/RKEntityMappingTest.m
@@ -232,7 +232,7 @@
     RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
     RKEntityMapping *humanEntityMapping = [RKEntityMapping mappingForEntityForName:@"Human" inManagedObjectStore:managedObjectStore];
     [humanEntityMapping addConnectionForRelationship:@"favoriteCat" connectedBy:@"favoriteCatID"];
-    RKConnectionDescription *connection = [humanEntityMapping connectionForRelationship:@"favoriteCat"];
+    RKForeignKeyConnectionDescription *connection = (RKForeignKeyConnectionDescription *)[humanEntityMapping connectionForRelationship:@"favoriteCat"];
     NSDictionary *expectedAttributes = @{ @"favoriteCatID": @"favoriteCatID" };
     expect(connection.attributes).to.equal(expectedAttributes);
 }
@@ -245,7 +245,7 @@
         return @"age";
     }];
     [humanEntityMapping addConnectionForRelationship:@"favoriteCat" connectedBy:@"favoriteCatID"];
-    RKConnectionDescription *connection = [humanEntityMapping connectionForRelationship:@"favoriteCat"];
+    RKForeignKeyConnectionDescription *connection = (RKForeignKeyConnectionDescription *)[humanEntityMapping connectionForRelationship:@"favoriteCat"];
     NSDictionary *expectedAttributes = @{ @"favoriteCatID": @"age" };
     expect(connection.attributes).to.equal(expectedAttributes);
 }
@@ -255,7 +255,7 @@
     RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
     RKEntityMapping *humanEntityMapping = [RKEntityMapping mappingForEntityForName:@"Human" inManagedObjectStore:managedObjectStore];
     [humanEntityMapping addConnectionForRelationship:@"cats" connectedBy:@[ @"railsID", @"name" ]];
-    RKConnectionDescription *connection = [humanEntityMapping connectionForRelationship:@"cats"];
+    RKForeignKeyConnectionDescription *connection = (RKForeignKeyConnectionDescription *)[humanEntityMapping connectionForRelationship:@"cats"];
     NSDictionary *expectedAttributes = @{ @"railsID": @"railsID", @"name": @"name" };
     expect(connection.attributes).to.equal(expectedAttributes);
 }
@@ -270,7 +270,7 @@
         else return sourceKey;
     }];
     [humanEntityMapping addConnectionForRelationship:@"cats" connectedBy:@[ @"railsID", @"name" ]];
-    RKConnectionDescription *connection = [humanEntityMapping connectionForRelationship:@"cats"];
+    RKForeignKeyConnectionDescription *connection = (RKForeignKeyConnectionDescription *)[humanEntityMapping connectionForRelationship:@"cats"];
     NSDictionary *expectedAttributes = @{ @"railsID": @"age", @"name": @"color" };
     expect(connection.attributes).to.equal(expectedAttributes);
 }
@@ -280,7 +280,7 @@
     RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
     RKEntityMapping *humanEntityMapping = [RKEntityMapping mappingForEntityForName:@"Human" inManagedObjectStore:managedObjectStore];
     [humanEntityMapping addConnectionForRelationship:@"cats" connectedBy:@{ @"railsID": @"railsID", @"name": @"name" }];
-    RKConnectionDescription *connection = [humanEntityMapping connectionForRelationship:@"cats"];
+    RKForeignKeyConnectionDescription *connection = (RKForeignKeyConnectionDescription *)[humanEntityMapping connectionForRelationship:@"cats"];
     NSDictionary *expectedAttributes = @{ @"railsID": @"railsID", @"name": @"name" };
     expect(connection.attributes).to.equal(expectedAttributes);
 }

--- a/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
@@ -290,7 +290,7 @@
     RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
     NSEntityDescription *entity = [NSEntityDescription entityForName:@"Human" inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
     RKEntityMapping *mapping = [[RKEntityMapping alloc] initWithEntity:entity];
-    RKConnectionDescription *connection = [[RKConnectionDescription alloc] initWithRelationship:entity.relationshipsByName[@"favoriteCat"] attributes:@{ @"railsID": @"railsID" }];
+    RKConnectionDescription *connection = [[RKForeignKeyConnectionDescription alloc] initWithRelationship:entity.relationshipsByName[@"favoriteCat"] attributes:@{ @"railsID": @"railsID" }];
     [mapping addConnection:connection];
     
     RKManagedObjectMappingOperationDataSource *dataSource = [[RKManagedObjectMappingOperationDataSource alloc] initWithManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext

--- a/Tests/Logic/CoreData/RKRelationshipConnectionOperationTest.m
+++ b/Tests/Logic/CoreData/RKRelationshipConnectionOperationTest.m
@@ -97,7 +97,7 @@
 {
     NSEntityDescription *entity = [[[RKTestFactory managedObjectStore] managedObjectModel] entitiesByName][@"Human"];
     NSRelationshipDescription *relationship = [entity relationshipsByName][@"landlord"];
-    RKConnectionDescription *connection = [[RKConnectionDescription alloc] initWithRelationship:relationship keyPath:@"residence.owner"];
+    RKConnectionDescription *connection = [[RKKeyPathConnectionDescription alloc] initWithRelationship:relationship keyPath:@"residence.owner"];
 
     RKHuman *tenant = [RKTestFactory insertManagedObjectForEntityForName:@"Human" inManagedObjectContext:nil withProperties:nil];
     RKHuman *homeowner = [RKTestFactory insertManagedObjectForEntityForName:@"Human" inManagedObjectContext:nil withProperties:nil];
@@ -116,7 +116,7 @@
 {
     NSEntityDescription *entity = [[[RKTestFactory managedObjectStore] managedObjectModel] entitiesByName][@"Human"];
     NSRelationshipDescription *relationship = [entity relationshipsByName][@"roommates"];
-    RKConnectionDescription *connection = [[RKConnectionDescription alloc] initWithRelationship:relationship keyPath:@"house.residents"];
+    RKConnectionDescription *connection = [[RKKeyPathConnectionDescription alloc] initWithRelationship:relationship keyPath:@"house.residents"];
 
     RKHuman *human = [RKTestFactory insertManagedObjectForEntityForName:@"Human" inManagedObjectContext:nil withProperties:nil];
     RKHouse *house = [RKTestFactory insertManagedObjectForEntityForName:@"House" inManagedObjectContext:nil withProperties:nil];
@@ -138,7 +138,7 @@
 {
     NSEntityDescription *entity = [[[RKTestFactory managedObjectStore] managedObjectModel] entitiesByName][@"Human"];
     NSRelationshipDescription *relationship = [entity relationshipsByName][@"friends"];
-    RKConnectionDescription *connection = [[RKConnectionDescription alloc] initWithRelationship:relationship keyPath:@"housesResidedAt.ownersInChronologicalOrder"];
+    RKConnectionDescription *connection = [[RKKeyPathConnectionDescription alloc] initWithRelationship:relationship keyPath:@"housesResidedAt.ownersInChronologicalOrder"];
 
     RKHuman *human = [RKTestFactory insertManagedObjectForEntityForName:@"Human" inManagedObjectContext:nil withProperties:nil];
 
@@ -168,7 +168,7 @@
 {
     NSEntityDescription *entity = [[[RKTestFactory managedObjectStore] managedObjectModel] entitiesByName][@"Human"];
     NSRelationshipDescription *relationship = [entity relationshipsByName][@"friendsInTheOrderWeMet"];
-    RKConnectionDescription *connection = [[RKConnectionDescription alloc] initWithRelationship:relationship keyPath:@"housesResidedAt.ownersInChronologicalOrder"];
+    RKConnectionDescription *connection = [[RKKeyPathConnectionDescription alloc] initWithRelationship:relationship keyPath:@"housesResidedAt.ownersInChronologicalOrder"];
 
     RKHuman *human = [RKTestFactory insertManagedObjectForEntityForName:@"Human" inManagedObjectContext:nil withProperties:nil];
 
@@ -197,7 +197,7 @@
 {
     NSEntityDescription *entity = [[[RKTestFactory managedObjectStore] managedObjectModel] entitiesByName][@"Human"];
     NSRelationshipDescription *relationship = [entity relationshipsByName][@"friendsInTheOrderWeMet"];
-    RKConnectionDescription *connection = [[RKConnectionDescription alloc] initWithRelationship:relationship keyPath:@"housesResidedAt.ownersInChronologicalOrder"];
+    RKConnectionDescription *connection = [[RKKeyPathConnectionDescription alloc] initWithRelationship:relationship keyPath:@"housesResidedAt.ownersInChronologicalOrder"];
 
     RKHuman *human = [RKTestFactory insertManagedObjectForEntityForName:@"Human" inManagedObjectContext:nil withProperties:nil];
 
@@ -213,7 +213,7 @@
     RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
     NSEntityDescription *childEntity = [NSEntityDescription entityForName:@"Child" inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
     NSRelationshipDescription *relationship = [childEntity relationshipsByName][@"friends"];
-    RKConnectionDescription *connection = [[RKConnectionDescription alloc] initWithRelationship:relationship attributes:@{ @"friendIDs": @"railsID" }];
+    RKConnectionDescription *connection = [[RKForeignKeyConnectionDescription alloc] initWithRelationship:relationship attributes:@{ @"friendIDs": @"railsID" }];
     connection.includesSubentities = YES;
 
     RKHuman *human = [RKTestFactory insertManagedObjectForEntityForName:@"Human" inManagedObjectContext:nil withProperties:nil];
@@ -237,7 +237,7 @@
     RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
     NSEntityDescription *childEntity = [NSEntityDescription entityForName:@"Child" inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
     NSRelationshipDescription *relationship = [childEntity relationshipsByName][@"friends"];
-    RKConnectionDescription *connection = [[RKConnectionDescription alloc] initWithRelationship:relationship attributes:@{ @"friendIDs": @"railsID" }];
+    RKConnectionDescription *connection = [[RKForeignKeyConnectionDescription alloc] initWithRelationship:relationship attributes:@{ @"friendIDs": @"railsID" }];
     connection.includesSubentities = NO;
 
     RKHuman *human = [RKTestFactory insertManagedObjectForEntityForName:@"Human" inManagedObjectContext:nil withProperties:nil];


### PR DESCRIPTION
Removed type getter `isForeignKeyConnection` / `isKeyPathConnection` and make internal used subclasses public. So it is possible to create own connections with custom behavior.

I want to build an eager RKRemoteForeignKeyConnectionDescription, which has a relationship route to full-automatic request related objects by their foreign keys if they are not found in local store. What do you mean, do you feel comfortable about this way?