### PR TITLE
-[RKPaginator cancel] should nil out objectRequestOperation

### DIFF
--- a/Code/Network/RKPaginator.m
+++ b/Code/Network/RKPaginator.m
@@ -262,6 +262,7 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
 - (void)cancel
 {
     [self.objectRequestOperation cancel];
+    self.objectRequestOperation = nil;
 }
 
 #pragma mark - iOS 5 proxy attributes


### PR DESCRIPTION
`-[RKPaginator cancel]` should nil out `objectRequestOperation`. 
Otherwise the next time `-[RKPaginator loadPage:0]` is called, RK complains about an existing load in progress, while the previous load had already been cancelled.
