### PR TITLE
Fix loss of precision when mapping large 64 bit integer strings to numer...

### DIFF
--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -117,8 +117,14 @@ id RKTransformedValueWithClass(id value, Class destinationType, NSValueTransform
             if ([booleanStrings containsObject:lowercasedString]) {
                 // Handle booleans encoded as Strings
                 return [NSNumber numberWithBool:[trueStrings containsObject:lowercasedString]];
-            } else {
+            } else if ([(NSString *)value rangeOfString:@"."].location != NSNotFound) {
+                // String -> Floating Point Number
+                // Only use floating point if needed to avoid losing precision
+                // on large integers
                 return [NSNumber numberWithDouble:[(NSString *)value doubleValue]];
+            } else {
+                // String -> Signed Integer
+                return [NSNumber numberWithLongLong:[(NSString *)value longLongValue]];
             }
         }
     } else if ([value isEqual:[NSNull null]]) {

--- a/Tests/Logic/ObjectMapping/RKMappingOperationTest.m
+++ b/Tests/Logic/ObjectMapping/RKMappingOperationTest.m
@@ -37,6 +37,7 @@
 @property (nonatomic, strong) NSURL *url;
 @property (nonatomic, strong) NSString *boolString;
 @property (nonatomic, strong) NSNumber *boolNumber;
+@property (nonatomic, strong) NSNumber *number;
 @property (nonatomic, strong) NSDate *date;
 @property (nonatomic, strong) NSOrderedSet *orderedSet;
 @property (nonatomic, strong) NSArray *array;
@@ -167,6 +168,44 @@
     BOOL success = (operation.error == nil);
     assertThatBool(success, is(equalToBool(YES)));
     assertThat(object.boolString, is(equalTo(@"123")));
+}
+
+- (void)testShouldSuccessfullyMapLongIntegerStringsToNumbers
+{
+    RKObjectMapping *mapping = [RKObjectMapping mappingForClass:[TestMappable class]];
+    [mapping addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:@"numberString" toKeyPath:@"number"]];
+    TestMappable *object = [[TestMappable alloc] init];
+
+    NSData *data = [@"{\"numberString\":\"69726278940360707\"}" dataUsingEncoding:NSUTF8StringEncoding];
+    id deserializedObject = [RKMIMETypeSerialization objectFromData:data MIMEType:RKMIMETypeJSON error:nil];
+
+    RKMappingOperation *operation = [[RKMappingOperation alloc] initWithSourceObject:deserializedObject destinationObject:object mapping:mapping];
+    RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
+    operation.dataSource = dataSource;
+    [operation start];
+    BOOL success = (operation.error == nil);
+    assertThatBool(success, is(equalToBool(YES)));
+    assertThatUnsignedLongLong([object.number unsignedLongLongValue], is(equalToUnsignedLongLong(69726278940360707)));
+    
+}
+
+- (void)testShouldSuccessfullyMapFloatingPointNumberStringsToNumbers
+{
+    RKObjectMapping *mapping = [RKObjectMapping mappingForClass:[TestMappable class]];
+    [mapping addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:@"numberString" toKeyPath:@"number"]];
+    TestMappable *object = [[TestMappable alloc] init];
+
+    NSData *data = [@"{\"numberString\":\"1234.5678\"}" dataUsingEncoding:NSUTF8StringEncoding];
+    id deserializedObject = [RKMIMETypeSerialization objectFromData:data MIMEType:RKMIMETypeJSON error:nil];
+
+    RKMappingOperation *operation = [[RKMappingOperation alloc] initWithSourceObject:deserializedObject destinationObject:object mapping:mapping];
+    RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
+    operation.dataSource = dataSource;
+    [operation start];
+    BOOL success = (operation.error == nil);
+    assertThatBool(success, is(equalToBool(YES)));
+    assertThatDouble([object.number doubleValue], is(equalToDouble(1234.5678)));
+    
 }
 
 - (void)testShouldSuccessfullyMapPropertiesBeforeKeyPathAttributes


### PR DESCRIPTION
...ic types

We are using 64 ints as IDs in our backend system passed as strings in JSON. For sufficiently high values these IDs were being altered due to the fact that they were being constructed in an NSNumber as doubles rather than long integers. 

This pull request fixes the issue while retaining support for doubles represented as strings. See added unit tests for example of a breaking case.
