### PR TITLE
Fix assertion error while copying RKEntityMapping having non empty connections.

### DIFF
--- a/Code/CoreData/RKEntityMapping.m
+++ b/Code/CoreData/RKEntityMapping.m
@@ -188,6 +188,7 @@ static BOOL entityIdentificationInferenceEnabled = YES;
     copy.identificationAttributes = self.identificationAttributes;
     copy.identificationPredicate = self.identificationPredicate;
     copy.deletionPredicate = self.deletionPredicate;
+    copy.mutableConnections = [NSMutableArray array];
     
     for (RKConnectionDescription *connection in self.connections) {
         [copy addConnection:[connection copy]];


### PR DESCRIPTION
`- addConnection:` is throwing exception on the line:

`NSAssert(self.mutableConnections, @"self.mutableConnections should not be nil");`
