### PR TITLE
Feature/operation exists in objectmanager queue

### DIFF
--- a/Code/Network/RKObjectManager.h
+++ b/Code/Network/RKObjectManager.h
@@ -535,7 +535,7 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
 - (void)cancelAllObjectRequestOperationsWithMethod:(RKRequestMethod)method matchingPathPattern:(NSString *)pathPattern;
 
 /**
- Finds any operation in the object manager's operation queue whose requests match the specified HTTP method and path pattern and returns YES if one exist.
+ Returns an array of operations in the object manager's operation queue whose requests match the specified HTTP method and path pattern and returns YES if one exist.
  
  Paths are matches against the `path` of the `NSURL` of the `NSURLRequest` of each `RKObjectRequestOperation` contained in the receiver's operation queue using a `RKPathMatcher` object.
  
@@ -544,7 +544,7 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  
  @see `RKPathMatcher`
  */
-- (BOOL)objectManagerContainsObjectRequestOperationsWithMethod:(RKRequestMethod)method matchingPathPattern:(NSString *)pathPattern;
+- (NSArray *)enqueuedObjectRequestOperationsWithMethod:(RKRequestMethod)method matchingPathPattern:(NSString *)pathPattern;
 
 ///-----------------------------------------
 /// @name Batching Object Request Operations

--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -798,8 +798,9 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     }
 }
 
-- (BOOL)objectManagerContainsObjectRequestOperationsWithMethod:(RKRequestMethod)method matchingPathPattern:(NSString *)pathPattern
+- (NSArray *)enqueuedObjectRequestOperationsWithMethod:(RKRequestMethod)method matchingPathPattern:(NSString *)pathPattern
 {
+    NSMutableArray *matches = [NSMutableArray array];
     NSString *methodName = RKStringFromRequestMethod(method);
     RKPathMatcher *pathMatcher = [RKPathMatcher pathMatcherWithPattern:pathPattern];
     for (NSOperation *operation in [self.operationQueue operations]) {
@@ -810,10 +811,10 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
         NSString *pathAndQueryString = RKPathAndQueryStringFromURLRelativeToURL([request URL], self.baseURL);
         
         if ((!methodName || [methodName isEqualToString:[request HTTPMethod]]) && [pathMatcher matchesPath:pathAndQueryString tokenizeQueryStrings:NO parsedArguments:nil]) {
-            return YES;
+            [matches addObject:operation];
         }
     }
-    return NO;
+    return [matches copy];
 }
 
 - (void)enqueueBatchOfObjectRequestOperationsWithRoute:(RKRoute *)route

--- a/Tests/Logic/ObjectMapping/RKObjectManagerTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectManagerTest.m
@@ -330,45 +330,57 @@
     expect([operation isCancelled]).to.equal(YES);
 }
 
-- (void)testContainsOperationByExactMethodAndPath
+- (void)testEnqueuedObjectRequestOperationByExactMethodAndPath
 {
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"/object_manager/cancel" relativeToURL:self.objectManager.HTTPClient.baseURL]];
     RKObjectRequestOperation *operation = [[RKObjectRequestOperation alloc] initWithRequest:request responseDescriptors:self.objectManager.responseDescriptors];
     [_objectManager enqueueObjectRequestOperation:operation];
-    expect([_objectManager objectManagerContainsObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@"/object_manager/cancel"]).to.equal(YES);
+    expect([[_objectManager enqueuedObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@"/object_manager/cancel"] count]).to.equal(1);
 }
 
-- (void)testContainsOperationByPathMatch
+- (void)testEnqueuedObjectRequestOperationByMultipleExactMethodAndPath
+{
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"/object_manager/cancel" relativeToURL:self.objectManager.HTTPClient.baseURL]];
+    RKObjectRequestOperation *operation = [[RKObjectRequestOperation alloc] initWithRequest:request responseDescriptors:self.objectManager.responseDescriptors];
+    RKObjectRequestOperation *secondOperation = [operation copy];
+    RKObjectRequestOperation *thirdOperation = [operation copy];
+    [_objectManager enqueueObjectRequestOperation:operation];
+    [_objectManager enqueueObjectRequestOperation:secondOperation];
+    [_objectManager enqueueObjectRequestOperation:thirdOperation];
+    expect([[_objectManager enqueuedObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@"/object_manager/cancel"] count]).to.equal(3);
+}
+
+- (void)testEnqueuedObjectRequestOperationByPathMatch
 {
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"/object_manager/1234/cancel" relativeToURL:self.objectManager.HTTPClient.baseURL]];
     RKObjectRequestOperation *operation = [[RKObjectRequestOperation alloc] initWithRequest:request responseDescriptors:self.objectManager.responseDescriptors];
     [_objectManager enqueueObjectRequestOperation:operation];
-    expect([_objectManager objectManagerContainsObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@"/object_manager/:objectID/cancel"]).to.equal(YES);
+    expect([[_objectManager enqueuedObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@"/object_manager/:objectID/cancel"] count]).to.equal(1);
 }
 
-- (void)testContainsOperationFailsForMismatchedMethod
+- (void)testEnqueuedObjectRequestOperationFailsForMismatchedMethod
 {
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"/object_manager/cancel" relativeToURL:self.objectManager.HTTPClient.baseURL]];
     RKObjectRequestOperation *operation = [[RKObjectRequestOperation alloc] initWithRequest:request responseDescriptors:self.objectManager.responseDescriptors];
     [_objectManager enqueueObjectRequestOperation:operation];
-    expect([_objectManager objectManagerContainsObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@"/wrong"]).to.equal(NO);
+    expect([[_objectManager enqueuedObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@"/wrong"] count]).to.equal(0);
 }
 
-- (void)testContainsOperationFailsForMismatchedPath
+- (void)testEnqueuedObjectRequestOperationFailsForMismatchedPath
 {
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"/object_manager/cancel" relativeToURL:self.objectManager.HTTPClient.baseURL]];
     RKObjectRequestOperation *operation = [[RKObjectRequestOperation alloc] initWithRequest:request responseDescriptors:self.objectManager.responseDescriptors];
     [_objectManager enqueueObjectRequestOperation:operation];
-    expect([_objectManager objectManagerContainsObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@"/wrong"]).to.equal(NO);
+    expect([[_objectManager enqueuedObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@"/wrong"] count]).to.equal(0);
 }
 
-- (void)testContainsOperationByPathMatchForBaseURLWithPath
+- (void)testEnqueuedObjectRequestOperationByPathMatchForBaseURLWithPath
 {
     self.objectManager = [RKObjectManager managerWithBaseURL:[NSURL URLWithString:@"http://localhost:4567/object_manager/"]];
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:4567/object_manager/1234/cancel"]];
     RKObjectRequestOperation *operation = [[RKObjectRequestOperation alloc] initWithRequest:request responseDescriptors:self.objectManager.responseDescriptors];
     [_objectManager enqueueObjectRequestOperation:operation];
-    expect([_objectManager objectManagerContainsObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@":objectID/cancel"]).to.equal(YES);
+    expect([[_objectManager enqueuedObjectRequestOperationsWithMethod:RKRequestMethodGET matchingPathPattern:@":objectID/cancel"] count]).to.equal(1);
 }
 
 - (void)testShouldProperlyFireABatchOfOperations


### PR DESCRIPTION
Finds any operation in the object manager's operation queue whose requests match the specified HTTP method and path pattern and returns YES if one exist.

 Paths are matches against the `path` of the `NSURL` of the `NSURLRequest` of each `RKObjectRequestOperation` contained in the receiver's operation queue using a `RKPathMatcher` object.

 @param method The HTTP method to match for the cancelled requests, such as `RKRequestMethodGET`, `RKRequestMethodPOST`, `RKRequestMethodPUT`, `RKRequestMethodPatch`, or `RKRequestMethodDELETE`. If `RKRequestMethodAny`, all object request operations with URLs matching the given path pattern will be cancelled.
 @param pathPattern The pattern to match against the path of the request URL for executing object request operations considered for cancellation.

 @see `RKPathMatcher`
