### PR TITLE
Support JSON with keys in dots (in some cases)

### DIFF
--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -405,12 +405,22 @@ static NSString *const RKRootKeyPathPrefix = @"@root.";
     NSArray *sourceKeyComponents = [mapping.sourceKeyPath componentsSeparatedByString:@"."];
     if (sourceKeyComponents.count > 1)
     {
-        for (NSString *key in [sourceKeyComponents subarrayWithRange:NSMakeRange(0, sourceKeyComponents.count - 1)])
-        {
-            parentSourceObject = [[RKMappingSourceObject alloc] initWithObject:[parentSourceObject valueForKey:key]
-                                                                  parentObject:parentSourceObject
-                                                                    rootObject:self.rootSourceObject
-                                                                      metadata:self.metadata];
+        @try {
+            for (NSString *key in [sourceKeyComponents subarrayWithRange:NSMakeRange(0, sourceKeyComponents.count - 1)])
+            {
+                parentSourceObject = [[RKMappingSourceObject alloc] initWithObject:[parentSourceObject valueForKey:key]
+                                                                      parentObject:parentSourceObject
+                                                                        rootObject:self.rootSourceObject
+                                                                          metadata:self.metadata];
+            }
+        }
+        @catch (NSException *exception) {
+            if ([exception.name isEqualToString:NSInvalidArgumentException]) {
+                RKLogDebug(@"Caught NSInvalidArgumentException while creating parent object chain. Assuming this is caused by a key containing dots and directly using source object.");
+                parentSourceObject = self.sourceObject;
+            } else {
+                [exception raise];
+            }
         }
     }
 

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -599,6 +599,8 @@
 		BE05BDD11782109F00F7C9C9 /* RKRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */; };
 		BE05BDD2178214AA00F7C9C9 /* RKRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */; };
 		E2F2B89961FC462B981CEB7A /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E457EFC3D502479D8B4FCF2A /* libPods-ios.a */; };
+		F60B066D17A687FB007E26A8 /* keys_with_dots.json in Resources */ = {isa = PBXBuildFile; fileRef = F60B066C17A68531007E26A8 /* keys_with_dots.json */; };
+		F6D1196017A7C45F00C041E5 /* keys_with_dots.json in Resources */ = {isa = PBXBuildFile; fileRef = F60B066C17A68531007E26A8 /* keys_with_dots.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -976,6 +978,7 @@
 		BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRouteTest.m; sourceTree = "<group>"; };
 		E457EFC3D502479D8B4FCF2A /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED192D1B86AB47D7927731B0 /* Pods-osx.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.xcconfig"; path = "Pods/Pods-osx.xcconfig"; sourceTree = SOURCE_ROOT; };
+		F60B066C17A68531007E26A8 /* keys_with_dots.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = keys_with_dots.json; sourceTree = "<group>"; };
 		F66056291744FF9000A87A45 /* and_cats.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = and_cats.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1393,6 +1396,7 @@
 				25160FE81456F2330060A5C5 /* users.json */,
 				25CAAA9315254E7800CAE5D7 /* ArrayOfHumans.json */,
 				25119FB5154A34B400C6BC58 /* parents_and_children.json */,
+				F60B066C17A68531007E26A8 /* keys_with_dots.json */,
 			);
 			path = JSON;
 			sourceTree = "<group>";
@@ -2105,6 +2109,7 @@
 				25CAAA9415254E7800CAE5D7 /* ArrayOfHumans.json in Resources */,
 				25119FB6154A34B400C6BC58 /* parents_and_children.json in Resources */,
 				259D983C154F6C90008C90F5 /* benchmark_parents_and_children.json in Resources */,
+				F60B066D17A687FB007E26A8 /* keys_with_dots.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2157,6 +2162,7 @@
 				25CAAA9515254E7800CAE5D7 /* ArrayOfHumans.json in Resources */,
 				25119FB7154A34B400C6BC58 /* parents_and_children.json in Resources */,
 				259D983D154F6C90008C90F5 /* benchmark_parents_and_children.json in Resources */,
+				F6D1196017A7C45F00C041E5 /* keys_with_dots.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Fixtures/JSON/keys_with_dots.json
+++ b/Tests/Fixtures/JSON/keys_with_dots.json
@@ -1,0 +1,9 @@
+{
+    "data": {
+        "users.current.details": {
+            "id": 12345,
+            "name": "Simon"
+        }
+    },
+    "success": true
+}

--- a/Tests/Logic/ObjectMapping/RKObjectMappingNextGenTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectMappingNextGenTest.m
@@ -112,6 +112,46 @@
 
 @end
 
+@interface RKExampleGroupWithUser : NSObject {
+    RKTestUser *_user;
+}
+
+@property (nonatomic, retain) RKTestUser *user;
+
+@end
+
+@implementation RKExampleGroupWithUser
+
+@synthesize user = _user;
+
++ (RKExampleGroupWithUser *)group
+{
+    return [self new];
+}
+
+@end
+
+@interface RKExampleGroupWithGroup : NSObject {
+    RKExampleGroupWithUser *_userGroup;
+}
+
+@property (nonatomic, retain) RKExampleGroupWithUser *userGroup;
+
+@end
+
+@implementation RKExampleGroupWithGroup
+
+@synthesize userGroup = _userGroup;
+
++ (RKExampleGroupWithGroup *)group
+{
+    return [self new];
+}
+
+@end
+
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 #pragma mark -
@@ -938,6 +978,31 @@
     NSError *error = nil;
     [operation performMapping:&error];
     assertThat(error, isNot(nilValue()));
+}
+
+- (void)testShouldBeAbleToMapKeysWithDots
+{
+    RKObjectMapping *userMapping = [RKObjectMapping mappingForClass:[RKTestUser class]];
+    RKAttributeMapping *idMapping = [RKAttributeMapping attributeMappingFromKeyPath:@"id" toKeyPath:@"userID"];
+    [userMapping addPropertyMapping:idMapping];
+    RKAttributeMapping *nameMapping = [RKAttributeMapping attributeMappingFromKeyPath:@"name" toKeyPath:@"name"];
+    [userMapping addPropertyMapping:nameMapping];
+    
+    RKObjectMapping *innerMapping = [RKObjectMapping mappingForClass:[RKExampleGroupWithUser class]];
+    [innerMapping addPropertyMapping:[RKRelationshipMapping relationshipMappingFromKeyPath:@"users.current.details" toKeyPath:@"user" withMapping:userMapping]];
+     
+    RKObjectMapping *outerMapping = [RKObjectMapping mappingForClass:[RKExampleGroupWithGroup class]];
+    [outerMapping addPropertyMapping:[RKRelationshipMapping relationshipMappingFromKeyPath:@"data" toKeyPath:@"userGroup" withMapping:innerMapping]];
+    
+    id groupInfo = [RKTestFixture parsedObjectWithContentsOfFixture:@"keys_with_dots.json"];
+    RKExampleGroupWithGroup *group = [RKExampleGroupWithGroup new];
+    
+    RKMappingOperation *operation = [[RKMappingOperation alloc] initWithSourceObject:groupInfo destinationObject:group mapping:outerMapping];
+    RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
+    operation.dataSource = dataSource;
+    [operation start];
+    assertThat(group.userGroup.user.name, is(equalTo(@"Simon")));
+    assertThatInt([group.userGroup.user.userID intValue], is(equalToInt(12345)));
 }
 
 #pragma mark - Attribute Mapping

--- a/Tests/Server/server.rb
+++ b/Tests/Server/server.rb
@@ -337,6 +337,11 @@ class RestKitTestServer < Sinatra::Base
     render_fixture('/JSON/user.json', :status => 200)
   end
 
+  get '/key_with_dots' do
+    content_type 'application/json'
+    render_fixture('/JSON/key_with_dots.json', :status => 200)
+  end
+
   # start the server if ruby file executed directly
   run! if app_file == $0
 end


### PR DESCRIPTION
If we catch NSInvalidArgumentException while creating the parent object chain, assume that this is because the JSON contains a key with dots. Fixes #1532.

This only works in some situations.  Consider this JSON:

```
{
    "data": {
        "users.current.details": {
            "id": 12345,
            "name": "Simon"
        }
    },
    "success": true
}
```

We can create a mapping in which we have a representation for each level like so: (see RKObjectMappingNextGenTest.m for the class definitions)

```
RKObjectMapping *userMapping = [RKObjectMapping mappingForClass:[RKTestUser class]];
    RKAttributeMapping *idMapping = [RKAttributeMapping attributeMappingFromKeyPath:@"id" toKeyPath:@"userID"];
    [userMapping addPropertyMapping:idMapping];
    RKAttributeMapping *nameMapping = [RKAttributeMapping attributeMappingFromKeyPath:@"name" toKeyPath:@"name"];
    [userMapping addPropertyMapping:nameMapping];
    
    RKObjectMapping *innerMapping = [RKObjectMapping mappingForClass:[RKExampleGroupWithUser class]];
    [innerMapping addPropertyMapping:[RKRelationshipMapping relationshipMappingFromKeyPath:@"users.current.details" toKeyPath:@"user" withMapping:userMapping]];
     
    RKObjectMapping *outerMapping = [RKObjectMapping mappingForClass:[RKExampleGroupWithGroup class]];
    [outerMapping addPropertyMapping:[RKRelationshipMapping relationshipMappingFromKeyPath:@"data" toKeyPath:@"userGroup" withMapping:innerMapping]];
```

We can't create a mapping which does it all in one go, like so:

```
RKObjectMapping *userMapping = [RKObjectMapping mappingForClass:[RKTestUser class]];
    RKAttributeMapping *idMapping = [RKAttributeMapping attributeMappingFromKeyPath:@"data.users.current.details.id" toKeyPath:@"userID"];
    [userMapping addPropertyMapping:idMapping];
    RKAttributeMapping *nameMapping = [RKAttributeMapping attributeMappingFromKeyPath:@"data.users.current.details.name" toKeyPath:@"name"];
    [userMapping addPropertyMapping:nameMapping];
```

...but we couldn't before, so that isn't a regression.  To support that kind of mapping, we'd need to change `-[RKMappingOperation applyAttributeMappings:]` at this line:

```
id value = (attributeMapping.sourceKeyPath == nil) ? self.sourceObject : [self.sourceObject valueForKeyPath:attributeMapping.sourceKeyPath];
```

However since there isn't any way of testing whether an object has a particular KVC key other than to get its value and catch the exception, we'd have to iterate over the possibilities and the code would get quite hairy.