### PR TITLE
Create RKObjectRequestOperations with relevant ResponseDescriptors only

### DIFF
--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -547,16 +547,33 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
                                                         success:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success
                                                         failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
+    return [self objectRequestOperationWithRequest:request responseDescriptors:self.responseDescriptors success:success failure:failure];
+}
+
+- (RKObjectRequestOperation *)objectRequestOperationWithRequest:(NSURLRequest *)request
+                                            responseDescriptors:(NSArray *)responseDescriptors
+                                                        success:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success
+                                                        failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
+{
     Class HTTPRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredHTTPRequestOperationClasses] ?: [RKHTTPRequestOperation class];
     RKHTTPRequestOperation *HTTPRequestOperation = [[HTTPRequestOperationClass alloc] initWithRequest:request];
     [self copyStateFromHTTPClientToHTTPRequestOperation:HTTPRequestOperation];
     Class objectRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredObjectRequestOperationClasses] ?: [RKObjectRequestOperation class];
-    RKObjectRequestOperation *operation = [[objectRequestOperationClass alloc] initWithHTTPRequestOperation:HTTPRequestOperation responseDescriptors:self.responseDescriptors];
+    RKObjectRequestOperation *operation = [[objectRequestOperationClass alloc] initWithHTTPRequestOperation:HTTPRequestOperation responseDescriptors:responseDescriptors];
     [operation setCompletionBlockWithSuccess:success failure:failure];
     return operation;
 }
 
 - (RKManagedObjectRequestOperation *)managedObjectRequestOperationWithRequest:(NSURLRequest *)request
+                                                          managedObjectContext:(NSManagedObjectContext *)managedObjectContext
+                                                                      success:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success
+                                                                      failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
+{
+    return [self managedObjectRequestOperationWithRequest:request responseDescriptors:self.responseDescriptors managedObjectContext:managedObjectContext success:success failure:failure];
+}
+
+- (RKManagedObjectRequestOperation *)managedObjectRequestOperationWithRequest:(NSURLRequest *)request
+                                                          responseDescriptors:(NSArray *)responseDescriptors
                                                          managedObjectContext:(NSManagedObjectContext *)managedObjectContext
                                                                       success:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success
                                                                       failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
@@ -565,7 +582,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     RKHTTPRequestOperation *HTTPRequestOperation = [[HTTPRequestOperationClass alloc] initWithRequest:request];
     [self copyStateFromHTTPClientToHTTPRequestOperation:HTTPRequestOperation];
     Class objectRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredManagedObjectRequestOperationClasses] ?: [RKManagedObjectRequestOperation class];
-    RKManagedObjectRequestOperation *operation = (RKManagedObjectRequestOperation *)[[objectRequestOperationClass alloc] initWithHTTPRequestOperation:HTTPRequestOperation responseDescriptors:self.responseDescriptors];        
+    RKManagedObjectRequestOperation *operation = (RKManagedObjectRequestOperation *)[[objectRequestOperationClass alloc] initWithHTTPRequestOperation:HTTPRequestOperation responseDescriptors:responseDescriptors];
     [operation setCompletionBlockWithSuccess:success failure:failure];
     operation.managedObjectContext = managedObjectContext ?: self.managedObjectStore.mainQueueManagedObjectContext;
     operation.managedObjectCache = self.managedObjectStore.managedObjectCache;
@@ -601,7 +618,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     if (isManagedObjectRequestOperation && self.managedObjectStore) {
         // Construct a Core Data operation
         NSManagedObjectContext *managedObjectContext = [object respondsToSelector:@selector(managedObjectContext)] ? [object managedObjectContext] : self.managedObjectStore.mainQueueManagedObjectContext;
-        operation = [self managedObjectRequestOperationWithRequest:request managedObjectContext:managedObjectContext success:nil failure:nil];
+        operation = [self managedObjectRequestOperationWithRequest:request responseDescriptors:matchingDescriptors managedObjectContext:managedObjectContext success:nil failure:nil];
 
         if ([object isKindOfClass:[NSManagedObject class]]) {
             static NSPredicate *temporaryObjectsPredicate = nil;
@@ -620,7 +637,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
         }
     } else {
         // Non-Core Data operation
-        operation = [self objectRequestOperationWithRequest:request success:nil failure:nil];
+        operation = [self objectRequestOperationWithRequest:request responseDescriptors:matchingDescriptors success:nil failure:nil];
     }
     
     if (RKDoesArrayOfResponseDescriptorsContainMappingForClass(self.responseDescriptors, [object class])) operation.targetObject = object;

--- a/Tests/Logic/ObjectMapping/RKObjectManagerTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectManagerTest.m
@@ -1551,6 +1551,54 @@
 
 @end
 
+@interface RKObjectManagerNonCoreDataTest: RKTestCase
+@property (nonatomic, strong) RKObjectManager *objectManager;
+
+@property (nonatomic, strong) RKResponseDescriptor *addressResponseDescriptor;
+@property (nonatomic, strong) RKResponseDescriptor *coordinateResponseDescriptor;
+
+@end
+
+@implementation RKObjectManagerNonCoreDataTest
+
+-(void)setUp{
+    [RKTestFactory setUp];
+    self.objectManager = [RKTestFactory objectManager];
+    [RKObjectManager setSharedManager:self.objectManager];
+    
+    RKObjectMapping *addressMapping = [RKObjectMapping mappingForClass:[RKTestAddress class]];
+    [addressMapping addAttributeMappingsFromArray:@[@"addressID", @"city", @"state", @"country"]];
+    
+    RKObjectMapping *coordinateMapping = [RKObjectMapping mappingForClass:[RKTestCoordinate class]];
+    [coordinateMapping addAttributeMappingsFromArray:@[@""]];
+    
+    self.addressResponseDescriptor = [RKResponseDescriptor responseDescriptorWithMapping:addressMapping method:RKRequestMethodGET pathPattern:@"address" keyPath:@"address" statusCodes:RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful)];
+    self.coordinateResponseDescriptor = [RKResponseDescriptor responseDescriptorWithMapping:coordinateMapping method:RKRequestMethodPOST pathPattern:@"coordinate" keyPath:nil statusCodes:RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful)];
+ 
+    [self.objectManager.router.routeSet addRoute:[RKRoute routeWithClass:[RKTestCoordinate class] pathPattern:@"coordinate" method:RKRequestMethodPOST]];
+    [self.objectManager addResponseDescriptorsFromArray:@[self.addressResponseDescriptor, self.coordinateResponseDescriptor]];
+}
+
+-(void)tearDown{
+    [RKTestFactory tearDown];
+}
+
+-(void)testThatAppropriateObjectRequestOperationOnlyContainsResponseDescriptorsThatMatchObjectAndMethod{
+    RKTestCoordinate *coordinate = [RKTestCoordinate new];
+    RKObjectRequestOperation *operation = [self.objectManager appropriateObjectRequestOperationWithObject:coordinate method:RKRequestMethodPOST path:@"coordinate" parameters:nil];
+    expect(operation.responseDescriptors.count).to.equal(1);
+    expect(operation.responseDescriptors[0]).to.equal(self.coordinateResponseDescriptor);
+}
+
+-(void)testThatAppropriateObjectRequestOperationOnlyContainsResponseDescriptorsThatMatchPahtAndMethod{
+    RKObjectRequestOperation *operation = [self.objectManager appropriateObjectRequestOperationWithObject:nil method:RKRequestMethodGET path:@"address" parameters:nil];
+    expect(operation.responseDescriptors.count).to.equal(1);
+    expect(operation.responseDescriptors[0]).to.equal(self.addressResponseDescriptor);
+}
+
+
+@end
+
 RKRequestDescriptor *RKRequestDescriptorFromArrayMatchingObjectAndRequestMethod(NSArray *requestDescriptors, id object, RKRequestMethod requestMethod);
 
 @interface RKRequestDescriptorFromArrayMatchingObjectAndRequestMethodTest : RKTestCase


### PR DESCRIPTION
Documentation seems to imply that RKObjectRequestOperation objects created with RKObjectManager appropriateObjectRequestOperationWithObject:method:path:parameters:  will contain the RKResponseDescriptors relevant to the object, path and method passed in.  Development branch is creating the operation with all of the descriptors that have been added to the RKObjectManager.  This pull request:
- creates two new RKObjectRequestOperation builder methods that accept an array of RKResponseDescriptors.
- Updated previous signature to just call into the new factor method with self.responseDescriptors to preserve original behavior.
- update appropriateObjectRequestOperationWithObject:method:path:parameters: to use the new factory methods passing in the local matchingDescriptors array.
