### PR TITLE
Change TransitionKit submodule url to public url.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/AFNetworking/AFNetworking.git
 [submodule "Vendor/TransitionKit"]
 	path = Vendor/TransitionKit
-	url = git@github.com:blakewatters/TransitionKit.git
+	url = https://github.com/blakewatters/TransitionKit.git


### PR DESCRIPTION
I changed the url of the TransitionKit submodule, since it had a user embedded in it and Github was asking for the keys. The url is now the public url of the same repo on Github.
