### PR TITLE
Allow route type any for get requests

### DIFF
--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -646,7 +646,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     NSDictionary *interpolatedParameters = nil;
     NSURL *URL = [self URLWithRoute:route object:object interpolatedParameters:&interpolatedParameters];
     NSAssert(URL, @"No route found named '%@'", routeName);
-    NSAssert(route.method == RKRequestMethodGET || route.method == RKRequestMethodAny, @"Expected route named '%@' to specify a GET (or *), but it does not", routeName);
+    NSAssert(route.method & RKRequestMethodGET, @"Expected route named '%@' to specify a GET, but it does not", routeName);
     
     RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:nil method:RKRequestMethodGET path:[URL relativeString] parameters:parameters];
     operation.mappingMetadata = @{ @"routing": @{ @"parameters": interpolatedParameters, @"route": route } };


### PR DESCRIPTION
If you attempt to use the RKRequestMethodAny constant on an named RKRoute, using the -[RKObjectManager getObjectsAtPathForRouteNamed:] method crashes with an assertion failure. This (small) change fixes that.
