### PR TITLE
Fix Crash in RKPropertyInspector

### DIFF
--- a/Code/CoreData/RKPropertyInspector+CoreData.m
+++ b/Code/CoreData/RKPropertyInspector+CoreData.m
@@ -132,12 +132,14 @@
 - (Class)rk_classForPropertyAtKeyPath:(NSString *)keyPath isPrimitive:(BOOL *)isPrimitive
 {
     NSArray *components = [keyPath componentsSeparatedByString:@"."];
-    Class propertyClass = [self class];
+    Class currentPropertyClass = [self class];
+    Class propertyClass = nil;
     for (NSString *property in components) {
         if (isPrimitive) *isPrimitive = NO; // Core Data does not enable you to model primitives
         propertyClass = [[RKPropertyInspector sharedInspector] classForPropertyNamed:property ofEntity:[self entity]];
-        propertyClass = propertyClass ?: [[RKPropertyInspector sharedInspector] classForPropertyNamed:property ofClass:propertyClass isPrimitive:isPrimitive];
+        propertyClass = propertyClass ?: [[RKPropertyInspector sharedInspector] classForPropertyNamed:property ofClass:currentPropertyClass isPrimitive:isPrimitive];
         if (! propertyClass) break;
+        currentPropertyClass = propertyClass;
     }
     
     return propertyClass;


### PR DESCRIPTION
Upgrading to the lastest dev commit of RestKit causes our app to crash.

The problem is line 125:

<pre>
        [self.inspectionCache setObject:inspection forKey:(id<NSCopying>)objectClass];
</pre>


ObjectClass is nil.  If you backtrack the call sequence you can see that rk_classForPropertyAtKeyPath is not coded correctly since at line 140 it intentionally send a nil class to classForPropertyNamed resulting in the crash.
