### PR TITLE
Fixed a clang warning for the variable success not being set in some paths through the code so that the compile is clean

### DIFF
--- a/Code/Testing/RKMappingTest.m
+++ b/Code/Testing/RKMappingTest.m
@@ -197,7 +197,7 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
 
 - (BOOL)event:(RKMappingTestEvent *)event satisfiesExpectation:(id)expectation error:(NSError **)error
 {
-    BOOL success;
+    BOOL success = NO;
 
     NSDictionary *userInfo = @{ RKMappingTestEventErrorKey : event,
                                 RKMappingTestExpectationErrorKey : expectation };


### PR DESCRIPTION
No actual change to the logic of the app, but it ensures a cleaner compile which allows you to spot real problems and avoid the situation where yellow issues during compile become normal.
