### PR TITLE
Support mapping parsed arguments when using response descriptors

### DIFF
--- a/Code/Network/RKResponseDescriptor.h
+++ b/Code/Network/RKResponseDescriptor.h
@@ -158,6 +158,16 @@
  */
 - (BOOL)matchesResponse:(NSHTTPURLResponse *)response;
 
+/**
+ Returns a Dictionary of parsed arguments extracted from the URL of the given response object.
+ 
+ @param response The HTTP response object to compare with the base URL, path pattern, and status codes set of the receiver.
+ @return A dictionary of parsed arguments if the response matches the base URL, path pattern, and status codes set of the receiver, else `nil`.
+ @see `matchesResponse:`
+ 
+ */
+- (NSDictionary *)parsedArgumentsFromResponse:(NSHTTPURLResponse *)response;
+
 ///-------------------------
 /// @name Comparing Response Descriptors
 ///-------------------------

--- a/Code/Network/RKResponseDescriptor.m
+++ b/Code/Network/RKResponseDescriptor.m
@@ -105,26 +105,41 @@ extern NSString *RKStringDescribingRequestMethod(RKRequestMethod method);
 
 - (BOOL)matchesPath:(NSString *)path
 {
+    return [self matchesPath:path parsedArguments:nil];
+}
+
+- (BOOL)matchesPath:(NSString *)path parsedArguments:(NSDictionary **)outParsedArguments
+{
     if (!self.pathPattern || !path) return YES;
     RKPathMatcher *pathMatcher = [RKPathMatcher pathMatcherWithPattern:self.pathPattern];
-    return [pathMatcher matchesPath:path tokenizeQueryStrings:NO parsedArguments:nil];
+    return [pathMatcher matchesPath:path tokenizeQueryStrings:NO parsedArguments:outParsedArguments];
 }
 
 - (BOOL)matchesURL:(NSURL *)URL
 {
+    return [self matchesURL:URL parsedArguments:nil];
+}
+
+- (BOOL)matchesURL:(NSURL *)URL parsedArguments:(NSDictionary **)outParsedArguments
+{
     NSString *pathAndQueryString = RKPathAndQueryStringFromURLRelativeToURL(URL, self.baseURL);
     if (self.baseURL) {
         if (! RKURLIsRelativeToURL(URL, self.baseURL)) return NO;
-        return [self matchesPath:pathAndQueryString];
+        return [self matchesPath:pathAndQueryString parsedArguments:outParsedArguments];
     } else {
-        return [self matchesPath:pathAndQueryString];
+        return [self matchesPath:pathAndQueryString parsedArguments:outParsedArguments];
     }
 }
 
 - (BOOL)matchesResponse:(NSHTTPURLResponse *)response
 {
-    if (! [self matchesURL:response.URL]) return NO;
+    return [self matchesResponse:response parsedArguments:nil];
+}
 
+- (BOOL)matchesResponse:(NSHTTPURLResponse *)response parsedArguments:(NSDictionary **)outParsedArguments
+{
+    if (![self matchesURL:response.URL parsedArguments:outParsedArguments]) return NO;
+    
     if (self.statusCodes) {
         if (! [self.statusCodes containsIndex:response.statusCode]) {
             return NO;
@@ -137,6 +152,17 @@ extern NSString *RKStringDescribingRequestMethod(RKRequestMethod method);
 - (BOOL)matchesMethod:(RKRequestMethod)method
 {
     return self.method & method;
+}
+
+- (NSDictionary *)parsedArgumentsFromResponse:(NSHTTPURLResponse *)response
+{
+    NSDictionary *parsedArguments = nil;
+    if ([self matchesResponse:response parsedArguments:&parsedArguments])
+    {
+        return parsedArguments;
+    }
+    
+    return nil;
 }
 
 - (BOOL)isEqual:(id)object

--- a/Code/Network/RKResponseMapperOperation.m
+++ b/Code/Network/RKResponseMapperOperation.m
@@ -128,6 +128,7 @@ static dispatch_queue_t RKResponseMapperSerializationQueue() {
 @property (nonatomic, strong, readwrite) NSError *error;
 @property (nonatomic, strong, readwrite) NSArray *matchingResponseDescriptors;
 @property (nonatomic, strong, readwrite) NSDictionary *responseMappingsDictionary;
+@property (nonatomic, strong, readwrite) NSDictionary *responseMappingArgumentsDictionary;
 @property (nonatomic, strong) RKMapperOperation *mapperOperation;
 @property (nonatomic, copy) id (^willMapDeserializedResponseBlock)(id);
 @property (nonatomic, copy) void(^didFinishMappingBlock)(RKMappingResult *, NSError *);
@@ -185,6 +186,7 @@ static NSMutableDictionary *RKRegisteredResponseMapperOperationDataSourceClasses
         self.responseDescriptors = responseDescriptors;
         self.matchingResponseDescriptors = [self buildMatchingResponseDescriptors];
         self.responseMappingsDictionary = [self buildResponseMappingsDictionary];
+        self.responseMappingArgumentsDictionary = [self buildResponseMappingArgumentsDictionary];
         self.treatsEmptyResponseAsSuccess = YES;
         self.mappingMetadata = @{}; // Initialize the metadata
     }
@@ -233,6 +235,30 @@ static NSMutableDictionary *RKRegisteredResponseMapperOperationDataSourceClasses
     return dictionary;
 }
 
+- (NSDictionary *)buildResponseMappingArgumentsDictionary
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    for (RKResponseDescriptor *responseDescriptor in self.matchingResponseDescriptors) {
+        
+        NSDictionary *arguments = [responseDescriptor parsedArgumentsFromResponse:self.response];
+        if (arguments)
+        {
+            // We don't add nil keypath at an [NSNull null] key, because that causes a crash later
+            // in RKDictionaryByMergingDictionaryWithDictionary
+            if (responseDescriptor.keyPath)
+            {
+                [dictionary setObject:arguments forKey:responseDescriptor.keyPath];
+            }
+            else
+            {
+                [dictionary addEntriesFromDictionary:arguments];
+            }
+        }
+    }
+    
+    return dictionary;
+}
+
 - (RKMappingResult *)performMappingWithObject:(id)sourceObject error:(NSError **)error
 {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
@@ -256,6 +282,12 @@ static NSMutableDictionary *RKRegisteredResponseMapperOperationDataSourceClasses
     NSDictionary *HTTPMetadata = @{ @"HTTP": @{ @"request":  @{ @"URL": self.request.URL, @"method": self.request.HTTPMethod, @"headers": [self.request allHTTPHeaderFields] ?: @{} },
                                                 @"response": @{ @"URL": self.response.URL, @"headers": [self.response allHeaderFields] ?: @{} } } };
     _mappingMetadata = RKDictionaryByMergingDictionaryWithDictionary(HTTPMetadata, mappingMetadata);
+    
+    if (self.responseMappingArgumentsDictionary)
+    {
+        NSDictionary *argumentsMetadata = @{ @"mapping" : @{ @"arguments" : self.responseMappingArgumentsDictionary } };
+        _mappingMetadata = RKDictionaryByMergingDictionaryWithDictionary(argumentsMetadata, _mappingMetadata);
+    }
 }
 
 - (void)cancel


### PR DESCRIPTION
The parsed arguments are now available in @metadata.mapping.arguments.  Fixes #1423.