### PR TITLE
Uses local quotes rather than global angled ones.

### DIFF
--- a/Code/Network/RKObjectManager.h
+++ b/Code/Network/RKObjectManager.h
@@ -18,7 +18,7 @@
 //  limitations under the License.
 //
 
-#import <RestKit/Network.h>
+#import "RestKit/Network.h"
 #import "RKRouter.h"
 #import "RKPaginator.h"
 #import "RKMacros.h"


### PR DESCRIPTION
When I tried to include the current git version into a project Xcode 4.5.2 compiler barked at the angled import.
