### PR TITLE
Force hasOne

### DIFF
--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -888,7 +888,7 @@ static NSString *const RKRootKeyPathPrefix = @"@root.";
         }
 
         // Handle case where incoming content is an array (generally with 1 item) but we want to map to a single object
-        if (!mappingToCollection && RKObjectIsCollection(value)) {
+        if (relationshipClass && !mappingToCollection && RKObjectIsCollection(value)) {
             value = [[value objectEnumerator] nextObject];
             if (value == nil) {
                 RKLogDebug(@"Did not find object in collectoin at keyPath '%@'", relationshipMapping.sourceKeyPath);


### PR DESCRIPTION
So I came across a corner case in an API where a singular relationship is wrapped in an Array.  So a person has one address, but the api is:

person: {name: "Bill",
               addresses: [{state: "CO"}]}

In 99.9% of the cases there is only one address.  And even when there is more than one address we only want to use one of them.  That's because we want to do sort people by state so dealing with 1-to-many relationship isn't worth the trouble.

So this patch implements this - its the opposite case of forceCollection which already exists - and thus was quite simple to implment.  Hopefully it doesn't have any unintended side consequences.  I did consolidate the code that sets a relationship to nil since it was already repeated in 2 places and 3 seemed excessive.

Anyway, see what you think.
