### PR TITLE
Update documentation for ObjectMapping Transformation Blocks

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.h
+++ b/Code/ObjectMapping/RKObjectMapping.h
@@ -46,16 +46,16 @@
  
  To combat this repetition, a block can be designated to perform a transformation on source keys to produce corresponding destination keys:
  
-    [userMapping setDefaultSourceToDestinationKeyTransformationBlock:^NSString *(NSString *sourceKey) {
+    [RKObjectMapping setDefaultSourceToDestinationKeyTransformationBlock:^NSString *(RKObjectMapping *mapping, NSString *sourceKey) {
         // Value transformer compliments of TransformerKit (See https://github.com/mattt/TransformerKit)
-        return [[NSValueTransformer valueTransformerForName:TKLlamaCaseStringTransformerName] transformedValue:key];
+        return [[NSValueTransformer valueTransformerForName:TKLlamaCaseStringTransformerName] transformedValue:sourceKey];
     }];
  
  With the block configured, the original configuration can be changed into a simpler array based invocation:
  
     [userMapping addAttributeMappingsFromArray:@[ @"first_name", @"last_name", @"email_address" ]];
  
- Transformation blocks can be configured on a per-mapping basis or globally via `[RKObjectMapping setDefaultSourceToDestinationKeyTransformationBlock:]`.
+ Transformation blocks can be configured globally via `[RKObjectMapping setDefaultSourceToDestinationKeyTransformationBlock:]`.
 
  @see `RKAttributeMapping`
  @see `RKRelationshipMapping`


### PR DESCRIPTION
There is no way to update ObjectMapping transformation blocks on the object level, only on the class level.

This is a fix of the documentation. I am not sure if the plan was to develop an object level transformation block as well (hence the existing documentation) or if it was scrapped. In either case this documentation update reflects the current status of the code.
