### PR TITLE
Fix deadlocking resulting from executing blocking operation on the main thread.

### DIFF
--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -193,7 +193,7 @@ static id RKRefetchedValueInManagedObjectContext(id value, NSManagedObjectContex
     if (! [self.mappingResult count]) return self.mappingResult;
     
     NSMutableDictionary *newDictionary = [self.mappingResult.dictionary mutableCopy];
-    [self.managedObjectContext performBlockAndWait:^{
+    void (^refetchingBlock)() = ^{
         NSSet *rootKeys = [NSSet setWithArray:[self.entityMappingEvents valueForKey:@"rootKey"]];
         for (id rootKey in rootKeys) {
             NSArray *eventsForRootKey = [self.entityMappingEvents filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"rootKey = %@", rootKey]];
@@ -227,7 +227,13 @@ static id RKRefetchedValueInManagedObjectContext(id value, NSManagedObjectContex
                 }
             }
         }
-    }];
+    };
+
+    if ([NSThread isMainThread]) {
+        refetchingBlock();
+    } else {
+        [self.managedObjectContext performBlockAndWait:refetchingBlock];
+    }
     
     return [[RKMappingResult alloc] initWithDictionary:newDictionary];
 }


### PR DESCRIPTION
The MOC at play here has the concurrency type of NSMainQueueConcurrencyType. And this method can easily be triggered by the main thread (e.g. the success callback calling RKObjectRequestOperation#array). So if we use NSManagedObjectContext#performBlockAndWait:, then we'll deadlock.
