### PR TITLE
The relationship variables are missing.

### DIFF
--- a/Code/CoreData/RKConnectionDescription.h
+++ b/Code/CoreData/RKConnectionDescription.h
@@ -62,7 +62,7 @@
  
      NSEntityDescription *projectEntity = [NSEntityDescription entityForName:@"Project" inManagedObjectContext:managedObjectContext];
      NSRelationshipDescription *teamMembers = [projectEntity relationshipsByName][@"teamMembers"]; // To many relationship for the `User` entity
-     RKConnectionDescription *connection = [[RKConnectionDescription alloc] initWithRelationship:relationship attributes:@{ @"teamMemberIDs": @"userID" }];
+     RKConnectionDescription *connection = [[RKConnectionDescription alloc] initWithRelationship:teamMembers attributes:@{ @"teamMemberIDs": @"userID" }];
  
  When evaluating the above JSON, the connection would be established for the 'teamMembers' relationship to the `User` entities whose userID's are 1, 2, 3 or 4.
  


### PR DESCRIPTION
In the example, a variable named "relationship" is used, but not created. On the line above, another variable "userRelationship" is created but not used.

I'm assuming this is a typo, and they are supposed to be the same?

Same thing with the second example.

They should probably also be named more coherently?
