### PR TITLE
Unescape URL metadata mapping parameters if route required parameter escaping

### DIFF
--- a/Code/Support/RKPathMatcher.m
+++ b/Code/Support/RKPathMatcher.m
@@ -140,7 +140,13 @@ static NSString *RKEncodeURLString(NSString *unencodedString)
     }
     NSString *path = [self.socPattern stringFromObject:object withBlock:encoderBlock];
     if (interpolatedParameters) {
-        *interpolatedParameters = [self.socPattern parameterDictionaryFromSourceString:path];
+        NSMutableDictionary *parsedParameters = [self.socPattern parameterDictionaryFromSourceString:path].mutableCopy;
+        if (addEscapes) {
+            for (NSString *key in parsedParameters.allKeys) {
+                parsedParameters[key] = [parsedParameters[key] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+            }
+        }
+        *interpolatedParameters = parsedParameters;
     }
     return path;
 }


### PR DESCRIPTION
URL metadata mapping parameters should be unescaped before mapped to the target object. If you use a route with required url escaping for the path pattern, the parsed metadata  parameters contain the escaped values.
