### PR TITLE
changed Error code when response mapping declined with `willMapDeserializedResponseBlock` block

### DIFF
--- a/Code/Network/RKResponseMapperOperation.m
+++ b/Code/Network/RKResponseMapperOperation.m
@@ -326,7 +326,7 @@ static NSMutableDictionary *RKRegisteredResponseMapperOperationDataSourceClasses
         parsedBody = self.willMapDeserializedResponseBlock(parsedBody);
         if (! parsedBody) {
             NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: @"Mapping was declined due to a `willMapDeserializedResponseBlock` returning nil." };
-            self.error = [NSError errorWithDomain:RKErrorDomain code:RKMappingErrorFromMappingResult userInfo:userInfo];
+            self.error = [NSError errorWithDomain:RKErrorDomain code:RKMappingErrorMappingDeclined userInfo:userInfo];
             RKLogError(@"Failed to parse response data: %@", [error localizedDescription]);
             [self willFinish];
             return;


### PR DESCRIPTION
According to documentation [here](http://restkit.org/api/latest/Classes/RKResponseMapperOperation.html#//api/name/setWillMapDeserializedResponseBlock:) when block returns nil mapping operation should fail with an error with the RKMappingErrorMappingDeclined code.
