### PR TITLE
Fix RKReplaceAssignmentPolicy

### DIFF
--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -673,8 +673,9 @@ static NSString * const RKMetadataKeyPathPrefix = @"@metadata.";
 
     // If the relationship has changed, set it
     if ([self shouldSetValue:&valueForRelationship atKeyPath:relationshipMapping.destinationKeyPath]) {
-        if ([self mapCoreDataToManyRelationshipValue:valueForRelationship withMapping:relationshipMapping]) {
+        if (! [self mapCoreDataToManyRelationshipValue:valueForRelationship withMapping:relationshipMapping]) {
             RKLogTrace(@"Mapped relationship object from keyPath '%@' to '%@'. Value: %@", relationshipMapping.sourceKeyPath, relationshipMapping.destinationKeyPath, valueForRelationship);
+            [self.destinationObject setValue:valueForRelationship forKeyPath:relationshipMapping.destinationKeyPath];
         }
     } else {
         if ([self.delegate respondsToSelector:@selector(mappingOperation:didNotSetUnchangedValue:forKeyPath:usingMapping:)]) {


### PR DESCRIPTION
RKReplaceAssignmentPolicy did not work on one to many relationships if one of the old values in the collection was also present in the new collection.  The problem was that new values for the relationship were gathered before the old values were deleted.  Therefore if one of the new values was the same as the old value, the valueForRelationship collection would contain a deleted managed object - causing lots of problems.

This fixes #1263, at least for me.

Also fixed:
- The if statement near line 674 was incorrectly negated
  - Setting the relationship value around line 676 was redundant since it was done in the mapCoreDataToManyRelationshipValue:withMapping method.
