### PR TITLE
Rakefile: Have 'make docs' create its temp folder if it doesn't exist

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,6 +84,8 @@ namespace :appledoc do
       puts "appledoc not found at /usr/local/bin/appledoc: Install via homebrew and try again: `brew install --HEAD appledoc`"
       exit 1
     end
+    appledoc_temp_path = ENV['HOME']+"/Library/Application Support/appledoc"
+    Dir.mkdir(appledoc_temp_path) unless Dir.exists?(appledoc_temp_path)
   end
 end
 


### PR DESCRIPTION
When the temp folder (hard-coded in apple_doc_command) does not exist, appledoc quits with this error:

```
Executing: `/usr/local/bin/appledoc -t ~/Library/Application\ Support/appledoc -o Docs/API -p RestKit -v 0.20.3-dev -c "RestKit" --company-id org.restkit --warn-undocumented-object --warn-undocumented-member  --warn-empty-description  --warn-unknown-directive --warn-invalid-crossref --warn-missing-arg --no-repeat-first-par  --no-create-docset --keep-intermediate-files --create-html `find Code/ -name '*.h'``
ERROR: AppledocException: Path '/Users/pnm/Library/Application Support/appledoc' from -t is not valid!
Error: appledoc, code 1000: Template path doesn't exist at '/Users/pnm/Library/Application Support/appledoc'!
```
