### PR TITLE
Exposed RKObjectRequestOperation within RKPaginator

### DIFF
--- a/Code/Network/RKPaginator.h
+++ b/Code/Network/RKPaginator.h
@@ -101,7 +101,7 @@
 /**
  Returns the ObjectRequestOperation used by the paginator to load the request
  */
-@property (nonatomic, strong) RKObjectRequestOperation *objectRequestOperation;
+@property (nonatomic, readonly) RKObjectRequestOperation *objectRequestOperation;
 
 /**
  Sets the `RKHTTPRequestOperation` subclass to be used when constructing HTTP request operations for requests dispatched by the paginator.

--- a/Code/Network/RKPaginator.m
+++ b/Code/Network/RKPaginator.m
@@ -172,7 +172,7 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
 {
     if (self.objectRequestOperation) {
         // The user by calling loadPage is ready to perform the next request so invalidate objectRequestOperation
-        self.objectRequestOperation = nil;
+        _objectRequestOperation = nil;
     }
     
     NSAssert(self.responseDescriptors, @"Cannot perform a load with nil response descriptors.");
@@ -190,9 +190,9 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
         managedObjectRequestOperation.fetchRequestBlocks = self.fetchRequestBlocks;
         managedObjectRequestOperation.deletesOrphanedObjects = NO;
         
-        self.objectRequestOperation = managedObjectRequestOperation;
+        _objectRequestOperation = managedObjectRequestOperation;
     } else {
-        self.objectRequestOperation = [[RKObjectRequestOperation alloc] initWithRequest:mutableRequest responseDescriptors:self.responseDescriptors];
+        _objectRequestOperation = [[RKObjectRequestOperation alloc] initWithRequest:mutableRequest responseDescriptors:self.responseDescriptors];
     }
     
     // Add KVO to ensure notification of loaded state prior to execution of completion block


### PR DESCRIPTION
Issue #1332

In order to determine the paginator's status inside of its completion blocks, RKObjectRequestOperation need to be visible inside of RKPaginator. There were a few methods proposed to this and I am open to suggestions but this seemed the most straightforward to continue working with the RKPaginator object after loadPage completion for various reasons.
