### PR TITLE
Update was-modified code to check the HTTP status code, not the status string

### DIFF
--- a/Code/Network/RKHTTPRequestOperation.m
+++ b/Code/Network/RKHTTPRequestOperation.m
@@ -257,7 +257,8 @@ static void *RKHTTPRequestOperationStartDate = &RKHTTPRequestOperationStartDate;
 
 - (BOOL)wasNotModified
 {
-    return (self.response.statusCode == 304);
+    NSString *status = (NSString *)[[self.response allHeaderFields] objectForKey:@"Status"];
+    return (self.response.statusCode == 304 || [status isEqualToString:@"304 Not Modified"]);
 }
 
 #pragma mark - NSURLConnectionDelegate methods


### PR DESCRIPTION
Comparing against the string "304 Not Modified" doesn't work if you're working with a custom server that doesn't have pre-crafted response strings.  This update allows RKHTTPRequestOperation to respond to the status code alone.
