### PR TITLE
Value Transformation Architecture

### DIFF
--- a/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
+++ b/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
@@ -36,23 +36,9 @@
 
 extern NSString * const RKObjectMappingNestingAttributeKeyName;
 
-static char kRKManagedObjectMappingOperationDataSourceAssociatedObjectKey;
+static void *RKManagedObjectMappingOperationDataSourceAssociatedObjectKey = &RKManagedObjectMappingOperationDataSourceAssociatedObjectKey;
 
-id RKTransformedValueWithClass(id value, Class destinationType, NSValueTransformer *dateToStringValueTransformer);
 NSArray *RKApplyNestingAttributeValueToMappings(NSString *attributeName, id value, NSArray *propertyMappings);
-
-// Return YES if the entity is identified by an attribute that acts as the nesting key in the source representation
-static BOOL RKEntityMappingIsIdentifiedByNestingAttribute(RKEntityMapping *entityMapping)
-{
-    for (NSAttributeDescription *attribute in [entityMapping identificationAttributes]) {
-        RKAttributeMapping *attributeMapping = [[entityMapping propertyMappingsByDestinationKeyPath] objectForKey:[attribute name]];
-        if ([attributeMapping.sourceKeyPath isEqualToString:RKObjectMappingNestingAttributeKeyName]) {
-            return YES;
-        }
-    }
-    
-    return NO;
-}
 
 static id RKValueForAttributeMappingInRepresentation(RKAttributeMapping *attributeMapping, NSDictionary *representation)
 {
@@ -81,16 +67,15 @@ static NSDictionary *RKEntityIdentificationAttributesForEntityMappingWithReprese
 {
     NSCParameterAssert(entityMapping);
     NSCAssert([representation isKindOfClass:[NSDictionary class]], @"Expected a dictionary representation");
-    
-    RKDateToStringValueTransformer *dateToStringTransformer = [[RKDateToStringValueTransformer alloc] initWithDateToStringFormatter:entityMapping.preferredDateFormatter
-                                                                                                             stringToDateFormatters:entityMapping.dateFormatters];
     NSArray *attributeMappings = entityMapping.attributeMappings;
-    
+    __block NSError *error = nil;
+
     // If the representation is mapped with a nesting attribute, we must apply the nesting value to the representation before constructing the identification attributes
     RKAttributeMapping *nestingAttributeMapping = [[entityMapping propertyMappingsBySourceKeyPath] objectForKey:RKObjectMappingNestingAttributeKeyName];
     if (nestingAttributeMapping) {
         Class attributeClass = [entityMapping classForProperty:nestingAttributeMapping.destinationKeyPath];
-        id attributeValue = RKTransformedValueWithClass([[representation allKeys] lastObject], attributeClass, dateToStringTransformer);
+        id attributeValue = nil;
+        [entityMapping.valueTransformer transformValue:[[representation allKeys] lastObject] toValue:&attributeValue ofClass:attributeClass error:&error];
         attributeMappings = RKApplyNestingAttributeValueToMappings(nestingAttributeMapping.destinationKeyPath, attributeValue, attributeMappings);
     }
     
@@ -100,7 +85,8 @@ static NSDictionary *RKEntityIdentificationAttributesForEntityMappingWithReprese
         RKAttributeMapping *attributeMapping = RKAttributeMappingForNameInMappings([attribute name], attributeMappings);
         Class attributeClass = [entityMapping classForProperty:[attribute name]];
         id sourceValue = RKValueForAttributeMappingInRepresentation(attributeMapping, representation);
-        id attributeValue = RKTransformedValueWithClass(sourceValue, attributeClass, dateToStringTransformer);
+        id attributeValue = nil;
+        if (sourceValue) [entityMapping.valueTransformer transformValue:sourceValue toValue:&attributeValue ofClass:attributeClass error:&error];
         [entityIdentifierAttributes setObject:attributeValue ?: [NSNull null] forKey:[attribute name]];
     }];
     
@@ -369,10 +355,10 @@ extern NSString * const RKObjectMappingNestingAttributeKeyName;
             RKManagedObjectDeletionOperation *deletionOperation = nil;
             if (self.parentOperation) {
                 // Attach a deletion operation for execution after the parent operation completes
-                deletionOperation = (RKManagedObjectDeletionOperation *)objc_getAssociatedObject(self.parentOperation, &kRKManagedObjectMappingOperationDataSourceAssociatedObjectKey);
+                deletionOperation = (RKManagedObjectDeletionOperation *)objc_getAssociatedObject(self.parentOperation, RKManagedObjectMappingOperationDataSourceAssociatedObjectKey);
                 if (! deletionOperation) {
                     deletionOperation = [[RKManagedObjectDeletionOperation alloc] initWithManagedObjectContext:self.managedObjectContext];
-                    objc_setAssociatedObject(self.parentOperation, &kRKManagedObjectMappingOperationDataSourceAssociatedObjectKey, deletionOperation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                    objc_setAssociatedObject(self.parentOperation, RKManagedObjectMappingOperationDataSourceAssociatedObjectKey, deletionOperation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                     [deletionOperation addDependency:self.parentOperation];
                     NSOperationQueue *operationQueue = self.operationQueue ?: [NSOperationQueue currentQueue];
                     [operationQueue addOperation:deletionOperation];
@@ -466,10 +452,12 @@ extern NSString * const RKObjectMappingNestingAttributeKeyName;
     if (! [currentValue respondsToSelector:@selector(compare:)]) return NO;
     
     RKPropertyMapping *propertyMappingForModificationKey = [[(RKEntityMapping *)mappingOperation.mapping propertyMappingsByDestinationKeyPath] objectForKey:modificationKey];
-    id rawValue = [[mappingOperation sourceObject] valueForKeyPath:propertyMappingForModificationKey.sourceKeyPath];    
-    RKDateToStringValueTransformer *transformer = [[RKDateToStringValueTransformer alloc] initWithDateToStringFormatter:entityMapping.preferredDateFormatter stringToDateFormatters:entityMapping.dateFormatters];
+    id rawValue = [[mappingOperation sourceObject] valueForKeyPath:propertyMappingForModificationKey.sourceKeyPath];
     Class attributeClass = [entityMapping classForProperty:propertyMappingForModificationKey.destinationKeyPath];
-    id transformedValue = RKTransformedValueWithClass(rawValue, attributeClass, transformer);
+
+    id transformedValue = nil;
+    NSError *error = nil;
+    [entityMapping.valueTransformer transformValue:rawValue toValue:&transformedValue ofClass:attributeClass error:&error];
     if (! transformedValue) return NO;
     
     if ([currentValue isKindOfClass:[NSString class]]) {

--- a/Code/Network/RKObjectParameterization.m
+++ b/Code/Network/RKObjectParameterization.m
@@ -28,6 +28,7 @@
 #import "RKMappingOperation.h"
 #import "RKMappingErrors.h"
 #import "RKPropertyInspector.h"
+#import "RKValueTransformers.h"
 
 // Set Logging Component
 #undef RKLogComponent
@@ -104,10 +105,7 @@
 {
     id transformedValue = nil;
     if ([value isKindOfClass:[NSDate class]]) {
-        // Date's are not natively serializable, must be encoded as a string
-        @synchronized(mapping.objectMapping.preferredDateFormatter) {
-            transformedValue = [mapping.objectMapping.preferredDateFormatter stringForObjectValue:value];
-        }
+        [mapping.objectMapping.valueTransformer transformValue:value toValue:&transformedValue ofClass:[NSString class] error:nil];
     } else if ([value isKindOfClass:[NSDecimalNumber class]]) {
         // Precision numbers are serialized as strings to work around Javascript notation limits
         transformedValue = [(NSDecimalNumber *)value stringValue];

--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -59,34 +59,6 @@ static NSString *RKLogTruncateString(NSString *string)
        (long) maxMessageLength];
 }
 
-static NSString *RKStringFromStreamStatus(NSStreamStatus streamStatus)
-{
-    switch (streamStatus) {
-        case NSStreamStatusNotOpen:     return @"Not Open";
-        case NSStreamStatusOpening:     return @"Opening";
-        case NSStreamStatusOpen:        return @"Open";
-        case NSStreamStatusReading:     return @"Reading";
-        case NSStreamStatusWriting:     return @"Writing";
-        case NSStreamStatusAtEnd:       return @"At End";
-        case NSStreamStatusClosed:      return @"Closed";
-        case NSStreamStatusError:       return @"Error";
-        default:                        break;
-    }
-    return nil;
-}
-
-static NSString *RKStringDescribingStream(NSStream *stream)
-{
-    NSString *errorDescription = ([stream streamStatus] == NSStreamStatusError) ? [NSString stringWithFormat:@", error=%@", [stream streamError]] : @"";
-    if ([stream isKindOfClass:[NSInputStream class]]) {
-        return [NSString stringWithFormat:@"<%@: %p hasBytesAvailable=%@, status='%@'%@>", [stream class], stream, [(NSInputStream *)stream hasBytesAvailable] ? @"YES" : @"NO", RKStringFromStreamStatus([stream streamStatus]), errorDescription];
-    } else if ([stream isKindOfClass:[NSOutputStream class]]) {
-        return [NSString stringWithFormat:@"<%@: %p hasSpaceAvailable=%@, status='%@'%@>", [stream class], stream, [(NSOutputStream *)stream hasSpaceAvailable] ? @"YES" : @"NO", RKStringFromStreamStatus([stream streamStatus]), errorDescription];
-    } else {
-        return [stream description];
-    }
-}
-
 @interface NSCachedURLResponse (RKLeakFix)
 
 - (NSData *)rkData;

--- a/Code/ObjectMapping.h
+++ b/Code/ObjectMapping.h
@@ -22,6 +22,7 @@
 #import "RKObjectMapping.h"
 #import "RKAttributeMapping.h"
 #import "RKRelationshipMapping.h"
+#import "RKValueTransformers.h"
 #import "RKObjectParameterization.h"
 #import "RKMappingResult.h"
 #import "RKMapperOperation.h"

--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -39,9 +39,6 @@
 
 extern NSString * const RKObjectMappingNestingAttributeKeyName;
 
-// Defined in RKObjectMapping.h
-NSDate *RKDateFromStringWithFormatters(NSString *dateString, NSArray *formatters);
-
 /**
  This function ensures that attribute mappings apply cleanly to an `NSMutableDictionary` target class to support mapping to nested keyPaths. See issue #882
  */
@@ -63,112 +60,6 @@ static BOOL RKIsManagedObject(id object)
 {
     Class managedObjectClass = NSClassFromString(@"NSManagedObject");
     return managedObjectClass && [object isKindOfClass:managedObjectClass];
-}
-
-/**
- NOTE: Because most Foundation classes are implemented as class-clusters, we cannot introspect them for mutability. Instead, we evaluate the destination type and if it is a mutable class, we return `YES` to trigger an invocation of `mutableCopy`.
- */
-static BOOL RKIsMutableTypeTransformation(id value, Class destinationType)
-{
-    if ([destinationType isEqual:[NSMutableArray class]]) return YES;
-    else if ([destinationType isEqual:[NSMutableDictionary class]]) return YES;
-    else if ([destinationType isEqual:[NSMutableString class]]) return YES;
-    else if ([destinationType isEqual:[NSMutableSet class]]) return YES;
-    else if ([destinationType isEqual:[NSMutableOrderedSet class]]) return YES;
-    else return NO;
-}
-
-id RKTransformedValueWithClass(id value, Class destinationType, NSValueTransformer *dateToStringValueTransformer);
-id RKTransformedValueWithClass(id value, Class destinationType, NSValueTransformer *dateToStringValueTransformer)
-{
-    Class sourceType = [value class];
-    
-    if ([value isKindOfClass:destinationType]) {
-        // No transformation necessary
-        return value;
-    } else if ([destinationType isSubclassOfClass:[NSDictionary class]]) {
-        return [NSMutableDictionary dictionaryWithObject:[NSMutableDictionary dictionary] forKey:value];
-    } else if (RKClassIsCollection(destinationType) && !RKObjectIsCollection(value)) {
-        // Call ourself recursively with an array value to transform as appropriate
-        return RKTransformedValueWithClass(@[ value ], destinationType, dateToStringValueTransformer);
-    } else if (RKIsMutableTypeTransformation(value, destinationType)) {
-        return [value mutableCopy];
-    } else if ([sourceType isSubclassOfClass:[NSString class]] && [destinationType isSubclassOfClass:[NSDate class]]) {
-        // String -> Date
-        return [dateToStringValueTransformer transformedValue:value];
-    } else if ([destinationType isSubclassOfClass:[NSString class]] && [value isKindOfClass:[NSDate class]]) {
-        // NSDate -> NSString
-        // Transform using the preferred date formatter
-        return [dateToStringValueTransformer reverseTransformedValue:value];
-    } else if ([destinationType isSubclassOfClass:[NSData class]]) {
-        return [NSKeyedArchiver archivedDataWithRootObject:value];
-    } else if ([sourceType isSubclassOfClass:[NSString class]]) {
-        if ([destinationType isSubclassOfClass:[NSURL class]]) {
-            // String -> URL
-            return [NSURL URLWithString:(NSString *)value];
-        } else if ([destinationType isSubclassOfClass:[NSDecimalNumber class]]) {
-            // String -> Decimal Number
-            return [NSDecimalNumber decimalNumberWithString:(NSString *)value];
-        } else if ([destinationType isSubclassOfClass:[NSNumber class]]) {
-            // String -> Number
-            NSString *lowercasedString = [(NSString *)value lowercaseString];
-            NSSet *trueStrings = [NSSet setWithObjects:@"true", @"t", @"yes", @"y", nil];
-            NSSet *booleanStrings = [trueStrings setByAddingObjectsFromSet:[NSSet setWithObjects:@"false", @"f", @"no", @"n", nil]];
-            if ([booleanStrings containsObject:lowercasedString]) {
-                // Handle booleans encoded as Strings
-                return [NSNumber numberWithBool:[trueStrings containsObject:lowercasedString]];
-            } else if ([(NSString *)value rangeOfString:@"."].location != NSNotFound) {
-                // String -> Floating Point Number
-                // Only use floating point if needed to avoid losing precision
-                // on large integers
-                return [NSNumber numberWithDouble:[(NSString *)value doubleValue]];
-            } else {
-                // String -> Signed Integer
-                return [NSNumber numberWithLongLong:[(NSString *)value longLongValue]];
-            }
-        }
-    } else if ([value isEqual:[NSNull null]]) {
-        // Transform NSNull -> nil for simplicity
-        return nil;
-    } else if ([sourceType isSubclassOfClass:[NSSet class]]) {
-        // Set -> Array
-        if ([destinationType isSubclassOfClass:[NSArray class]]) {
-            return [(NSSet *)value allObjects];
-        }
-    } else if ([sourceType isSubclassOfClass:[NSOrderedSet class]]) {
-        // OrderedSet -> Array
-        if ([destinationType isSubclassOfClass:[NSArray class]]) {
-            return [value array];
-        }
-    } else if ([sourceType isSubclassOfClass:[NSArray class]]) {
-        // Array -> Set
-        if ([destinationType isSubclassOfClass:[NSSet class]]) {
-            return [NSSet setWithArray:value];
-        }
-        // Array -> OrderedSet
-        if ([destinationType isSubclassOfClass:[NSOrderedSet class]]) {
-            return [[NSOrderedSet class] orderedSetWithArray:value];
-        }
-    } else if ([sourceType isSubclassOfClass:[NSNumber class]] && [destinationType isSubclassOfClass:[NSDate class]]) {
-        // Number -> Date
-        return [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)value doubleValue]];
-    } else if ([sourceType isSubclassOfClass:[NSNumber class]] && [destinationType isSubclassOfClass:[NSDecimalNumber class]]) {
-        // Number -> Decimal Number
-        return [NSDecimalNumber decimalNumberWithDecimal:[value decimalValue]];
-    } else if ( ([sourceType isSubclassOfClass:NSClassFromString(@"__NSCFBoolean")] ||
-                 [sourceType isSubclassOfClass:NSClassFromString(@"NSCFBoolean")] ) &&
-               [destinationType isSubclassOfClass:[NSString class]]) {
-        return ([value boolValue] ? @"true" : @"false");
-        if ([destinationType isSubclassOfClass:[NSDate class]]) {
-            return [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)value intValue]];
-        } else if (([sourceType isSubclassOfClass:NSClassFromString(@"__NSCFBoolean")] || [sourceType isSubclassOfClass:NSClassFromString(@"NSCFBoolean")]) && [destinationType isSubclassOfClass:[NSString class]]) {
-            return ([value boolValue] ? @"true" : @"false");
-        }
-    } else if ([destinationType isSubclassOfClass:[NSString class]] && [value respondsToSelector:@selector(stringValue)]) {
-        return [value stringValue];
-    }
-    
-    return nil;
 }
 
 // Returns the appropriate value for `nil` value of a primitive type
@@ -203,15 +94,6 @@ NSArray *RKApplyNestingAttributeValueToMappings(NSString *attributeName, id valu
     }
     
     return nestedMappings;
-}
-
-static void RKSetValueForObject(id value, id destinationObject)
-{
-    if ([destinationObject isKindOfClass:[NSMutableDictionary class]] && [value isKindOfClass:[NSDictionary class]]) {
-        [destinationObject setDictionary:value];
-    } else {
-        [NSException raise:NSInvalidArgumentException format:@"Unable to set value for destination object of type '%@': no strategy available. %@ to %@", [destinationObject class], value, destinationObject];
-    }
 }
 
 // Returns YES if there is a value present for at least one key path in the given collection
@@ -436,24 +318,6 @@ static NSString *const RKRootKeyPathPrefix = @"@root.";
     return [self.dataSource mappingOperation:self targetObjectForRepresentation:(NSDictionary *)sourceObject withMapping:concreteMapping inRelationship:relationshipMapping];
 }
 
-- (NSDate *)parseDateFromString:(NSString *)string
-{
-    RKLogTrace(@"Transforming string value '%@' to NSDate...", string);
-    return RKDateFromStringWithFormatters(string, self.objectMapping.dateFormatters);
-}
-
-- (id)transformValue:(id)value atKeyPath:(NSString *)keyPath toType:(Class)destinationType
-{
-    RKLogTrace(@"Found transformable value at keyPath '%@'. Transforming from type '%@' to '%@'", keyPath, NSStringFromClass([value class]), NSStringFromClass(destinationType));
-    RKDateToStringValueTransformer *transformer = [[RKDateToStringValueTransformer alloc] initWithDateToStringFormatter:self.objectMapping.preferredDateFormatter stringToDateFormatters:self.objectMapping.dateFormatters];
-    id transformedValue = RKTransformedValueWithClass(value, destinationType, transformer);        
-    if (transformedValue != value) return transformedValue;
-    
-    RKLogWarning(@"Failed transformation of value at keyPath '%@'. No strategy for transforming from '%@' to '%@'", keyPath, NSStringFromClass([value class]), NSStringFromClass(destinationType));
-
-    return nil;
-}
-
 - (BOOL)validateValue:(id *)value atKeyPath:(NSString *)keyPath
 {
     BOOL success = YES;
@@ -558,6 +422,19 @@ static NSString *const RKRootKeyPathPrefix = @"@root.";
     return [self applyNestingToMappings:self.objectMapping.relationshipMappings];
 }
 
+- (BOOL)transformValue:(id)inputValue toValue:(__autoreleasing id *)outputValue withPropertyMapping:(RKPropertyMapping *)propertyMapping error:(NSError *__autoreleasing *)error
+{
+    Class transformedValueClass = [self.objectMapping classForKeyPath:propertyMapping.destinationKeyPath];
+    if (! transformedValueClass) {
+        *outputValue = inputValue;
+        return YES;
+    }
+    RKLogTrace(@"Found transformable value at keyPath '%@'. Transforming from class '%@' to '%@'", propertyMapping.sourceKeyPath, NSStringFromClass([inputValue class]), NSStringFromClass(transformedValueClass));
+    BOOL success = [propertyMapping.valueTransformer transformValue:inputValue toValue:outputValue ofClass:transformedValueClass error:error];
+    if (! success) RKLogError(@"Failed transformation of value at keyPath '%@' to representation of type '%@': %@", propertyMapping.sourceKeyPath, transformedValueClass, *error);
+    return success;
+}
+
 - (void)applyAttributeMapping:(RKAttributeMapping *)attributeMapping withValue:(id)value
 {
     if ([self.delegate respondsToSelector:@selector(mappingOperation:didFindValue:forKeyPath:mapping:)]) {
@@ -565,17 +442,15 @@ static NSString *const RKRootKeyPathPrefix = @"@root.";
     }
     RKLogTrace(@"Mapping attribute value keyPath '%@' to '%@'", attributeMapping.sourceKeyPath, attributeMapping.destinationKeyPath);
 
-    // Inspect the property type to handle any value transformations
-    Class type = [self.objectMapping classForKeyPath:attributeMapping.destinationKeyPath];
-    if (type && NO == [[value class] isSubclassOfClass:type]) {
-        value = [self transformValue:value atKeyPath:attributeMapping.sourceKeyPath toType:type];
-    }
+    id transformedValue = nil;
+    NSError *error = nil;
+    if (! [self transformValue:value toValue:&transformedValue withPropertyMapping:attributeMapping error:&error]) return;
     
     // If we have a nil value for a primitive property, we need to coerce it into a KVC usable value or bail out
-    if (value == nil && RKPropertyInspectorIsPropertyAtKeyPathOfObjectPrimitive(attributeMapping.destinationKeyPath, self.destinationObject)) {
+    if (transformedValue == nil && RKPropertyInspectorIsPropertyAtKeyPathOfObjectPrimitive(attributeMapping.destinationKeyPath, self.destinationObject)) {
         RKLogDebug(@"Detected `nil` value transformation for primitive property at keyPath '%@'", attributeMapping.destinationKeyPath);
-        value = RKPrimitiveValueForNilValueOfClass(type);
-        if (! value) {
+        transformedValue = RKPrimitiveValueForNilValueOfClass([self.objectMapping classForKeyPath:attributeMapping.destinationKeyPath]);
+        if (! transformedValue) {
             RKLogTrace(@"Skipped mapping of attribute value from keyPath '%@ to keyPath '%@' -- Unable to transform `nil` into primitive value representation", attributeMapping.sourceKeyPath, attributeMapping.destinationKeyPath);
             return;
         }
@@ -584,21 +459,25 @@ static NSString *const RKRootKeyPathPrefix = @"@root.";
     RKSetIntermediateDictionaryValuesOnObjectForKeyPath(self.destinationObject, attributeMapping.destinationKeyPath);
     
     // Ensure that the value is different
-    if ([self shouldSetValue:&value forKeyPath:attributeMapping.destinationKeyPath usingMapping:attributeMapping]) {
-        RKLogTrace(@"Mapped attribute value from keyPath '%@' to '%@'. Value: %@", attributeMapping.sourceKeyPath, attributeMapping.destinationKeyPath, value);
+    if ([self shouldSetValue:&transformedValue forKeyPath:attributeMapping.destinationKeyPath usingMapping:attributeMapping]) {
+        RKLogTrace(@"Mapped attribute value from keyPath '%@' to '%@'. Value: %@", attributeMapping.sourceKeyPath, attributeMapping.destinationKeyPath, transformedValue);
         
         if (attributeMapping.destinationKeyPath) {
-            [self.destinationObject setValue:value forKeyPath:attributeMapping.destinationKeyPath];
+            [self.destinationObject setValue:transformedValue forKeyPath:attributeMapping.destinationKeyPath];
         } else {
-            RKSetValueForObject(value, self.destinationObject);
+            if ([self.destinationObject isKindOfClass:[NSMutableDictionary class]] && [transformedValue isKindOfClass:[NSDictionary class]]) {
+                [self.destinationObject setDictionary:transformedValue];
+            } else {
+                [NSException raise:NSInvalidArgumentException format:@"Unable to set value for destination object of type '%@': Can only directly set destination object for `NSMutableDictionary` targets. (transformedValue=%@)", [self.destinationObject class], transformedValue];
+            }
         }
         if ([self.delegate respondsToSelector:@selector(mappingOperation:didSetValue:forKeyPath:usingMapping:)]) {
-            [self.delegate mappingOperation:self didSetValue:value forKeyPath:attributeMapping.destinationKeyPath usingMapping:attributeMapping];
+            [self.delegate mappingOperation:self didSetValue:transformedValue forKeyPath:attributeMapping.destinationKeyPath usingMapping:attributeMapping];
         }
     } else {
-        RKLogTrace(@"Skipped mapping of attribute value from keyPath '%@ to keyPath '%@' -- value is unchanged (%@)", attributeMapping.sourceKeyPath, attributeMapping.destinationKeyPath, value);
+        RKLogTrace(@"Skipped mapping of attribute value from keyPath '%@ to keyPath '%@' -- value is unchanged (%@)", attributeMapping.sourceKeyPath, attributeMapping.destinationKeyPath, transformedValue);
         if ([self.delegate respondsToSelector:@selector(mappingOperation:didNotSetUnchangedValue:forKeyPath:usingMapping:)]) {
-            [self.delegate mappingOperation:self didNotSetUnchangedValue:value forKeyPath:attributeMapping.destinationKeyPath usingMapping:attributeMapping];
+            [self.delegate mappingOperation:self didNotSetUnchangedValue:transformedValue forKeyPath:attributeMapping.destinationKeyPath usingMapping:attributeMapping];
         }
     }
     [self.mappingInfo addPropertyMapping:attributeMapping];
@@ -764,7 +643,9 @@ static NSString *const RKRootKeyPathPrefix = @"@root.";
     if (relationshipMapping.assignmentPolicy == RKUnionAssignmentPolicy) {
         RKLogDebug(@"Mapping relationship with union assignment policy: constructing combined relationship value.");
         id existingObjects = [self.destinationObject valueForKeyPath:relationshipMapping.destinationKeyPath] ?: @[];
-        NSArray *existingObjectsArray = RKTransformedValueWithClass(existingObjects, [NSArray class], nil);
+        NSArray *existingObjectsArray = nil;
+        NSError *error = nil;
+        [[RKValueTransformer defaultValueTransformer] transformValue:existingObjects toValue:&existingObjectsArray ofClass:[NSArray class] error:&error];
         [relationshipCollection addObjectsFromArray:existingObjectsArray];
     }
     else if (relationshipMapping.assignmentPolicy == RKReplaceAssignmentPolicy) {
@@ -774,7 +655,6 @@ static NSString *const RKRootKeyPathPrefix = @"@root.";
     }
 
     [value enumerateObjectsUsingBlock:^(id nestedObject, NSUInteger collectionIndex, BOOL *stop) {
-
         id parentSourceObject = [self parentObjectForRelationshipMapping:relationshipMapping];
         id mappableObject = [self destinationObjectForMappingRepresentation:nestedObject parentRepresentation:parentSourceObject withMapping:relationshipMapping.mapping inRelationship:relationshipMapping];
         if (mappableObject) {
@@ -786,12 +666,9 @@ static NSString *const RKRootKeyPathPrefix = @"@root.";
         }
     }];
 
-    id valueForRelationship = relationshipCollection;
-    // Transform from NSSet <-> NSArray if necessary
-    Class type = [self.objectMapping classForKeyPath:relationshipMapping.destinationKeyPath];
-    if (type && NO == [[relationshipCollection class] isSubclassOfClass:type]) {
-        valueForRelationship = [self transformValue:relationshipCollection atKeyPath:relationshipMapping.sourceKeyPath toType:type];
-    }
+    id valueForRelationship = nil;
+    NSError *error = nil;
+    if (! [self transformValue:relationshipCollection toValue:&valueForRelationship withPropertyMapping:relationshipMapping error:&error]) return NO;
 
     // If the relationship has changed, set it
     if ([self shouldSetValue:&valueForRelationship forKeyPath:relationshipMapping.destinationKeyPath usingMapping:relationshipMapping]) {

--- a/Code/ObjectMapping/RKObjectMapping.h
+++ b/Code/ObjectMapping/RKObjectMapping.h
@@ -22,6 +22,7 @@
 #import "RKMapping.h"
 
 @class RKPropertyMapping, RKAttributeMapping, RKRelationshipMapping;
+@protocol RKValueTransforming;
 
 /**
  An `RKObjectMapping` object describes a transformation between object represenations using key-value coding and run-time type introspection. The mapping is defined in terms of a source object class and a collection of `RKPropertyMapping` objects describing how key paths in the source representation should be transformed into attributes and relationships on the target object. Object mappings are provided to instances of `RKMapperOperation` and `RKMappingOperation` to perform the transformations they describe.
@@ -31,7 +32,7 @@
  1. `RKAttributeMapping`: An attribute mapping describes a transformation between a single value from a source key path to a destination key path. The value to be mapped is read from the source object representation using `valueForKeyPath:` and then set to the destination key path using `setValueForKeyPath:`. Before the value is set, the `RKObjecMappingOperation` performing the mapping performs runtime introspection on the destination property to determine what, if any, type transformation is to be performed. Typical type transformations include reading an `NSString` value representation and mapping it to an `NSDecimalNumber` destination key path or reading an `NSString` and transforming it into an `NSDate` value before assigning to the destination.
  1. `RKRelationshipMapping`: A relationship mapping describes a transformation between a nested child object or objects from a source key path to a destination key path using another `RKObjectMapping`. The child objects to be mapped are read from the source object representation using `valueForKeyPath:`, then mapped recursively using the object mapping associated with the relationship mapping, and then finally assigned to the destination key path. Before assignment to the destination key path runtime type introspection is performed to determine if any type transformation is necessary. For relationship mappings, common type transformations include transforming a single object value in an `NSArray` or transforming an `NSArray` of object values into an `NSSet`.
 
- All type transformations available are discussed in detail in the documentation for `RKMappingOperation`.
+ All type transformations available are discussed in detail in the documentation for `RKValueTransformer`.
  
  ## Transforming Representation to Property Keys
  
@@ -295,6 +296,11 @@
 @property (nonatomic, assign) BOOL performKeyValueValidation;
 
 /**
+ A value transformer with which to process input values being mapped with the receiver. Defaults to a copy of `[RKValueTransformer defaultTransformer]`.
+ */
+@property (nonatomic, strong) id<RKValueTransforming> valueTransformer;
+
+/**
  Returns the default value to be assigned to the specified attribute when it is missing from a mappable payload.
 
  The default implementation returns nil for transient object mappings. On an entity mapping, the default value returned from the Entity definition will be used.
@@ -302,28 +308,6 @@
  @see `[RKEntityMapping defaultValueForAttribute:]`
  */
 - (id)defaultValueForAttribute:(NSString *)attributeName;
-
-///----------------------------------
-/// @name Configuring Date Formatters
-///----------------------------------
-
-/**
- An array of `NSFormatter` objects to use when mapping string values into `NSDate` attributes on the target `objectClass`. Each date formatter will be invoked with the string value being mapped until one of the date formatters does not return nil.
-
- Defaults to the application-wide collection of date formatters configured via `[RKObjectMapping setDefaultDateFormatters:]`
-
- @see `[RKObjectMapping defaultDateFormatters]`
- */
-@property (nonatomic, strong) NSArray *dateFormatters;
-
-/**
- The `NSFormatter` object for your application's preferred date and time configuration. This date formatter will be used when generating string representations of NSDate attributes (i.e. during serialization to URL form encoded or JSON format).
-
- Defaults to the application-wide preferred date formatter configured via: `[RKObjectMapping setPreferredDateFormatter:]`
-
- @see `[RKObjectMapping preferredDateFormatter]`
- */
-@property (nonatomic, strong) NSFormatter *preferredDateFormatter;
 
 ///----------------------------------
 /// @name Generating Inverse Mappings
@@ -376,11 +360,19 @@
 /////////////////////////////////////////////////////////////////////////////
 
 /**
+ **Deprecated in v0.21.0**
+ 
+ This category contains deprecated API interfaces for configuring date formatters. Starting in RestKit 0.20.4 date formatting is configured via the `RKValueTransformer` API's.
+
  Defines the interface for configuring time and date formatting handling within RestKit object mappings. For performance reasons, RestKit reuses a pool of date formatters rather than constructing them at mapping time. This collection of date formatters can be configured on a per-object mapping or application-wide basis using the static methods exposed in this category.
  */
-@interface RKObjectMapping (DateAndTimeFormatting)
+@interface RKObjectMapping (LegacyDateAndTimeFormatting)
 
 /**
+ **Deprecated in v0.21.0**
+ 
+ This method accesses `[RKValueTransformer defaultTransformer]` and returns all `NSDate` <-> `NSString` value transformers.
+
  Returns the collection of default date formatters that will be used for all object mappings that have not been configured specifically.
 
  Out of the box, RestKit initializes default date formatters for you in the UTC time zone with the following format strings:
@@ -390,34 +382,50 @@
 
  @return An array of `NSFormatter` objects used when mapping strings into NSDate attributes
  */
-+ (NSArray *)defaultDateFormatters;
++ (NSArray *)defaultDateFormatters DEPRECATED_ATTRIBUTE_MESSAGE("Configure `[RKValueTransformer defaultValueTransformer]` instead");
 
 /**
+ **Deprecated in v0.21.0**
+ 
+ This method accesses `[RKValueTransformer defaultTransformer]` and removes all `NSDate` <-> `NSString` value transformers that are instances of `NSFormatter` and then adds the given array of formatters to the default transformer.
+
  Sets the collection of default date formatters to the specified array. The array should contain configured instances of NSDateFormatter in the order in which you want them applied during object mapping operations.
 
  @param dateFormatters An array of date formatters to replace the existing defaults.
  @see `defaultDateFormatters`
  */
-+ (void)setDefaultDateFormatters:(NSArray *)dateFormatters;
++ (void)setDefaultDateFormatters:(NSArray *)dateFormatters DEPRECATED_ATTRIBUTE_MESSAGE("Configure `[RKValueTransformer defaultValueTransformer]` instead");
 
 /**
+ **Deprecated in v0.21.0**
+ 
+ This methods prepends the given date formatter to `[RKValueTransformer defaultValueTransformer]`.
+
  Adds a date formatter instance to the default collection
 
  @param dateFormatter An `NSFormatter` object to prepend to the default formatters collection
  @see `defaultDateFormatters`
  */
-+ (void)addDefaultDateFormatter:(NSFormatter *)dateFormatter;
++ (void)addDefaultDateFormatter:(NSFormatter *)dateFormatter DEPRECATED_ATTRIBUTE_MESSAGE("Configure `[RKValueTransformer defaultValueTransformer]` instead");
 
 /**
+ **Deprecated in v0.21.0**
+ 
+ This method instantiates a new `NSDateFormatter` object with the given format string and time zone and prepends it to `[RKValueTransformer defaultValueTransformer]`.
+
  Convenience method for quickly constructing a date formatter and adding it to the collection of default date formatters. The locale is auto-configured to `en_US_POSIX`.
 
  @param dateFormatString The dateFormat string to assign to the newly constructed `NSDateFormatter` instance
  @param nilOrTimeZone The NSTimeZone object to configure on the `NSDateFormatter` instance. Defaults to UTC time.
  @see `NSDateFormatter`
  */
-+ (void)addDefaultDateFormatterForString:(NSString *)dateFormatString inTimeZone:(NSTimeZone *)nilOrTimeZone;
++ (void)addDefaultDateFormatterForString:(NSString *)dateFormatString inTimeZone:(NSTimeZone *)nilOrTimeZone  DEPRECATED_ATTRIBUTE_MESSAGE("Configure `[RKValueTransformer defaultValueTransformer]` instead");
 
 /**
+ **Deprecated in v0.21.0**
+ 
+ This method returns the first `NSString` -> `NSDate` value transformer that is an instance of `NSFormatter` in `[RKValueTransformer defaultValueTransformer]`.
+
  Returns the preferred date formatter to use when generating NSString representations from NSDate attributes. This type of transformation occurs when RestKit is mapping local objects into JSON or form encoded serializations that do not have a native time construct.
 
  Defaults to an instance of the `RKISO8601DateFormatter` configured with the UTC time-zone. The format string is equal to "yyyy-MM-DDThh:mm:ssTZD"
@@ -426,39 +434,43 @@
 
  @return The preferred NSFormatter object to use when serializing dates into strings
  */
-+ (NSFormatter *)preferredDateFormatter;
++ (NSFormatter *)preferredDateFormatter DEPRECATED_ATTRIBUTE_MESSAGE("Access `[RKValueTransformer defaultValueTransformer]` instead");
 
 /**
+ **Deprecated in v0.21.0**
+ 
+ This method inserts the given date formatter at position zero in `[RKValueTransformer defaultValueTransformer]`, ensuring that it will be used for all transformations from `NSDate` -> `NSString`.
+
  Sets the preferred date formatter to use when generating NSString representations from NSDate attributes. This type of transformation occurs when RestKit is mapping local objects into JSON or form encoded serializations that do not have a native time construct.
 
  @param dateFormatter The NSFormatter object to designate as the new preferred instance
  */
-+ (void)setPreferredDateFormatter:(NSFormatter *)dateFormatter;
++ (void)setPreferredDateFormatter:(NSFormatter *)dateFormatter DEPRECATED_ATTRIBUTE_MESSAGE("Configure `[RKValueTransformer defaultValueTransformer]` instead");
+
+///----------------------------------
+/// @name Configuring Date Formatters
+///----------------------------------
+
+/**
+ **Deprecated in v0.21.0**
+ 
+ An array of `NSFormatter` objects to use when mapping string values into `NSDate` attributes on the target `objectClass`. Each date formatter will be invoked with the string value being mapped until one of the date formatters does not return nil.
+
+ Defaults to the application-wide collection of date formatters configured via `[RKObjectMapping setDefaultDateFormatters:]`
+
+ @see `[RKObjectMapping defaultDateFormatters]`
+ */
+@property (nonatomic, strong) NSArray *dateFormatters DEPRECATED_ATTRIBUTE_MESSAGE("Use `valueTransformer` instead");
+
+/**
+ **Deprecated in v0.21.0**
+
+ The `NSFormatter` object for your application's preferred date and time configuration. This date formatter will be used when generating string representations of NSDate attributes (i.e. during serialization to URL form encoded or JSON format).
+
+ Defaults to the application-wide preferred date formatter configured via: `[RKObjectMapping setPreferredDateFormatter:]`
+
+ @see `[RKObjectMapping preferredDateFormatter]`
+ */
+@property (nonatomic, strong) NSFormatter *preferredDateFormatter  DEPRECATED_ATTRIBUTE_MESSAGE("Use `valueTransformer` instead");
 
 @end
-
-///----------------
-/// @name Functions
-///----------------
-
-/**
- Returns an date representation of a given string value by attempting to parse the string with all default date formatters in turn.
-
- @param dateString A string object encoding a date value.
- @return An `NSDate` object parsed from the given string, or `nil` if the string was found to be unparsable by all default date formatters.
- @see [RKObjectMapping defaultDateFormatters]
- */
-NSDate *RKDateFromString(NSString *dateString);
-
-/**
- Returns a string representation of a given date formatted with the preferred date formatter.
-
- This is a convenience function that is equivalent to the following example code:
-
-    NSString *string = [[RKObjectMapping preferredDateFormatter] stringForObjectValue:date]
-
- @param date The date object to be formatted.
- @return An `NSString` object representation of the given date formatted by the preferred date formatter.
- @see [RKObjectMapping preferredDateFormatter]
- */
-NSString *RKStringFromDate(NSDate *date);

--- a/Code/ObjectMapping/RKPropertyMapping.h
+++ b/Code/ObjectMapping/RKPropertyMapping.h
@@ -21,6 +21,7 @@
 #import <Foundation/Foundation.h>
 
 @class RKObjectMapping;
+@protocol RKValueTransforming;
 
 /**
  `RKPropertyMapping` is an abstract class for describing the properties being mapped within an `RKObjectMapping` or `RKEntityMapping` object. It defines the common interface for its concrete subclasses `RKAttributeMapping` and `RKRelationshipMapping`. Each property mapping defines a single transformation from a source key path (often in the deserialized representation of a JSON or XML document) to a destination key path (typically on a target object).
@@ -49,6 +50,15 @@
  A key path on the destination object on which to set information that has been mapped from the source object.
  */
 @property (nonatomic, copy, readonly) NSString *destinationKeyPath;
+
+///-------------------------------------
+/// @name Specifying a Value Transformer
+///-------------------------------------
+
+/**
+ A value transformer with which to process input values being mapped with the receiver. If `nil`, then the `valueTransformer` of the parent `objectMapping` will be used instead.
+ */
+@property (nonatomic, strong) id<RKValueTransforming> valueTransformer;
 
 ///----------------------------------
 /// @name Comparing Property Mappings

--- a/Code/ObjectMapping/RKPropertyMapping.m
+++ b/Code/ObjectMapping/RKPropertyMapping.m
@@ -19,6 +19,7 @@
 //
 
 #import "RKPropertyMapping.h"
+#import "RKObjectMapping.h"
 
 @interface RKPropertyMapping ()
 // Synthesize as read/write to allow assignment in `RKObjectMapping`
@@ -47,6 +48,11 @@
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"<%@: %p %@ => %@>", self.class, self, self.sourceKeyPath, self.destinationKeyPath];
+}
+
+- (id<RKValueTransforming>)valueTransformer
+{
+    return _valueTransformer ?: [self.objectMapping valueTransformer];
 }
 
 @end

--- a/Code/ObjectMapping/RKValueTransformers.h
+++ b/Code/ObjectMapping/RKValueTransformers.h
@@ -2,17 +2,372 @@
 //  RKValueTransformers.h
 //  RestKit
 //
-//  Created by Blake Watters on 11/26/12.
-//  Copyright (c) 2012 RestKit. All rights reserved.
+//  Created by Blake Watters on 8/18/13.
+//  Copyright (c) 2013 RestKit. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>
+#import "RKISO8601DateFormatter.h"
 
-@interface RKDateToStringValueTransformer : NSValueTransformer
+/**
+ Objects wish to perform transformation on values as part of a RestKit object mapping operation much adopt the `RKValueTransforming` protocol. Value transformers must introspect a given input value to determine if they are capable of performing a transformation and if so, perform the transformation and assign the new value to the given pointer to an output value and return `YES` or else construct an error describing the failure and return `NO`. Value transformers may also optionally implement a validation method that enables callers to determine if a given value transformer object is capable of performing a transformation on an input value.
+ */
+@protocol RKValueTransforming <NSObject>
 
-@property (nonatomic, copy) NSFormatter *dateToStringFormatter;
-@property (nonatomic, copy) NSArray *stringToDateFormatters;
+@required
 
-- (id)initWithDateToStringFormatter:(NSFormatter *)dateToStringFormatter stringToDateFormatters:(NSArray *)stringToDateFormatters;
+/**
+ Transforms a given value into a new representation.
+ 
+ Attempts to perform a transformation of a given value into a new representation and returns a Boolean value indicating if the transformation was successful. Transformers are responsible for introspecting their input values before attempting to perform the transformation. If the transformation cannot be performed, then the transformer must construct an `NSError` object describing the nature of the failure else a warning will be emitted.
+ 
+ @param inputValue The value to be transformed.
+ @param outputValue A pointer to an `id` object that will be assigned to the transformed representation. May be assigned to `nil` if that is the result of the transformation.
+ @param outputValueClass The class of the `outputValue` variable. Specifies the expected type of a successful transformation. May be `nil` to indicate that the type is unknown or unimportant.
+ @param error A pointer to an `NSError` object that must be assigned to a newly constructed `NSError` object if the transformation cannot be performed.
+ @return A Boolean value indicating if the transformation was successful. This is used to determine whether another transformer should be given an opportunity to attempt a transformation.
+ */
+- (BOOL)transformValue:(id)inputValue toValue:(id *)outputValue ofClass:(Class)outputValueClass error:(NSError **)error;
+
+@optional
+
+/**
+ Asks the transformer if it is capable of performing a transformation from a given class into a new representation of another given class. 
+ 
+ This is an optional method that need only be implemented by transformers that are tightly bound to values with specific types.
+ 
+ @param inputValueClass The `Class` of an input value being inspected.
+ @param outputValueClass The `Class` of an output value being inspected.
+ @return `YES` if the receiver can perform a transformation between the given source and destination classes.
+ */
+- (BOOL)validateTransformationFromClass:(Class)inputValueClass toClass:(Class)outputValueClass;
 
 @end
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+typedef NS_ENUM(NSUInteger, RKValueTransformationError) {
+    RKValueTransformationErrorUntransformableInputValue     = 3000,     // The input value was determined to be unacceptable and no transformation was performed.
+    RKValueTransformationErrorUnsupportedOutputClass        = 3001,     // The specified class type for the output value is unsupported and no transformation was performed.
+    RKValueTransformationErrorTransformationFailed          = 3002      // A transformation was attempted, but failed.
+};
+
+/**
+ Tests if a given input value is of an expected class and returns a failure if it is not.
+ 
+ This macro is useful for quickly verifying that a transformer can work with a given input value by checking if the value is an instance of an expected class. On failure, the macro constructs an error describing the class mismatch.
+ 
+ @param inputValue The input value to test.
+ @param expectedClass The expected class or array of classes of the input value.
+ @param error A pointer to an `NSError` object in which to assign a newly constructed error if the test fails. Cannot be `nil`.
+ */
+#define RKValueTransformerTestInputValueIsKindOfClass(inputValue, expectedClass, error) ({ \
+    NSArray *supportedClasses = [expectedClass isKindOfClass:[NSArray class]] ? (NSArray *)expectedClass : @[ expectedClass ];\
+    BOOL success = NO; \
+    for (Class supportedClass in supportedClasses) {\
+        if ([inputValue isKindOfClass:supportedClass]) { \
+            success = YES; \
+            break; \
+        }; \
+    } \
+    if (! success) { \
+        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected an `inputValue` of type `%@`, but got a `%@`.", expectedClass, [inputValue class]] };\
+        if (error) *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorUntransformableInputValue userInfo:userInfo]; \
+        return NO; \
+    } \
+})
+
+/**
+ Tests if a given output value class is of an expected class and returns a failure if it is not.
+ 
+ This macro is useful for quickly verifying that a transformer can work with a given input value by checking if the value is an instance of an expected class. On failure, the macro constructs an error describing the class mismatch.
+ 
+ @param outputValueClass The input value to test.
+ @param expectedClass The expected class or array of classes of the input value.
+ @param error A pointer to an `NSError` object in which to assign a newly constructed error if the test fails. Cannot be `nil`.
+ */
+#define RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, expectedClass, error) ({ \
+NSArray *supportedClasses = [expectedClass isKindOfClass:[NSArray class]] ? (NSArray *)expectedClass : @[ expectedClass ];\
+BOOL success = NO; \
+for (Class supportedClass in supportedClasses) {\
+if ([outputValueClass isSubclassOfClass:supportedClass]) { \
+success = YES; \
+break; \
+}; \
+} \
+if (! success) { \
+NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected an `outputValueClass` of type `%@`, but got a `%@`.", expectedClass, outputValueClass] };\
+if (error) *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorUnsupportedOutputClass userInfo:userInfo]; \
+return NO; \
+} \
+})
+
+/**
+ Tests a condition to evaluate the success of an attempted value transformation and returns a failure if it is not true.
+ 
+ This macro is useful for quickly verifying that an attempted transformation was successful. If the condition is not true, than an error is constructed describing the failure.
+ 
+ @param condition The condition to test.
+ @param expectedClass The expected class of the input value.
+ @param error A pointer to an `NSError` object in which to assign a newly constructed error if the test fails. Cannot be `nil`.
+ @param ... A string describing what the failure was that occurred. This may be a format string with additional arguments.
+ */
+#define RKValueTransformerTestTransformation(condition, error, ...) ({ \
+if (! (condition)) { \
+NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:__VA_ARGS__] };\
+if (error) *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorTransformationFailed userInfo:userInfo]; \
+return NO; \
+} \
+})
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@class RKCompoundValueTransformer;
+
+/**
+ The `RKValueTransformer` class is an abstract base class for implementing a value transformer that conforms to the `RKValueTransforming` protocol. The class is provided to enable third-party extensions of the value transformer to be implemented through subclassing. The default implementation contains no behavior and will raise an exception if an implementation of `transformValue:toValue:ofClass:error:` is not provided by the subclass. `RKValueTransformer` also exposes accessors for the default value transformer implementations that are provided with RestKit.
+ */
+@interface RKValueTransformer : NSObject <RKValueTransforming>
+
+///--------------------------------------
+/// @name Retrieving Default Transformers
+///--------------------------------------
+
+/**
+ Returns a transformer that will return the input value if it is already of the desired output class.
+ */
++ (instancetype)identityValueTransformer;
+
+/**
+ Returns a transformer capable of transforming between `NSString` and `NSURL` representations.
+ */
++ (instancetype)stringToURLValueTransformer;
+
+/**
+ Returns a transformer capable of transforming between `NSNumber` and `NSURL` representations.
+ */
++ (instancetype)numberToStringValueTransformer;
+
+/**
+ Returns a transformer capable of transforming between `NSArray` and `NSOrderedSet` representations.
+ */
++ (instancetype)arrayToOrderedSetValueTransformer;
+
+/**
+ Returns a transformer capable of transforming between `NSArray` and `NSSet` representations.
+ */
++ (instancetype)arrayToSetValueTransformer;
+
+/**
+ Returns a transformer capable of transforming between `NSDecimalNumber` and `NSNumber` representations.
+ */
++ (instancetype)decimalNumberToNumberValueTransformer;
+
+/**
+ Returns a transformer capable of transforming between `NSDecimalNumber` and `NSString` representations.
+ */
++ (instancetype)decimalNumberToStringValueTransformer;
+
+/**
+ Returns a transformer capable of transforming from `[NSNull null]` to `nil` representations.
+ */
++ (instancetype)nullValueTransformer;
+
+/**
+ Returns a transformer capable of transforming between objects that conform to the `NSCoding` protocol and `NSData` representations by using an `NSKeyedArchiver`/`NSKeyedUnarchiver` to serialize as a property list.
+ */
++ (instancetype)keyedArchivingValueTransformer;
+
+/**
+ Returns a transformer capable of transforming between `NSNumber` or `NSString` and `NSDate` representations by evaluating the input value as a time interval since the UNIX epoch (1 January 1970, GMT).
+
+ The transformation treats numeric values as a `double` in order to provide sub-second accuracy.
+ */
++ (instancetype)timeIntervalSince1970ToDateValueTransformer;
+
+/**
+ Returns a transformer capable of transforming any `NSObject` that implements the `stringValue` method into an `NSString` representation.
+ */
++ (instancetype)stringValueTransformer;
+
+/**
+ Returns a transformer capable of enclosing any singular `NSObject` into a collection type such as `NSArray`, `NSSet`, or `NSOrderedSet` (and its mutable descendents).
+ */
++ (instancetype)objectToCollectionValueTransformer;
+
+/**
+ Returns a transformer capable of transforming any object that conforms to the `NSCopying` protocol into a dictionary representation keyed by the transformed object.
+ */
++ (instancetype)keyOfDictionaryValueTransformer;
+
+/**
+ Returns a transformer capable of transforming any object conforming to the `NSMutableCopying` protocol into a mutable representation of itself.
+ */
++ (instancetype)mutableValueTransformer;
+
+/**
+ Returns the singleton instance of the default value transformer. The default transformer is a compound transformer that includes all the individual value transformers implemented on the `RKValueTransformer` base class as well as an instance of `RKISO8601DateForamtter` and `NSDateFormatter` instances for the following date format strings:
+ 
+    * MM/dd/yyyy
+    * yyyy-MM-dd'T'HH:mm:ss'Z'
+    * yyyy-MM-dd
+ 
+ All date formatters are configured to the use `en_US_POSIX` locale and the UTC time zone.
+ */
++ (RKCompoundValueTransformer *)defaultValueTransformer;
+
+/**
+ Sets the default value transformer to a new instance. Setting the default transformer to `nil` will result in a new singleton instance with the default configuration being rebuilt.
+
+ @param compoundValueTransformer The new default compound transformer. Passing `nil` will reset the transformer to the default configuration.
+ */
++ (void)setDefaultValueTransformer:(RKCompoundValueTransformer *)compoundValueTransformer;
+
+@end
+
+/**
+ The `RKBlockValueTransformer` class provides a concrete implementation of the `RKValueTransforming` protocol using blocks to provide the implementation of the transformer.
+ */
+@interface RKBlockValueTransformer : RKValueTransformer
+
+///-----------------------------------
+/// @name Creating a Block Transformer
+///-----------------------------------
+
+/**
+ Creates and returns a new value transformer with the given validation and transformation blocks. The blocks are used to provide the implementation of the corresponding methods from the `RKValueTransforming` protocol.
+ 
+ @param validationBlock A block that evaluates whether the transformer can perform a transformation between a given pair of input and output classes.
+ */
++ (instancetype)valueTransformerWithValidationBlock:(BOOL (^)(Class inputValueClass, Class outputValueClass))validationBlock
+                                transformationBlock:(BOOL (^)(id inputValue, id *outputValue, Class outputClass, NSError **error))transformationBlock;
+
+/**
+ An optional name for the transformer.
+ */
+@property (nonatomic, copy) NSString *name;
+
+@end
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ The `RKCompoundValueTransformer` class provides an implementation of the `RKValueTransforming` protocol in which a collection of underlying value transformers are assembled into a composite value transformer. Compound values transformers are ordered collections in which each underlying transformer is given the opportunity to transform a value in the order in which it appears within the receiver. Compound transformers are copyable, enumerable and support subscripted access to the underlying value transformers.
+ */
+@interface RKCompoundValueTransformer : NSObject <RKValueTransforming, NSCopying, NSFastEnumeration>
+
+///--------------------------------------
+/// @name Creating a Compound Transformer
+///--------------------------------------
+
+/**
+ Creates and returns a new compound transformer from an array of individual value transformers.
+ 
+ @param valueTransformers An array containining an arbitrary number of objects that conform to the `RKValueTransforming` protocol. Cannot be `nil`.
+ @return A new compound transformer initialized with the given collection of underlying transformers.
+ @raises NSInvalidArgumentException Raised if `valueTransformers` is `nil` or any objects in the given collection do not conform to the `RKValueTransforming` protocol.
+ */
++ (instancetype)compoundValueTransformerWithValueTransformers:(NSArray *)valueTransformers;
+
+///----------------------------------------------------
+/// @name Manipulating the Value Transformer Collection
+///----------------------------------------------------
+
+/**
+ Adds the given value transformer to the end of the receiver's transformer collection.
+ 
+ Adding a transformer appends it to the end of the collection meaning that it will be consulted after all other transformers.
+ 
+ @param valueTransformer The transformer to add to the receiver.
+ */
+- (void)addValueTransformer:(id<RKValueTransforming>)valueTransformer;
+
+/**
+ Removes the given value transformer from the receiver.
+
+ @param valueTransformer The transformer to remove from the receiver.
+ */
+- (void)removeValueTransformer:(id<RKValueTransforming>)valueTransformer;
+
+/**
+ Inserts the given value transformer into the receiver at a specific position. If the transformer already exists within the receiver then it is moved to the specified position.
+ 
+ @param valueTransformer The value transformer to be added to (or moved within) the receiver.
+ @param index The position at which the transformer should be consulted within the collection. An index of 0 would mean that the transformer is consulted before all other transformers.
+ */
+- (void)insertValueTransformer:(id<RKValueTransforming>)valueTransformer atIndex:(NSUInteger)index;
+
+/**
+ Returns a count of the number of value transformers in the receiver.
+ 
+ @return An integer specifying the number of transformers within the receiver.
+ */
+- (NSUInteger)numberOfValueTransformers;
+
+///------------------------------------------
+/// @name Retrieving Constituent Transformers
+///------------------------------------------
+
+/**
+ Returns a new array containing a subset of the value transformers contained within the receiver that are valid for a transformation between a representation with a given input class and a given output class. 
+ 
+ Whether or not a given transformer is returned is determined by the invocation of the optional `RKValueTransforming` method `validateTransformationFromClass:toClass:`. Any transformer that does not respond to `validateTransformationFromClass:toClass:` will be included within the returned array. The sequencing of the transformers within the returned array is determined by their position within the receiver.
+ 
+ If you wish to obtain an array containing all of the transformers contained within the receiver then pass `Nil` for both the `inputValueClass` and `outputValueClass` arguments.
+
+ @param inputValueClass The class of input values that you wish to retrieve the transformers for. Can only be `Nil` if `outputValueClass` is also `Nil`.
+ @param outputValueClass The class of output values that you wish to retrieve the transformers for. Can only be `Nil` if `inputValueClass` is also `Nil`.
+ @raises NSInvalidArgumentException Raised if `Nil` is given exclusively for `inputValueClass` or `outputValueClass`.
+ */
+- (NSArray *)valueTransformersForTransformingFromClass:(Class)inputValueClass toClass:(Class)outputValueClass;
+
+@end
+
+// Adopts `RKValueTransforming` to provide transformation from `NSString` <-> `NSNumber`
+@interface NSNumberFormatter (RKValueTransformers) <RKValueTransforming>
+@end
+
+// Adopts `RKValueTransforming` to provide transformation from `NSString` <-> `NSDate`
+@interface NSDateFormatter (RKValueTransformers) <RKValueTransforming>
+@end
+
+@interface RKISO8601DateFormatter (RKValueTransformers) <RKValueTransforming>
+@end
+
+///----------------
+/// @name Functions
+///----------------
+
+/**
+ Returns an date representation of a given string value by attempting to parse the string with all default date formatters in turn.
+
+ @param dateString A string object encoding a date value.
+ @return An `NSDate` object parsed from the given string, or `nil` if the string was found to be unparsable by all default date formatters.
+ @see [RKObjectMapping defaultDateFormatters]
+ */
+NSDate *RKDateFromString(NSString *dateString);
+
+/**
+ Returns a string representation of a given date formatted with the preferred date formatter.
+
+ This is a convenience function that is equivalent to the following example code:
+
+ NSString *string = [[RKObjectMapping preferredDateFormatter] stringForObjectValue:date]
+
+ @param date The date object to be formatted.
+ @return An `NSString` object representation of the given date formatted by the preferred date formatter.
+ @see [RKObjectMapping preferredDateFormatter]
+ */
+NSString *RKStringFromDate(NSDate *date);

--- a/Code/ObjectMapping/RKValueTransformers.m
+++ b/Code/ObjectMapping/RKValueTransformers.m
@@ -2,52 +2,692 @@
 //  RKValueTransformers.m
 //  RestKit
 //
-//  Created by Blake Watters on 11/26/12.
+//  Created by Blake Watters on 8/18/13.
 //  Copyright (c) 2012 RestKit. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "RKValueTransformers.h"
 #import "RKMacros.h"
+#import "RKLog.h"
+#import "RKErrors.h"
+#import "RKObjectUtilities.h"
 
-// Implementation lives in RKObjectMapping.m at the moment
-NSDate *RKDateFromStringWithFormatters(NSString *dateString, NSArray *formatters);
+@implementation RKValueTransformer
 
-@implementation RKDateToStringValueTransformer
-
-+ (Class)transformedValueClass
+- (id)init
 {
-    return [NSDate class];
+    if ([self class] == [RKValueTransformer class]) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                       reason:[NSString stringWithFormat:@"`%@` is abstract and cannot be directly instantiated. "
+                                               @"Instantiate a subclass implementation instead.",
+                                               NSStringFromClass([self class])]
+                                     userInfo:nil];
+    }
+    return [super init];
 }
 
-+ (BOOL)allowsReverseTransformation
+#pragma mark RKValueTransforming
+
+- (BOOL)transformValue:(id)inputValue toValue:(__autoreleasing id *)outputValue ofClass:(Class)outputValueClass error:(NSError *__autoreleasing *)error
 {
-    return YES;
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"`RKValueTransformer` subclasses must provide a concrete implementation of `%@`.",
+                                           NSStringFromSelector(_cmd)]
+                                 userInfo:nil];
 }
 
-- (id)initWithDateToStringFormatter:(NSFormatter *)dateToStringFormatter stringToDateFormatters:(NSArray *)stringToDateFormatters
+#pragma mark Default Transformers
+
++ (instancetype)singletonValueTransformer:(RKBlockValueTransformer * __strong *)valueTransformer
+                                     name:(NSString *)name
+                                onceToken:(dispatch_once_t *)onceToken
+                          validationBlock:(BOOL (^)(Class sourceClass, Class destinationClass))validationBlock
+                      transformationBlock:(BOOL (^)(id inputValue, id *outputValue, Class outputValueClass, NSError **error))transformationBlock
 {
-    self = [self init];
+    dispatch_once(onceToken, ^{
+        RKBlockValueTransformer *transformer = [RKBlockValueTransformer valueTransformerWithValidationBlock:validationBlock transformationBlock:transformationBlock];
+        transformer.name = name;
+        *valueTransformer = transformer;
+    });
+    return *valueTransformer;
+}
+
++ (instancetype)identityValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:nil transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputValueClass, NSError *__autoreleasing *error) {
+        RKValueTransformerTestTransformation([inputValue isKindOfClass:outputValueClass], error, @"The given value is not already an instance of '%@'", outputValueClass);
+        *outputValue = inputValue;
+        return YES;
+    }];
+}
+
++ (instancetype)stringToURLValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return (([sourceClass isSubclassOfClass:[NSString class]] && [destinationClass isSubclassOfClass:[NSURL class]]) ||
+                ([sourceClass isSubclassOfClass:[NSURL class]] && [destinationClass isSubclassOfClass:[NSString class]]));
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        RKValueTransformerTestInputValueIsKindOfClass(inputValue, (@[ [NSString class], [NSURL class]]), error);
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSString class], [NSURL class]]), error);
+        if ([inputValue isKindOfClass:[NSString class]]) {
+            NSURL *URL = [NSURL URLWithString:inputValue];
+            RKValueTransformerTestTransformation(URL != nil, error, @"Failed transformation of '%@' to URL: the string is malformed and cannot be transformed to an `NSURL` representation.", inputValue);
+            *outputValue = URL;
+        } else if ([inputValue isKindOfClass:[NSURL class]]) {
+            *outputValue = [(NSURL *)inputValue absoluteString];
+        }
+        return YES;
+    }];
+}
+
++ (instancetype)numberToStringValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return (([sourceClass isSubclassOfClass:[NSNumber class]] && [destinationClass isSubclassOfClass:[NSString class]]) ||
+                ([sourceClass isSubclassOfClass:[NSString class]] && [destinationClass isSubclassOfClass:[NSNumber class]]));
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        RKValueTransformerTestInputValueIsKindOfClass(inputValue, (@[ [NSNumber class], [NSString class] ]), error);
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSNumber class], [NSString class]]), error);
+        if ([inputValue isKindOfClass:[NSString class]]) {
+            NSString *lowercasedString = [inputValue lowercaseString];
+            NSSet *trueStrings = [NSSet setWithObjects:@"true", @"t", @"yes", @"y", nil];
+            NSSet *booleanStrings = [trueStrings setByAddingObjectsFromSet:[NSSet setWithObjects:@"false", @"f", @"no", @"n", nil]];
+            if ([booleanStrings containsObject:lowercasedString]) {
+                // Handle booleans encoded as Strings
+                *outputValue = [NSNumber numberWithBool:[trueStrings containsObject:lowercasedString]];
+            } else if ([lowercasedString rangeOfString:@"."].location != NSNotFound) {
+                // String -> Floating Point Number
+                // Only use floating point if needed to avoid losing precision on large integers
+                *outputValue = [NSNumber numberWithDouble:[lowercasedString doubleValue]];
+            } else {
+                // String -> Signed Integer
+                *outputValue = [NSNumber numberWithLongLong:[lowercasedString longLongValue]];
+            }
+        } else if ([inputValue isKindOfClass:[NSNumber class]]) {
+            if (NSClassFromString(@"__NSCFBoolean") && [inputValue isKindOfClass:NSClassFromString(@"__NSCFBoolean")]) {
+                *outputValue = [inputValue boolValue] ? @"true" : @"false";
+            } else if (NSClassFromString(@"NSCFBoolean") && [inputValue isKindOfClass:NSClassFromString(@"NSCFBoolean")]) {
+                *outputValue = [inputValue boolValue] ? @"true" : @"false";
+            } else {
+                *outputValue = [inputValue stringValue];
+            }
+        }
+        return YES;
+    }];
+}
+
++ (instancetype)arrayToOrderedSetValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return (([sourceClass isSubclassOfClass:[NSArray class]] && [destinationClass isSubclassOfClass:[NSOrderedSet class]]) ||
+                ([sourceClass isSubclassOfClass:[NSOrderedSet class]] && [destinationClass isSubclassOfClass:[NSArray class]]));
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        RKValueTransformerTestInputValueIsKindOfClass(inputValue, (@[ [NSArray class], [NSOrderedSet class]]), error);
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSArray class], [NSOrderedSet class]]), error);
+        if ([inputValue isKindOfClass:[NSArray class]]) {
+            *outputValue = [NSOrderedSet orderedSetWithArray:inputValue];
+        } else if ([inputValue isKindOfClass:[NSOrderedSet class]]) {
+            *outputValue = [inputValue array];
+        }
+        return YES;
+    }];
+}
+
++ (instancetype)arrayToSetValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return (([sourceClass isSubclassOfClass:[NSArray class]] && [destinationClass isSubclassOfClass:[NSSet class]]) ||
+                ([sourceClass isSubclassOfClass:[NSSet class]] && [destinationClass isSubclassOfClass:[NSArray class]]));
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        RKValueTransformerTestInputValueIsKindOfClass(inputValue, (@[ [NSSet class], [NSArray class]]), error);
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSSet class], [NSArray class]]), error);
+        if ([inputValue isKindOfClass:[NSArray class]]) {
+            if ([outputValueClass isSubclassOfClass:[NSMutableSet class]]) *outputValue = [NSMutableSet setWithArray:inputValue];
+            else *outputValue = [NSSet setWithArray:inputValue];
+        } else if ([inputValue isKindOfClass:[NSSet class]]) {
+            if ([outputValueClass isSubclassOfClass:[NSMutableArray class]]) *outputValue = [[inputValue allObjects] mutableCopy];
+            else *outputValue = [inputValue allObjects];
+        }
+        return YES;
+    }];
+}
+
++ (instancetype)decimalNumberToStringValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return (([sourceClass isSubclassOfClass:[NSDecimalNumber class]] && [destinationClass isSubclassOfClass:[NSString class]]) ||
+                ([sourceClass isSubclassOfClass:[NSString class]] && [destinationClass isSubclassOfClass:[NSDecimalNumber class]]));
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        RKValueTransformerTestInputValueIsKindOfClass(inputValue, (@[ [NSString class], [NSDecimalNumber class]]), error);
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSString class], [NSDecimalNumber class]]), error);
+        if ([inputValue isKindOfClass:[NSString class]]) {
+            NSDecimalNumber *decimalNumber = [NSDecimalNumber decimalNumberWithString:inputValue];
+            RKValueTransformerTestTransformation(! [decimalNumber isEqual:[NSDecimalNumber notANumber]], error, @"Failed transformation of '%@' to `NSDecimalNumber`: the input string was transformed into Not a Number (NaN) value.", inputValue);
+            *outputValue = decimalNumber;
+        } else if ([inputValue isKindOfClass:[NSDecimalNumber class]]) {
+            *outputValue = [inputValue stringValue];
+        }
+        return YES;
+    }];
+}
+
++ (instancetype)decimalNumberToNumberValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return (([sourceClass isSubclassOfClass:[NSDecimalNumber class]] && [destinationClass isSubclassOfClass:[NSNumber class]]) ||
+                ([sourceClass isSubclassOfClass:[NSNumber class]] && [destinationClass isSubclassOfClass:[NSDecimalNumber class]]));
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        RKValueTransformerTestInputValueIsKindOfClass(inputValue, (@[ [NSNumber class], [NSDecimalNumber class]]), error);
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSNumber class], [NSDecimalNumber class]]), error);
+        if ([inputValue isKindOfClass:[NSNumber class]]) {
+            *outputValue = [NSDecimalNumber decimalNumberWithDecimal:[inputValue decimalValue]];
+        } else if ([inputValue isKindOfClass:[NSDecimalNumber class]]) {
+            *outputValue = inputValue;
+        }
+        return YES;
+    }];
+}
+
++ (instancetype)nullValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:nil transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        RKValueTransformerTestInputValueIsKindOfClass(inputValue, [NSNull class], error);
+        *outputValue = nil;
+        return YES;
+    }];
+}
+
++ (instancetype)keyedArchivingValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return (([sourceClass conformsToProtocol:@protocol(NSCoding)] && [destinationClass isSubclassOfClass:[NSData class]]) ||
+                ([sourceClass isSubclassOfClass:[NSData class]] && [destinationClass conformsToProtocol:@protocol(NSCoding)]));
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        if ([inputValue isKindOfClass:[NSData class]]) {
+            id unarchivedValue = nil;
+            @try {
+                unarchivedValue = [NSKeyedUnarchiver unarchiveObjectWithData:inputValue];
+            }
+            @catch (NSException *exception) {
+                NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"An `%@` exception was encountered while attempting to unarchive the given inputValue.", [exception name]], @"exception": exception };
+                *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorTransformationFailed userInfo:userInfo];
+                return NO;
+            }
+            if (! [unarchivedValue isKindOfClass:outputValueClass]) {
+                NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected an `outputValueClass` of type `%@`, but the unarchived object is a `%@`.", outputValueClass, [unarchivedValue class]] };
+                *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorTransformationFailed userInfo:userInfo];
+                return NO;
+            }
+            *outputValue = unarchivedValue;
+        } else if ([inputValue conformsToProtocol:@protocol(NSCoding)]) {
+            RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, [NSData class], error);
+            *outputValue = [NSKeyedArchiver archivedDataWithRootObject:inputValue];
+        } else {
+            NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected an `inputValue` of type `NSData` or conforming to `NSCoding`, but got a `%@` which does not satisfy these expectation.", [inputValue class]] };
+            *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorUntransformableInputValue userInfo:userInfo];
+            return NO;
+        }
+        return YES;
+    }];
+}
+
++ (instancetype)timeIntervalSince1970ToDateValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return ((([sourceClass isSubclassOfClass:[NSString class]] || [sourceClass isSubclassOfClass:[NSNumber class]]) && [destinationClass isSubclassOfClass:[NSDate class]]) ||
+                ([sourceClass isSubclassOfClass:[NSDate class]] && ([destinationClass isSubclassOfClass:[NSNumber class]] || [destinationClass isSubclassOfClass:[NSString class]])));
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputValueClass, NSError *__autoreleasing *error) {
+        static dispatch_once_t onceToken;
+        static NSNumberFormatter *numberFormatter;
+        dispatch_once(&onceToken, ^{
+            numberFormatter = [NSNumberFormatter new];
+            numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
+        });
+        RKValueTransformerTestInputValueIsKindOfClass(inputValue, (@[ [NSNumber class], [NSString class], [NSDate class] ]), error);
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSNumber class], [NSString class], [NSDate class] ]), error);
+        if ([outputValueClass isSubclassOfClass:[NSDate class]]) {
+            if ([inputValue isKindOfClass:[NSNumber class]]) {
+                *outputValue = [NSDate dateWithTimeIntervalSince1970:[inputValue doubleValue]];
+            } else if ([inputValue isKindOfClass:[NSString class]]) {
+                if ([[inputValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] length] == 0) {
+                    *outputValue = nil;
+                    return YES;
+                }
+                NSString *errorDescription = nil;
+                NSNumber *formattedNumber;
+                BOOL success = [numberFormatter getObjectValue:&formattedNumber forString:inputValue errorDescription:&errorDescription];
+                RKValueTransformerTestTransformation(success, error, @"%@", errorDescription);
+                *outputValue = [NSDate dateWithTimeIntervalSince1970:[formattedNumber doubleValue]];
+            }
+        } else if ([outputValueClass isSubclassOfClass:[NSNumber class]]) {
+            *outputValue = @([inputValue timeIntervalSince1970]);
+        } else if ([outputValueClass isSubclassOfClass:[NSString class]]) {
+            *outputValue = [numberFormatter stringForObjectValue:@([inputValue timeIntervalSince1970])];
+        }
+        return YES;
+    }];
+}
+
++ (instancetype)stringValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return ([sourceClass instancesRespondToSelector:@selector(stringValue)] && [destinationClass isSubclassOfClass:[NSString class]]);
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        if (! [inputValue respondsToSelector:@selector(stringValue)]) {
+            NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: @"Expected an `inputValue` that responds to `stringValue`, but it does not." };
+            *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorUntransformableInputValue userInfo:userInfo];
+            return NO;
+        }
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, [NSString class], error);
+        *outputValue = [inputValue stringValue];
+        return YES;
+    }];
+}
+
++ (instancetype)objectToCollectionValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return (!RKClassIsCollection(sourceClass) && RKClassIsCollection(destinationClass));
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        if (RKObjectIsCollection(inputValue)) {
+            NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected an `inputValue` that is not a collection, but got a `%@`.", [inputValue class]] };
+            *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorUntransformableInputValue userInfo:userInfo];
+            return NO;
+        }
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSArray class], [NSSet class], [NSOrderedSet class]]), error);
+        if ([outputValueClass isSubclassOfClass:[NSMutableArray class]]) *outputValue = [NSMutableArray arrayWithObject:inputValue];
+        else if ([outputValueClass isSubclassOfClass:[NSMutableSet class]]) *outputValue = [NSMutableSet setWithObject:inputValue];
+        else if ([outputValueClass isSubclassOfClass:[NSMutableOrderedSet class]]) *outputValue = [NSMutableOrderedSet orderedSetWithObject:inputValue];
+        else if ([outputValueClass isSubclassOfClass:[NSArray class]]) *outputValue = @[ inputValue ];
+        else if ([outputValueClass isSubclassOfClass:[NSSet class]]) *outputValue = [NSSet setWithObject:inputValue];
+        else if ([outputValueClass isSubclassOfClass:[NSOrderedSet class]]) *outputValue = [NSOrderedSet orderedSetWithObject:inputValue];
+        RKValueTransformerTestTransformation(*outputValue, error, @"Failed to transform value into collection %@", outputValueClass);
+        return YES;
+    }];
+}
+
++ (instancetype)mutableValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    NSArray *mutableClasses = @[ [NSMutableArray class], [NSMutableDictionary class], [NSMutableString class], [NSMutableSet class], [NSMutableOrderedSet class], [NSMutableData class], [NSMutableIndexSet class], [NSMutableString class], [NSMutableAttributedString class] ];
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        /**
+         NOTE: Because of class clusters in Foundation you cannot make any assumptions about mutability based on classes. For example, given `__NSArrayI` (immutable array) and a destination class of `NSMutableArray`, `isSubClassOfClass:` will not evaluate to `YES`. If you want a mutable result, you need to invoke `mutableCopy`.
+         */
+        return [sourceClass conformsToProtocol:@protocol(NSMutableCopying)] && [mutableClasses containsObject:destinationClass];
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputValueClass, NSError *__autoreleasing *error) {
+        if (! [inputValue conformsToProtocol:@protocol(NSMutableCopying)]) {
+            NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected an `inputValue` that conforms to `NSMutableCopying`, but `%@` objects do not.", [inputValue class]] };
+            *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorUntransformableInputValue userInfo:userInfo];
+            return NO;
+        }
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, mutableClasses, error);
+        *outputValue = [inputValue mutableCopy];
+        return YES;
+    }];
+}
+
++ (instancetype)keyOfDictionaryValueTransformer
+{
+    static dispatch_once_t onceToken;
+    static RKBlockValueTransformer *valueTransformer;
+    return [self singletonValueTransformer:&valueTransformer name:NSStringFromSelector(_cmd) onceToken:&onceToken validationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return ([sourceClass conformsToProtocol:@protocol(NSCopying)] && [destinationClass isSubclassOfClass:[NSDictionary class]]);
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        if (! [inputValue conformsToProtocol:@protocol(NSCopying)]) {
+            NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: @"Expected an `inputValue` that conforms to `NSCopying`, but it does not." };
+            *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorUntransformableInputValue userInfo:userInfo];
+            return NO;
+        }
+        RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, [NSDictionary class], error);
+        if ([outputValueClass isSubclassOfClass:[NSMutableDictionary class]]) {
+            *outputValue = [NSMutableDictionary dictionaryWithObject:[NSMutableDictionary dictionary] forKey:inputValue];
+        } else {
+            *outputValue = @{ inputValue: @{} };
+        }
+
+        return YES;
+    }];
+}
+
+static RKCompoundValueTransformer *RKDefaultValueTransformer;
+static dispatch_once_t RKDefaultValueTransformerOnceToken;
+
++ (RKCompoundValueTransformer *)defaultValueTransformer
+{
+    dispatch_once(&RKDefaultValueTransformerOnceToken, ^{
+        if (! RKDefaultValueTransformer) {
+            RKDefaultValueTransformer = [RKCompoundValueTransformer compoundValueTransformerWithValueTransformers:@[
+                                         [self identityValueTransformer],
+                                         [self stringToURLValueTransformer],
+
+                                         // `NSDecimalNumber` transformers must be consulted ahead of `NSNumber` transformers because `NSDecimalNumber` is a subclass thereof
+                                         [self decimalNumberToNumberValueTransformer],
+                                         [self decimalNumberToStringValueTransformer],
+
+                                         [self numberToStringValueTransformer],
+                                         [self arrayToOrderedSetValueTransformer],
+                                         [self arrayToSetValueTransformer],
+                                         [self nullValueTransformer],
+                                         [self keyedArchivingValueTransformer],
+                                         [self stringValueTransformer],
+                                         [self objectToCollectionValueTransformer],
+                                         [self stringValueTransformer],
+                                         [self keyOfDictionaryValueTransformer],
+                                         [self mutableValueTransformer],
+                                         ]];
+
+            // Default date formatters
+            RKISO8601DateFormatter *iso8601DateFormatter = [RKISO8601DateFormatter new];
+            iso8601DateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+            iso8601DateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+            iso8601DateFormatter.includeTime = YES;
+            iso8601DateFormatter.parsesStrictly = YES;
+            [RKDefaultValueTransformer addValueTransformer:iso8601DateFormatter];
+
+            // Ensures that parameterization favors ISO8601 by default
+            [RKDefaultValueTransformer addValueTransformer:[self timeIntervalSince1970ToDateValueTransformer]];
+
+            NSArray *defaultDateFormatStrings = @[ @"MM/dd/yyyy", @"yyyy-MM-dd'T'HH:mm:ss'Z'", @"yyyy-MM-dd" ];
+            for (NSString *dateFormatString in defaultDateFormatStrings) {
+                NSDateFormatter *dateFormatter = [NSDateFormatter new];
+                dateFormatter.dateFormat = dateFormatString;
+                dateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+                dateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+                [RKDefaultValueTransformer addValueTransformer:dateFormatter];
+            }
+        }
+    });
+    return RKDefaultValueTransformer;
+}
+
++ (void)setDefaultValueTransformer:(RKCompoundValueTransformer *)compoundValueTransformer
+{
+    RKDefaultValueTransformerOnceToken = 0; // resets the once_token so dispatch_once will run again
+    RKDefaultValueTransformer = compoundValueTransformer;
+}
+
+@end
+
+@interface RKBlockValueTransformer ()
+@property (nonatomic, copy) BOOL (^validationBlock)(Class, Class);
+@property (nonatomic, copy) BOOL (^transformationBlock)(id, id *, Class, NSError **);
+@end
+
+@implementation RKBlockValueTransformer
+
++ (instancetype)valueTransformerWithValidationBlock:(BOOL (^)(Class sourceClass, Class destinationClass))validationBlock
+                                transformationBlock:(BOOL (^)(id inputValue, id *outputValue, Class outputClass, NSError **error))transformationBlock
+{
+    if (! transformationBlock) [NSException raise:NSInvalidArgumentException format:@"The `transformationBlock` cannot be `nil`."];
+    RKBlockValueTransformer *valueTransformer = [self new];
+    valueTransformer.validationBlock = validationBlock;
+    valueTransformer.transformationBlock = transformationBlock;
+    return valueTransformer;
+}
+
+#pragma mark RKValueTransforming
+
+- (BOOL)transformValue:(id)inputValue toValue:(__autoreleasing id *)outputValue ofClass:(Class)outputValueClass error:(NSError *__autoreleasing *)error
+{
+    NSError *blockError = nil;
+    BOOL success = self.transformationBlock(inputValue, outputValue, outputValueClass, &blockError);
+    if (error) *error = blockError;
+    return success;
+}
+
+- (BOOL)validateTransformationFromClass:(Class)sourceClass toClass:(Class)destinationClass
+{
+    if (self.validationBlock) return self.validationBlock(sourceClass, destinationClass);
+    else return YES;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p, name: %@>", NSStringFromClass([self class]), self, self.name];
+}
+
+@end
+
+@interface RKCompoundValueTransformer ()
+@property (nonatomic, strong) NSMutableArray *valueTransformers;
+@end
+
+@implementation RKCompoundValueTransformer
+
++ (instancetype)compoundValueTransformerWithValueTransformers:(NSArray *)valueTransformers
+{
+    if (! valueTransformers) [NSException raise:NSInvalidArgumentException format:@"`valueTransformers` argument cannot be `nil`."];
+    for (id<RKValueTransforming> valueTransformer in valueTransformers) {
+        if (! [valueTransformer conformsToProtocol:@protocol(RKValueTransforming)]) {
+            [NSException raise:NSInvalidArgumentException format:@"All objects in the given `valueTransformers` collection must conform to the `RKValueTransforming` protocol."];
+        }
+    }
+    RKCompoundValueTransformer *valueTransformer = [self new];
+    valueTransformer.valueTransformers = [valueTransformers mutableCopy];
+    return valueTransformer;
+}
+
+- (id)init
+{
+    self = [super init];
     if (self) {
-        self.dateToStringFormatter = dateToStringFormatter;
-        self.stringToDateFormatters = stringToDateFormatters;
+        self.valueTransformers = [NSMutableArray new];
     }
     return self;
 }
 
-- (id)transformedValue:(id)value
+- (NSString *)description
 {
-    NSAssert(self.stringToDateFormatters, @"Cannot transform an `NSDate` to an `NSString`: stringToDateFormatters is nil");
-    RKAssertValueIsKindOfClass(value, [NSString class]);
-    return RKDateFromStringWithFormatters(value, self.stringToDateFormatters);
+    return [NSString stringWithFormat:@"<%@: %p, valueTransformers=%@>", NSStringFromClass([self class]), self, self.valueTransformers];
 }
 
-- (id)reverseTransformedValue:(id)value
+- (void)addValueTransformer:(id<RKValueTransforming>)valueTransformer
 {
-    NSAssert(self.dateToStringFormatter, @"Cannot transform an `NSDate` to an `NSString`: dateToStringFormatter is nil");
-    RKAssertValueIsKindOfClass(value, [NSDate class]);
-    @synchronized(self.dateToStringFormatter) {
-        return [self.dateToStringFormatter stringForObjectValue:value];
+    if (! valueTransformer) [NSException raise:NSInvalidArgumentException format:@"Cannot add `nil` to a compound transformer."];
+    [self.valueTransformers addObject:valueTransformer];
+}
+
+- (void)removeValueTransformer:(id<RKValueTransforming>)valueTransformer
+{
+    if (! valueTransformer) [NSException raise:NSInvalidArgumentException format:@"Cannot remove `nil` from a compound transformer."];
+    [self.valueTransformers removeObject:valueTransformer];
+}
+
+- (void)insertValueTransformer:(id<RKValueTransforming>)valueTransformer atIndex:(NSUInteger)index
+{
+    if (! valueTransformer) [NSException raise:NSInvalidArgumentException format:@"Cannot insert `nil` into a compound transformer."];
+    [self removeValueTransformer:valueTransformer];
+    [self.valueTransformers insertObject:valueTransformer atIndex:index];
+}
+
+- (NSUInteger)numberOfValueTransformers
+{
+    return [self.valueTransformers count];
+}
+
+- (NSArray *)valueTransformersForTransformingFromClass:(Class)sourceClass toClass:(Class)destinationClass
+{
+    if (sourceClass == Nil && destinationClass == Nil) return [self.valueTransformers copy];
+    else if (sourceClass == Nil || destinationClass == Nil) [NSException raise:NSInvalidArgumentException format:@"If you specify a source or destination class then you must specify both."];
+    NSMutableArray *matchingTransformers = [NSMutableArray arrayWithCapacity:[self.valueTransformers count]];
+    for (RKValueTransformer *valueTransformer in self) {
+        if (! [valueTransformer respondsToSelector:@selector(validateTransformationFromClass:toClass:)]
+            || [valueTransformer validateTransformationFromClass:sourceClass toClass:destinationClass]) {
+            [matchingTransformers addObject:valueTransformer];
+        }
     }
+    return [matchingTransformers copy];
+}
+
+- (id)objectAtIndexedSubscript:(NSUInteger)index
+{
+    return [self.valueTransformers objectAtIndex:index];
+}
+
+#pragma mark RKValueTransforming
+
+- (BOOL)transformValue:(id)inputValue toValue:(__autoreleasing id *)outputValue ofClass:(__unsafe_unretained Class)outputValueClass error:(NSError *__autoreleasing *)error
+{
+    NSArray *matchingTransformers = [self valueTransformersForTransformingFromClass:[inputValue class] toClass:outputValueClass];
+    NSMutableArray *errors = [NSMutableArray array];
+    NSError *underlyingError = nil;
+    for (id<RKValueTransforming> valueTransformer in matchingTransformers) {
+        BOOL success = [valueTransformer transformValue:inputValue toValue:outputValue ofClass:outputValueClass error:&underlyingError];
+        if (success) return YES;
+        else [errors addObject:underlyingError];
+    }
+    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed transformation of value '%@' to %@: none of the %d value transformers consulted were successful.", inputValue, outputValueClass, [matchingTransformers count]], RKDetailedErrorsKey: errors };
+    if (error) *error = [NSError errorWithDomain:RKErrorDomain code:RKValueTransformationErrorTransformationFailed userInfo:userInfo];
+    return NO;
+}
+
+- (BOOL)validateTransformationFromClass:(Class)sourceClass toClass:(Class)destinationClass
+{
+    return [[self valueTransformersForTransformingFromClass:sourceClass toClass:destinationClass] count] > 0;
+}
+
+#pragma mark NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [[[self class] allocWithZone:zone] init];
+    compoundValueTransformer.valueTransformers = [self.valueTransformers mutableCopy];
+    return compoundValueTransformer;
+}
+
+#pragma mark NSFastEnumeration
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id __unsafe_unretained [])buffer count:(NSUInteger)len
+{
+    return [self.valueTransformers countByEnumeratingWithState:state objects:buffer count:len];
 }
 
 @end
+
+@implementation NSNumberFormatter (RKValueTransformers)
+
+- (BOOL)validateTransformationFromClass:(Class)inputValueClass toClass:(Class)outputValueClass
+{
+    return (([inputValueClass isSubclassOfClass:[NSNumber class]] && [outputValueClass isSubclassOfClass:[NSString class]]) ||
+            ([inputValueClass isSubclassOfClass:[NSString class]] && [outputValueClass isSubclassOfClass:[NSNumber class]]));
+}
+
+- (BOOL)transformValue:(id)inputValue toValue:(id *)outputValue ofClass:(Class)outputValueClass error:(NSError **)error
+{
+    RKValueTransformerTestInputValueIsKindOfClass(inputValue, (@[ [NSString class], [NSNumber class] ]), error);
+    RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSString class], [NSNumber class] ]), error);
+    if ([inputValue isKindOfClass:[NSString class]]) {
+        NSString *errorDescription = nil;
+        BOOL success = [self getObjectValue:outputValue forString:inputValue errorDescription:&errorDescription];
+        RKValueTransformerTestTransformation(success, error, @"%@", errorDescription);
+    } else if ([inputValue isKindOfClass:[NSNumber class]]) {
+        *outputValue = [self stringFromNumber:inputValue];
+    }
+    return YES;
+}
+
+@end
+
+@implementation NSDateFormatter (RKValueTransformers)
+
+- (BOOL)validateTransformationFromClass:(Class)inputValueClass toClass:(Class)outputValueClass
+{
+    return (([inputValueClass isSubclassOfClass:[NSDate class]] && [outputValueClass isSubclassOfClass:[NSString class]]) ||
+            ([inputValueClass isSubclassOfClass:[NSString class]] && [outputValueClass isSubclassOfClass:[NSDate class]]));
+}
+
+- (BOOL)transformValue:(id)inputValue toValue:(id *)outputValue ofClass:(Class)outputValueClass error:(NSError **)error
+{
+    RKValueTransformerTestInputValueIsKindOfClass(inputValue, (@[ [NSString class], [NSDate class] ]), error);
+    RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSString class], [NSDate class] ]), error);
+    if ([inputValue isKindOfClass:[NSString class]]) {
+        NSString *errorDescription = nil;
+        BOOL success = [self getObjectValue:outputValue forString:inputValue errorDescription:&errorDescription];
+        RKValueTransformerTestTransformation(success, error, @"%@", errorDescription);
+    } else if ([inputValue isKindOfClass:[NSDate class]]) {
+        *outputValue = [self stringFromDate:inputValue];
+    }
+    return YES;
+}
+
+@end
+
+@implementation RKISO8601DateFormatter (RKValueTransformers)
+
+- (BOOL)validateTransformationFromClass:(Class)inputValueClass toClass:(Class)outputValueClass
+{
+    return (([inputValueClass isSubclassOfClass:[NSDate class]] && [outputValueClass isSubclassOfClass:[NSString class]]) ||
+            ([inputValueClass isSubclassOfClass:[NSString class]] && [outputValueClass isSubclassOfClass:[NSDate class]]));
+}
+
+- (BOOL)transformValue:(id)inputValue toValue:(id *)outputValue ofClass:(Class)outputValueClass error:(NSError **)error
+{
+    RKValueTransformerTestInputValueIsKindOfClass(inputValue, (@[ [NSString class], [NSDate class] ]), error);
+    RKValueTransformerTestOutputValueClassIsSubclassOfClass(outputValueClass, (@[ [NSString class], [NSDate class] ]), error);
+    if ([inputValue isKindOfClass:[NSString class]]) {
+        NSString *errorDescription = nil;
+        BOOL success = [self getObjectValue:outputValue forString:inputValue errorDescription:&errorDescription];
+        RKValueTransformerTestTransformation(success, error, @"%@", errorDescription);
+    } else if ([inputValue isKindOfClass:[NSDate class]]) {
+        *outputValue = [self stringFromDate:inputValue];
+    }
+    return YES;
+}
+
+@end
+
+#pragma mark - Functions
+
+NSDate *RKDateFromString(NSString *dateString)
+{
+    NSDate *outputDate = nil;
+    NSError *error = nil;
+    BOOL success = [[RKValueTransformer defaultValueTransformer] transformValue:dateString toValue:&outputDate ofClass:[NSDate class] error:&error];
+    return success ? outputDate : nil;
+}
+
+NSString *RKStringFromDate(NSDate *date)
+{
+    NSString *outputString = nil;
+    NSError *error = nil;
+    BOOL success = [[RKValueTransformer defaultValueTransformer] transformValue:date toValue:&outputString ofClass:[NSString class] error:&error];
+    return success ? outputString : nil;
+}

--- a/Code/Support/RKDotNetDateFormatter.m
+++ b/Code/Support/RKDotNetDateFormatter.m
@@ -21,9 +21,20 @@
 #import "RKDotNetDateFormatter.h"
 #import "RKLog.h"
 
-static BOOL RKDotNetDateFormatterIsValidRange(NSRange rangeOfMatch);
-static NSTimeInterval RKDotNetDateFormatterSecondsFromMilliseconds(NSTimeInterval millisecs);
-static NSTimeInterval RKDotNetDateFormatterMillisecondsFromSeconds(NSTimeInterval seconds);
+static BOOL RKDotNetDateFormatterIsValidRange(NSRange rangeOfMatch)
+{
+    return (!NSEqualRanges(rangeOfMatch, NSMakeRange(NSNotFound, 0)));
+}
+
+static NSTimeInterval RKDotNetDateFormatterSecondsFromMilliseconds(NSTimeInterval millisecs)
+{
+    return millisecs / 1000.f;
+}
+
+static NSTimeInterval RKDotNetDateFormatterMillisecondsFromSeconds(NSTimeInterval seconds)
+{
+    return seconds *1000.f;
+}
 
 @interface RKDotNetDateFormatter ()
 @property (nonatomic, strong) NSRegularExpression *dotNetExpression;
@@ -90,9 +101,6 @@ static NSTimeInterval RKDotNetDateFormatterMillisecondsFromSeconds(NSTimeInterva
     return self;
 }
 
-
-
-
 - (NSString *)millisecondsFromString:(NSString *)string
 {
     if (!string) return nil;
@@ -103,22 +111,5 @@ static NSTimeInterval RKDotNetDateFormatterMillisecondsFromSeconds(NSTimeInterva
     NSString *milliseconds = [string substringWithRange:millisecRange];
     return milliseconds;
 }
+
 @end
-
-
-static BOOL RKDotNetDateFormatterIsValidRange(NSRange rangeOfMatch)
-{
-    return (!NSEqualRanges(rangeOfMatch, NSMakeRange(NSNotFound, 0)));
-}
-
-
-static NSTimeInterval RKDotNetDateFormatterSecondsFromMilliseconds(NSTimeInterval millisecs)
-{
-    return millisecs / 1000.f;
-}
-
-
-static NSTimeInterval RKDotNetDateFormatterMillisecondsFromSeconds(NSTimeInterval seconds)
-{
-    return seconds *1000.f;
-}

--- a/Code/Support/RKErrors.h
+++ b/Code/Support/RKErrors.h
@@ -41,7 +41,7 @@ typedef enum {
  The key RestKit generated errors will appear at within an NSNotification
  indicating an error
  */
-extern NSString * const RKErrorNotificationErrorKey;
+extern NSString *const RKErrorNotificationErrorKey;
 
 /**
  When RestKit constructs an NSError object from one or more RKErrorMessage
@@ -52,8 +52,8 @@ extern NSString * const RKErrorNotificationErrorKey;
 
  @see RKObjectMappingResult
  */
-extern NSString * const RKObjectMapperErrorObjectsKey;
+extern NSString *const RKObjectMapperErrorObjectsKey;
 
-extern NSString * const RKDetailedErrorsKey; // When multiple errors occur, they are stored in a composite error
+extern NSString *const RKDetailedErrorsKey; // When multiple errors occur, they are stored in a composite error
 
-extern NSString * const RKMIMETypeErrorKey;
+extern NSString *const RKMIMETypeErrorKey;

--- a/Code/Support/RKISO8601DateFormatter.m
+++ b/Code/Support/RKISO8601DateFormatter.m
@@ -165,8 +165,11 @@ static NSMutableDictionary *timeZonesByOffset;
 	return [self dateComponentsFromString:string timeZone:outTimeZone range:NULL];
 }
 
-- (NSDateComponents *) dateComponentsFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone range:(out NSRange *)outRange\
+- (NSDateComponents *) dateComponentsFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone range:(out NSRange *)outRange
 {
+    // We don't support ISO-8601 intervals so bail if the string contains a slash delimiter
+    if ([string rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]].location != NSNotFound) return nil;
+
 	NSDate *now = [NSDate date];
     
 	NSDateComponents *components = [[NSDateComponents alloc] init];
@@ -640,7 +643,7 @@ static NSMutableDictionary *timeZonesByOffset;
     if (! components) return nil;
 	if (outTimeZone)
 		*outTimeZone = timeZone;
-	self.parsingCalendar.timeZone = timeZone;
+	self.parsingCalendar.timeZone = timeZone ?: self.timeZone;
 	return [self.parsingCalendar dateFromComponents:components];
 }
 

--- a/Code/Testing/RKTestFactory.m
+++ b/Code/Testing/RKTestFactory.m
@@ -28,6 +28,7 @@
 
 #ifdef _COREDATADEFINES_H
 #import "RKManagedObjectStore.h"
+#import "RKManagedObjectStore+RKSearchAdditions.h"
 #endif
 
 // Expose MIME Type singleton and initialization routine

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ namespace :test do
   
   desc "Run the unit tests for iOS"
   task :ios => :prepare do
-    $ios_success = system("xctool -workspace RestKit.xcworkspace -scheme RestKitTests -sdk iphonesimulator test -test-sdk iphonesimulator")
+    $ios_success = system("xctool -workspace RestKit.xcworkspace -scheme RestKitTests -sdk iphonesimulator test -test-sdk iphonesimulator ONLY_ACTIVE_ARCH=NO")
   end
   
   desc "Run the unit tests for OS X"

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -598,6 +598,8 @@
 		7F9CBC6174004E31AEC35813 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 86EC453810D648768BF62304 /* libPods-osx.a */; };
 		BE05BDD11782109F00F7C9C9 /* RKRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */; };
 		BE05BDD2178214AA00F7C9C9 /* RKRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */; };
+		C05CFFFB176A02EC006B1EBE /* RKValueTransformerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C05CFFFA176A02EC006B1EBE /* RKValueTransformerTest.m */; };
+		C05CFFFC176A02EC006B1EBE /* RKValueTransformerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C05CFFFA176A02EC006B1EBE /* RKValueTransformerTest.m */; };
 		E2F2B89961FC462B981CEB7A /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E457EFC3D502479D8B4FCF2A /* libPods-ios.a */; };
 /* End PBXBuildFile section */
 
@@ -974,6 +976,7 @@
 		86EC453810D648768BF62304 /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F2DFE1E847347368405F3B5 /* Pods-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.xcconfig"; path = "Pods/Pods-ios.xcconfig"; sourceTree = SOURCE_ROOT; };
 		BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRouteTest.m; sourceTree = "<group>"; };
+		C05CFFFA176A02EC006B1EBE /* RKValueTransformerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKValueTransformerTest.m; sourceTree = "<group>"; };
 		E457EFC3D502479D8B4FCF2A /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED192D1B86AB47D7927731B0 /* Pods-osx.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.xcconfig"; path = "Pods/Pods-osx.xcconfig"; sourceTree = SOURCE_ROOT; };
 		F66056291744FF9000A87A45 /* and_cats.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = and_cats.json; sourceTree = "<group>"; };
@@ -1516,6 +1519,7 @@
 				2519764215823BA1004FE9DD /* RKAttributeMappingTest.m */,
 				2519764715824455004FE9DD /* RKRelationshipMappingTest.m */,
 				2519764B158244F8004FE9DD /* RKObjectMappingTest.m */,
+				C05CFFFA176A02EC006B1EBE /* RKValueTransformerTest.m */,
 			);
 			name = ObjectMapping;
 			path = Logic/ObjectMapping;
@@ -2041,7 +2045,7 @@
 		25160D0D14564E810060A5C5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = RestKit;
 			};
 			buildConfigurationList = 25160D1014564E810060A5C5 /* Build configuration list for PBXProject "RestKit" */;
@@ -2322,6 +2326,7 @@
 				251610AA1456F2330060A5C5 /* RKHouse.m in Sources */,
 				251610AC1456F2330060A5C5 /* RKHuman.m in Sources */,
 				251610AE1456F2330060A5C5 /* RKMappableAssociation.m in Sources */,
+				C05CFFFB176A02EC006B1EBE /* RKValueTransformerTest.m in Sources */,
 				251610B01456F2330060A5C5 /* RKMappableObject.m in Sources */,
 				251610B21456F2330060A5C5 /* RKObjectLoaderTestResultModel.m in Sources */,
 				251610B41456F2330060A5C5 /* RKObjectMapperTestModel.m in Sources */,
@@ -2481,6 +2486,7 @@
 				251610AB1456F2330060A5C5 /* RKHouse.m in Sources */,
 				251610AD1456F2330060A5C5 /* RKHuman.m in Sources */,
 				251610AF1456F2330060A5C5 /* RKMappableAssociation.m in Sources */,
+				C05CFFFC176A02EC006B1EBE /* RKValueTransformerTest.m in Sources */,
 				251610B11456F2330060A5C5 /* RKMappableObject.m in Sources */,
 				251610B31456F2330060A5C5 /* RKObjectLoaderTestResultModel.m in Sources */,
 				251610B51456F2330060A5C5 /* RKObjectMapperTestModel.m in Sources */,
@@ -2558,10 +2564,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -2577,9 +2584,12 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
 			};
@@ -2589,10 +2599,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -2601,7 +2612,9 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				SDKROOT = iphoneos;
@@ -2699,7 +2712,6 @@
 		25160E88145651060060A5C5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2728,7 +2740,6 @@
 		25160E89145651060060A5C5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -2758,7 +2769,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = ED192D1B86AB47D7927731B0 /* Pods-osx.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -2779,7 +2789,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = ED192D1B86AB47D7927731B0 /* Pods-osx.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/Tests/Logic/CoreData/RKEntityMappingTest.m
+++ b/Tests/Logic/CoreData/RKEntityMappingTest.m
@@ -587,7 +587,7 @@
     expect(caughtException.reason).to.equal(@"`requestMapping` is not meant to be invoked on `RKEntityMapping`. You probably want to invoke `[RKObjectMapping requestMapping]`.");
 }
 
-- (void)testMappingArrayToMutableArray
+- (void)testMappingArrayToMutableSet
 {
     RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
     RKEntityMapping *mapping = [RKEntityMapping mappingForEntityForName:@"Human" inManagedObjectStore:managedObjectStore];
@@ -601,8 +601,8 @@
     NSError *error = nil;
     [operation performMapping:&error];
     
-    assertThat(human.mutableFavoriteColors, is(equalTo(@[ @"Blue", @"Red" ])));
-    assertThat(human.mutableFavoriteColors, is(instanceOf([NSMutableArray class])));
+    assertThat(human.mutableFavoriteColors, is(equalTo([NSMutableSet setWithArray:@[ @"Blue", @"Red" ]])));
+    assertThat(human.mutableFavoriteColors, is(instanceOf([NSMutableSet class])));
 }
 
 - (void)testSettingModificationAttributeForName

--- a/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
@@ -1019,7 +1019,6 @@
     NSError *error = nil;
     BOOL success = [managedObjectStore.persistentStoreManagedObjectContext save:&error];
     assertThatBool(success, is(equalToBool(YES)));
-    NSLog(@"Failed to save MOC: %@", error);
     assertThat(error, is(nilValue()));
 
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Parent"];

--- a/Tests/Logic/Network/RKManagedObjectRequestOperationTest.m
+++ b/Tests/Logic/Network/RKManagedObjectRequestOperationTest.m
@@ -1305,7 +1305,6 @@ NSSet *RKSetByRemovingSubkeypathsFromSet(NSSet *setOfKeyPaths);
     expect(managedObjectRequestOperation.error).to.beNil();
     RKMappableObject *result = [managedObjectRequestOperation.mappingResult.array lastObject];
     RKTestUser *user = (RKTestUser *)result.hasMany.anyObject;
-    NSLog(@"Examining result = %@, with result.hasMany = %@, user = %@ and user.bestFriend(%@) = %@", result, result.hasMany, user, [user.bestFriend class], user.bestFriend);
     expect(user.bestFriend).to.beInstanceOf([RKHuman class]);
     expect([user.bestFriend managedObjectContext]).to.equal(managedObjectStore.persistentStoreManagedObjectContext);
 }

--- a/Tests/Logic/ObjectMapping/RKMappingOperationTest.m
+++ b/Tests/Logic/ObjectMapping/RKMappingOperationTest.m
@@ -385,6 +385,9 @@
     assertThat([object.date description], is(equalTo(@"2011-08-09 00:00:00 +0000")));
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 - (void)testShouldMapAStringIntoTheLocalTimeZone
 {
     NSTimeZone *EDTTimeZone = [NSTimeZone timeZoneWithAbbreviation:@"EDT"];
@@ -425,6 +428,25 @@
     BOOL success = [operation performMapping:&error];
     assertThatBool(success, is(equalToBool(YES)));
     assertThat(newObject.boolString, is(equalTo(@"11-27-1982")));
+}
+
+#pragma clang diagnostic pop
+
+- (void)testShouldMapAStringToAURL
+{
+    RKObjectMapping *mapping = [RKObjectMapping mappingForClass:[TestMappable class]];
+    [mapping addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:@"url" toKeyPath:@"url"]];
+    TestMappable *object = [[TestMappable alloc] init];
+    object.url = [NSURL URLWithString:@"http://www.restkit.org"];
+    TestMappable *newObject = [TestMappable new];
+    RKMappingOperation *operation = [[RKMappingOperation alloc] initWithSourceObject:object destinationObject:newObject mapping:mapping];
+    RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
+    operation.dataSource = dataSource;
+    NSError *error = nil;
+    BOOL success = [operation performMapping:&error];
+    assertThatBool(success, is(equalToBool(YES)));
+    assertThat(newObject.url, is(equalTo([NSURL URLWithString:@"http://www.restkit.org"])));
+
 }
 
 - (void)testShouldLogADebugMessageIfTheRelationshipMappingTargetsAnArrayOfArrays
@@ -524,6 +546,27 @@
     expect(blake.luckyNumber).to.equal(@25);
     expect(blake.friend).notTo.beNil();
     expect(blake.friend.luckyNumber).to.beNil();
+}
+
+- (void)testThatCustomTransformerOnPropertyMappingIsInvoked
+{
+    RKObjectMapping *mapping = [RKObjectMapping mappingForClass:[TestMappable class]];
+    RKPropertyMapping *propertyMapping = [RKAttributeMapping attributeMappingFromKeyPath:@"url" toKeyPath:@"url"];
+    propertyMapping.valueTransformer = [RKBlockValueTransformer valueTransformerWithValidationBlock:nil transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        *outputValue = [inputValue URLByAppendingPathComponent:@"test"];
+        return YES;
+    }];
+    [mapping addPropertyMapping:propertyMapping];
+    TestMappable *object = [[TestMappable alloc] init];
+    object.url = [NSURL URLWithString:@"http://www.restkit.org"];
+    TestMappable *newObject = [TestMappable new];
+    RKMappingOperation *operation = [[RKMappingOperation alloc] initWithSourceObject:object destinationObject:newObject mapping:mapping];
+    RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
+    operation.dataSource = dataSource;
+    NSError *error = nil;
+    BOOL success = [operation performMapping:&error];
+    assertThatBool(success, is(equalToBool(YES)));
+    assertThat(newObject.url, is(equalTo([NSURL URLWithString:@"http://www.restkit.org/test"])));
 }
 
 @end

--- a/Tests/Logic/ObjectMapping/RKObjectParameterizationTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectParameterizationTest.m
@@ -46,6 +46,9 @@
     
     [RKMIMETypeSerialization sharedSerialization].registrations = [NSMutableArray array];
     [[RKMIMETypeSerialization sharedSerialization] addRegistrationsForKnownSerializations];
+
+    // Reset the default transformer
+    [RKValueTransformer setDefaultValueTransformer:nil];
 }
 
 - (void)tearDown
@@ -84,6 +87,9 @@
     expect(parameters[@"date-form-name"]).to.equal(@"1970-01-01T00:00:00Z");
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 - (void)testShouldSerializeADateToAStringUsingThePreferredDateFormatter
 {
     NSDictionary *object = [NSDictionary dictionaryWithObjectsAndKeys:@"value1", @"key1", [NSDate dateWithTimeIntervalSince1970:0], @"date", nil];
@@ -104,6 +110,8 @@
     expect(error).to.beNil();
     expect(string).to.equal(@"date-form-name=01/01/1970&key1-form-name=value1");
 }
+
+#pragma clang diagnostic pop
 
 - (void)testShouldSerializeADateToJSON
 {

--- a/Tests/Logic/ObjectMapping/RKValueTransformerTest.m
+++ b/Tests/Logic/ObjectMapping/RKValueTransformerTest.m
@@ -1,0 +1,1468 @@
+//
+//  RKValueTransformerTest.m
+//  RestKit
+//
+//  Created by Samuel E. Giddins on 6/13/13.
+//  Copyright (c) 2013 RestKit. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "RKTestEnvironment.h"
+#import "RKValueTransformers.h"
+
+// Used to test subclass raising
+@interface RKIncompleteValueTransformer : RKValueTransformer
+@end
+
+@implementation RKIncompleteValueTransformer
+@end
+
+@interface RKValueTransformerTest : SenTestCase
+@end
+
+@implementation RKValueTransformerTest
+
+#pragma mark - Abstract Class Tests
+
+- (void)testThatDirectInstantiationOfRKValueTransformerRaises
+{
+    expect(^{ [RKValueTransformer new]; }).to.raiseWithReason(NSInternalInconsistencyException, @"`RKValueTransformer` is abstract and cannot be directly instantiated. Instantiate a subclass implementation instead.");
+}
+
+- (void)testThatIncompleteSubclassesRaiseOnTransformation
+{
+    RKIncompleteValueTransformer *incompleteTransformer = [RKIncompleteValueTransformer new];
+    expect(^{ [incompleteTransformer transformValue:nil toValue:nil ofClass:Nil error:nil]; }).to.raiseWithReason(NSInternalInconsistencyException, @"`RKValueTransformer` subclasses must provide a concrete implementation of `transformValue:toValue:ofClass:error:`.");
+}
+
+#pragma mark - Default Transformers
+
+#pragma mark String to URL
+
+- (void)testStringToURLTransformerValidationSuccessFromStringToURL
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer stringToURLValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSURL class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testStringToURLTransformerValidationSuccessFromURLToString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer stringToURLValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSURL class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testStringToURLTransformerValidationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer stringToURLValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSURL class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testStringToURLTransformerTransformationSuccessFromStringToURL
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer stringToURLValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"http://restkit.org" toValue:&value ofClass:[NSURL class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beInstanceOf([NSURL class]);
+    expect(value).to.equal([NSURL URLWithString:@"http://restkit.org"]);
+}
+
+- (void)testStringToURLTransformerTransformationSuccessFromURLToString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer stringToURLValueTransformer];
+    NSString *value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSURL URLWithString:@"http://restkit.org"] toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSString class]);
+    expect(value).to.equal(@"http://restkit.org");
+}
+
+- (void)testStringToURLTransformerFailureWithUntransformableInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer stringToURLValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@12345 toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testStringToURLTransformerFailureWithInvalidInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer stringToURLValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@":*7vxck#sf#adsa" toValue:&value ofClass:[NSURL class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorTransformationFailed);
+}
+
+- (void)testStringToURLTransformerFailureWithInvalidDestinationClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer stringToURLValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"http://restkit.org" toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+#pragma mark Number to String
+
+- (void)testNumberToStringTransformerValidationSuccessFromStringToNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSNumber class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testNumberToStringTransformerValidationFromNumberToString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSString class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testNumberToStringTransformerValidationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSNumber class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testNumberToStringTransformerTransformationSuccessFromStringToNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"12345" toValue:&value  ofClass:[NSNumber class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSNumber class]);
+    expect(value).to.equal(@12345);
+}
+
+- (void)testNumberToStringTransformerTransformationSuccessFromNumberToString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@12345 toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSString class]);
+    expect(value).to.equal(@"12345");
+}
+
+- (void)testNumberToStringTransformerTransformationSuccessFromStringToBooleanNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@12345 toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSString class]);
+    expect(value).to.equal(@"12345");
+}
+
+- (void)testNumberToStringTransformerTransformationSuccessFromBooleanNumberToString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    [valueTransformer transformValue:[NSNumber numberWithBool:YES] toValue:&value ofClass:[NSString class] error:&error];
+    expect(value).to.equal(@"true");
+    [valueTransformer transformValue:[NSNumber numberWithBool:NO] toValue:&value ofClass:[NSString class] error:&error];
+    expect(value).to.equal(@"false");
+}
+
+- (void)testNumberToStringTransformerTransformationSuccessFromBooleanStringToNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    
+    // True
+    [valueTransformer transformValue:@"true" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:YES]);
+    [valueTransformer transformValue:@"TRUE" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:YES]);
+    [valueTransformer transformValue:@"t" toValue:&value ofClass:[NSNumber class]error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:YES]);
+    [valueTransformer transformValue:@"T" toValue:&value ofClass:[NSNumber class]error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:YES]);
+    [valueTransformer transformValue:@"yes" toValue:&value ofClass:[NSNumber class]error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:YES]);
+    [valueTransformer transformValue:@"YES" toValue:&value ofClass:[NSNumber class]error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:YES]);
+    [valueTransformer transformValue:@"y" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:YES]);
+    [valueTransformer transformValue:@"Y" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:YES]);
+    
+    // False
+    [valueTransformer transformValue:@"false" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:NO]);
+    [valueTransformer transformValue:@"FALSE" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:NO]);
+    [valueTransformer transformValue:@"f" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:NO]);
+    [valueTransformer transformValue:@"F" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:NO]);
+    [valueTransformer transformValue:@"no" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:NO]);
+    [valueTransformer transformValue:@"NO" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:NO]);
+    [valueTransformer transformValue:@"f" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:NO]);
+    [valueTransformer transformValue:@"F" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(value).to.equal([NSNumber numberWithBool:NO]);
+}
+
+- (void)testNumberToStringTransformerFailureWithUntransformableInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[] toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testNumberToStringTransformerTransformsNonsenseStringToZero
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@":*7vxck#sf#adsa" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.equal(0);
+}
+
+- (void)testNumberToStringTransformerFailureWithInvalidDestinationClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer numberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@12345 toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+#pragma mark Array to Ordered Set
+
+- (void)testArrayToOrderedSetTransformerValidationSuccessFromArrayToOrderedSet
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToOrderedSetValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSArray class] toClass:[NSOrderedSet class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testArrayToOrderedSetTransformerValidationSuccessFromOrderedSetToArray
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToOrderedSetValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSArray class] toClass:[NSOrderedSet class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testArrayToOrderedSetTransformerValidationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToOrderedSetValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSOrderedSet class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testArrayToOrderedSetTransformerTransformationSuccessFromArrayToOrderedSet
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToOrderedSetValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[ @"one", @"two", @"three" ] toValue:&value ofClass:[NSOrderedSet class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSOrderedSet class]);
+    expect(value).to.equal(([NSOrderedSet orderedSetWithArray:@[ @"one", @"two", @"three" ]]));
+}
+
+- (void)testArrayToOrderedSetTransformerTransformationSuccessFromOrderedSetToArray
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToOrderedSetValueTransformer];
+    NSString *value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSOrderedSet orderedSetWithArray:@[ @"one", @"two", @"three" ]] toValue:&value ofClass:[NSArray class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSArray class]);
+    expect(value).to.equal((@[ @"one", @"two", @"three" ]));
+}
+
+- (void)testArrayToOrderedSetTransformerFailureWithUntransformableInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToOrderedSetValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@12345 toValue:&value ofClass:[NSOrderedSet class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testArrayToOrderedSetTransformerFailureWithInvalidDestinationClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToOrderedSetValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[] toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+#pragma mark Array to Set
+
+- (void)testArrayToSetTransformerValidationSuccessFromArrayToSet
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToSetValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSArray class] toClass:[NSSet class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testArrayToSetTransformerValidationSuccessFromSetToArray
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToSetValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSArray class] toClass:[NSSet class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testArrayToSetTransformerValidationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToSetValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSSet class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testArrayToSetTransformerTransformationSuccessFromArrayToSet
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToSetValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[ @"one", @"two", @"three" ] toValue:&value ofClass:[NSSet class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSSet class]);
+    expect(value).to.equal(([NSSet setWithArray:@[ @"one", @"two", @"three" ]]));
+}
+
+- (void)testArrayToSetTransformerTransformationSuccessFromSetToArray
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToSetValueTransformer];
+    NSString *value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSSet setWithArray:@[ @"one", @"two", @"three" ]] toValue:&value ofClass:[NSSet class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSArray class]);
+    expect(value).to.equal((@[ @"one", @"two", @"three" ]));
+}
+
+- (void)testArrayToSetTransformerFailureWithUntransformableInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToSetValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@12345 toValue:&value ofClass:[NSArray class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testArrayToSetTransformerFailureWithInvalidDestinationClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer arrayToSetValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[] toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+#pragma mark Decimal Number to String
+
+- (void)testDecimalNumberToStringTransformerValidationSuccessFromDecimalNumberToString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToStringValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSDecimalNumber class] toClass:[NSString class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testDecimalNumberToStringTransformerValidationSuccessFromStringToDecimalNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToStringValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSDecimalNumber class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testDecimalNumberToStringTransformerValidationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToStringValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSString class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testDecimalNumberToStringTransformerTransformationSuccessFromDecimalNumberToString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSDecimalNumber decimalNumberWithString:@"123456.7890"] toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSString class]);
+    expect(value).to.equal(@"123456.789");
+}
+
+- (void)testDecimalNumberToStringTransformerTransformationSuccessFromStringToDecimalNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToStringValueTransformer];
+    NSString *value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"123456.7890" toValue:&value ofClass:[NSDecimalNumber class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSDecimalNumber class]);
+    expect(value).to.equal([NSDecimalNumber decimalNumberWithString:@"123456.7890"]);
+}
+
+- (void)testDecimalNumberToStringTransformerFailureWithUntransformableInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[] toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testDecimalNumberToStringTransformerFailureWithTransformationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"abdskjfsdkfjs" toValue:&value ofClass:[NSDecimalNumber class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorTransformationFailed);
+}
+
+- (void)testDecimalNumberToStringTransformerFailureWithInvalidDestinationClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToStringValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"12345.00" toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+#pragma mark Decimal Number to Number
+
+- (void)testDecimalNumberToNumberTransformerValidationSuccessFromDecimalNumberToNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToNumberValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSDecimalNumber class] toClass:[NSNumber class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testDecimalNumberToNumberTransformerValidationSuccessFromNumberToDecimalNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToNumberValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSDecimalNumber class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testDecimalNumberToNumberTransformerValidationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToNumberValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSNumber class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testDecimalNumberToNumberTransformerTransformationSuccessFromDecimalNumberToNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToNumberValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSDecimalNumber decimalNumberWithString:@"123456.7890"] toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSNumber class]);
+    expect(value).to.equal([NSDecimalNumber decimalNumberWithString:@"123456.7890"]);
+}
+
+- (void)testDecimalNumberToNumberTransformerTransformationSuccessFromNumberToDecimalNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToNumberValueTransformer];
+    NSNumber *value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@123456.7890 toValue:&value ofClass:[NSDecimalNumber class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSDecimalNumber class]);
+    expect(value).to.equal([NSDecimalNumber decimalNumberWithString:@"123456.7890"]);
+}
+
+- (void)testDecimalNumberToNumberTransformerFailureWithUntransformableInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToNumberValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[] toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testDecimalNumberToNumberTransformerFailureWithInvalidDestinationClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer decimalNumberToNumberValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@12345 toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+#pragma mark Null
+
+- (void)testNullTransformerValidationSuccessFromObjectToObject
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer nullValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSObject class] toClass:[NSObject class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testNullTransformerTransformationSuccessFromNullToNil
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer nullValueTransformer];
+    NSNumber *value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSNull null] toValue:&value ofClass:Nil error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beNil();
+}
+
+- (void)testNullTransformerFailureWithUntransformableInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer nullValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@12345 toValue:&value ofClass:Nil error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testDecimalNumberToNumberTransformerSucceedsWithAnyOutputClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer nullValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSNull null] toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beNil();
+}
+
+#pragma mark Keyed Archiving
+
+- (void)testKeyedArchivingTransformerValidationSuccessFromNSCodingCompliantToData
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyedArchivingValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSDictionary class] toClass:[NSData class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testKeyedArchivingTransformerValidationSuccessFromDataToNSCodingCompliant
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyedArchivingValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSData class] toClass:[NSDictionary class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testKeyedArchivingTransformerValidationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyedArchivingValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSData class] toClass:[NSObject class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testKeyedArchivingTransformerSuccessFromDataToDictionary
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyedArchivingValueTransformer];
+    NSDictionary *dictionary = @{ @"key": @"value" };
+    NSData *data = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:dictionary toValue:&data ofClass:[NSData class] error:&error];
+    expect(success).to.beTruthy();
+    expect(data).notTo.beNil();
+    id<NSCoding> decodedObject = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    expect(decodedObject).to.equal(dictionary);
+}
+
+- (void)testKeyedArchivingTransformerSuccessFromDictionaryToData
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyedArchivingValueTransformer];
+    NSDictionary *dictionary = @{ @"key": @"value" };
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:dictionary];
+    NSError *error = nil;
+    id<NSCoding> result = nil;
+    BOOL success = [valueTransformer transformValue:data toValue:&result ofClass:[NSDictionary class] error:&error];
+    expect(success).to.beTruthy();
+    expect(result).notTo.beNil();
+    expect(result).to.equal(dictionary);
+}
+
+- (void)testKeyedArchivingTransformerFailureWithInvalidInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyedArchivingValueTransformer];
+    id<NSCoding> result = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSObject new] toValue:&result ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(result).to.beNil();
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testKeyedArchivingTransformerFailureWithNonDecodableData
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyedArchivingValueTransformer];
+    id<NSCoding> result = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[@"this is invalid" dataUsingEncoding:NSUTF8StringEncoding] toValue:&result ofClass:[NSDictionary class] error:&error];
+    expect(success).to.beFalsy();
+    expect(result).to.beNil();
+    expect(error.code).to.equal(RKValueTransformationErrorTransformationFailed);
+}
+
+- (void)testKeyedArchivingTransformerFailureWithInvalidDestinationClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyedArchivingValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@{ @"key": @"value" } toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+- (void)testKeyedArchivingTransformerFailureDueToDesintationTypeMismatch
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyedArchivingValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    NSDictionary *dictionary = @{ @"key": @"value" };
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:dictionary];
+    BOOL success = [valueTransformer transformValue:data toValue:&value ofClass:[NSArray class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorTransformationFailed);
+}
+
+#pragma mark - Time Interval Since 1970 to Date
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerValidationSuccessFromNumberToDate
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSDate class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerValidationSuccessFromStringToDate
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSDate class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerValidationSuccessFromDateToNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSDate class] toClass:[NSNumber class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerValidationSuccessFromDateToString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSDate class] toClass:[NSString class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerValidationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSURL class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerTransformationSuccessFromNumberToDate
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@0 toValue:&value ofClass:[NSDate class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSDate class]);
+    expect([value description]).to.equal(@"1970-01-01 00:00:00 +0000");
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerTransformationSuccessFromStringToDate
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"0" toValue:&value ofClass:[NSDate class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSDate class]);
+    expect([value description]).to.equal(@"1970-01-01 00:00:00 +0000");
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerTransformationSuccessFromDateToNumber
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    NSDate *inputValue = [NSDate dateWithTimeIntervalSince1970:0];
+    BOOL success = [valueTransformer transformValue:inputValue toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSNumber class]);
+    expect(value).to.equal(0);
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerTransformationSuccessFromDateToString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    NSDate *inputValue = [NSDate dateWithTimeIntervalSince1970:0];
+    BOOL success = [valueTransformer transformValue:inputValue toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSString class]);
+    expect(value).to.equal(@"0");
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerFailureWithUntransformableInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[] toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerFailureWithInvalidInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@":*7vxck#sf#adsa" toValue:&value ofClass:[NSDate class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorTransformationFailed);
+}
+
+- (void)testTimeIntervalSince1970ToDateValueTransformerFailureWithInvalidDestinationClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer timeIntervalSince1970ToDateValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"http://restkit.org" toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+#pragma mark Mutable Value
+
+- (void)testMutableValueTransformerValidationSuccessFromString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer mutableValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSMutableString class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testMutableValueTransformerValidationSuccessFromArray
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer mutableValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSArray class] toClass:[NSMutableArray class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testMutableValueTransformerValidationSuccessFromSet
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer mutableValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSSet class] toClass:[NSMutableSet class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testMutableValueTransformerValidationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer mutableValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSURL class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testMutableValueTransformerTransformationSuccessFromString
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer mutableValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"http://restkit.org" toValue:&value ofClass:[NSMutableString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSMutableString class]);
+    expect(value).to.equal([NSMutableString stringWithString:@"http://restkit.org"]);
+}
+
+- (void)testMutableValueTransformerTransformationSuccessFromArray
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer mutableValueTransformer];
+    NSString *value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[ @"one", @"two" ] toValue:&value ofClass:[NSMutableArray class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSMutableArray class]);
+    expect(value).to.equal(([NSMutableArray arrayWithObjects:@"one", @"two", nil]));
+}
+
+- (void)testMutableValueTransformerFailureWithUntransformableInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer mutableValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@12345 toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testMutableValueTransformerFailureWithInvalidDestinationClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer mutableValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"http://restkit.org" toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+#pragma mark Copyable Object to NSDictionary
+
+- (void)testKeyOfDictionaryValueTransformerValidationSuccessFromCopyableToDictionary
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyOfDictionaryValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSDictionary class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testKeyOfDictionaryValueTransformerValidationSuccessFromCopyableToMutableDictionary
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyOfDictionaryValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSMutableDictionary class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testKeyOfDictionaryValueTransformerValidationFailure
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyOfDictionaryValueTransformer];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSObject class] toClass:[NSDictionary class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testKeyOfDictionaryValueTransformerTransformationSuccessFromStringToDictionary
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyOfDictionaryValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"key" toValue:&value ofClass:[NSDictionary class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSDictionary class]);
+    expect(value).to.equal(@{ @"key": @{}});
+}
+
+- (void)testKeyOfDictionaryValueTransformerTransformationSuccessFromStringToNSMutableDictionary
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyOfDictionaryValueTransformer];
+    NSString *value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"key" toValue:&value ofClass:[NSMutableDictionary class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSMutableDictionary class]);
+    expect(value).to.equal(([@{ @"key": [@{} mutableCopy] } mutableCopy]));
+}
+
+- (void)testKeyOfDictionaryValueTransformerFailureWithUntransformableInputValue
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyOfDictionaryValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSObject new] toValue:&value ofClass:[NSDictionary class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testKeyOfDictionaryValueTransformerFailureWithInvalidDestinationClass
+{
+    RKValueTransformer *valueTransformer = [RKValueTransformer keyOfDictionaryValueTransformer];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"key" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+@end
+
+static RKBlockValueTransformer *RKTestValueTransformerWithOutputValue(id staticOutputValue)
+{
+    return [RKBlockValueTransformer valueTransformerWithValidationBlock:nil transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, Class outputValueClass, NSError *__autoreleasing *error) {
+        *outputValue = staticOutputValue;
+        return YES;
+    }];
+}
+
+@interface RKCompoundValueTransformerTest : SenTestCase
+@end
+
+@implementation RKCompoundValueTransformerTest
+
+- (void)testAddingValueTransformer
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    expect([compoundValueTransformer numberOfValueTransformers]).to.equal(0);
+    [compoundValueTransformer addValueTransformer:RKTestValueTransformerWithOutputValue(@"OK")];
+    expect([compoundValueTransformer numberOfValueTransformers]).to.equal(1);
+}
+
+- (void)testRemovingValueTransformer
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    expect([compoundValueTransformer numberOfValueTransformers]).to.equal(0);
+    RKValueTransformer *addedTransformer = RKTestValueTransformerWithOutputValue(@"OK");
+    [compoundValueTransformer addValueTransformer:addedTransformer];
+    expect([compoundValueTransformer numberOfValueTransformers]).to.equal(1);
+    [compoundValueTransformer removeValueTransformer:RKTestValueTransformerWithOutputValue(@"invalid")];
+    expect([compoundValueTransformer numberOfValueTransformers]).to.equal(1);
+    [compoundValueTransformer removeValueTransformer:addedTransformer];
+    expect([compoundValueTransformer numberOfValueTransformers]).to.equal(0);
+}
+
+- (void)testInsertingValueTransformer
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    RKValueTransformer *firstTransformer = RKTestValueTransformerWithOutputValue(@"1");
+    [compoundValueTransformer addValueTransformer:firstTransformer];
+    RKValueTransformer *secondTransformer = RKTestValueTransformerWithOutputValue(@"2");
+    [compoundValueTransformer addValueTransformer:secondTransformer];
+    RKValueTransformer *thirdTransformer = RKTestValueTransformerWithOutputValue(@"3");
+    [compoundValueTransformer insertValueTransformer:thirdTransformer atIndex:0];
+    NSArray *valueTransformers = [compoundValueTransformer valueTransformersForTransformingFromClass:Nil toClass:Nil];
+    expect(valueTransformers[0]).to.equal(thirdTransformer);
+}
+
+- (void)testRetrievingValueTransformersBySourceToDestinationClass
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    RKValueTransformer *stringToValueTransformer = [RKBlockValueTransformer valueTransformerWithValidationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return [sourceClass isSubclassOfClass:[NSString class]] && [destinationClass isSubclassOfClass:[NSValue class]];
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        return NO;
+    }];
+    [compoundValueTransformer addValueTransformer:stringToValueTransformer];
+    RKValueTransformer *stringToNumberTransformer = [RKBlockValueTransformer valueTransformerWithValidationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return [sourceClass isSubclassOfClass:[NSString class]] && [destinationClass isSubclassOfClass:[NSNumber class]];
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        return NO;
+    }];
+    [compoundValueTransformer addValueTransformer:stringToNumberTransformer];
+    RKValueTransformer *stringToDecimalNumberTransformer = [RKBlockValueTransformer valueTransformerWithValidationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return [sourceClass isSubclassOfClass:[NSString class]] && [destinationClass isSubclassOfClass:[NSDecimalNumber class]];
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        return NO;
+    }];
+    [compoundValueTransformer addValueTransformer:stringToDecimalNumberTransformer];
+    RKValueTransformer *numberToStringValueTransformer = [RKBlockValueTransformer valueTransformerWithValidationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return [sourceClass isSubclassOfClass:[NSNumber class]] && [destinationClass isSubclassOfClass:[NSString class]];
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        return NO;
+    }];
+    [compoundValueTransformer addValueTransformer:numberToStringValueTransformer];
+    
+    expect([compoundValueTransformer valueTransformersForTransformingFromClass:[NSString class] toClass:[NSValue class]]).to.equal((@[ stringToValueTransformer ]));
+    expect([compoundValueTransformer valueTransformersForTransformingFromClass:[NSString class] toClass:[NSNumber class]]).to.equal((@[ stringToValueTransformer, stringToNumberTransformer ]));
+    expect([compoundValueTransformer valueTransformersForTransformingFromClass:[NSString class] toClass:[NSDecimalNumber class]]).to.equal((@[ stringToValueTransformer, stringToNumberTransformer, stringToDecimalNumberTransformer ]));
+    expect([compoundValueTransformer valueTransformersForTransformingFromClass:[NSNumber class] toClass:[NSString class]]).to.equal((@[ numberToStringValueTransformer ]));
+    expect([compoundValueTransformer valueTransformersForTransformingFromClass:[NSNumber class] toClass:[NSArray class]]).to.beEmpty();
+}
+
+#pragma mark RKValueTransforming
+
+- (void)testValidatingValueTransformation
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    RKValueTransformer *stringToValueTransformer = [RKBlockValueTransformer valueTransformerWithValidationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return [sourceClass isSubclassOfClass:[NSString class]] && [destinationClass isSubclassOfClass:[NSValue class]];
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        return NO;
+    }];
+    [compoundValueTransformer addValueTransformer:stringToValueTransformer];
+    RKValueTransformer *stringToNumberTransformer = [RKBlockValueTransformer valueTransformerWithValidationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return [sourceClass isSubclassOfClass:[NSString class]] && [destinationClass isSubclassOfClass:[NSNumber class]];
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        return NO;
+    }];
+    [compoundValueTransformer addValueTransformer:stringToNumberTransformer];
+    RKValueTransformer *stringToDecimalNumberTransformer = [RKBlockValueTransformer valueTransformerWithValidationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return [sourceClass isSubclassOfClass:[NSString class]] && [destinationClass isSubclassOfClass:[NSDecimalNumber class]];
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        return NO;
+    }];
+    [compoundValueTransformer addValueTransformer:stringToDecimalNumberTransformer];
+    RKValueTransformer *numberToStringValueTransformer = [RKBlockValueTransformer valueTransformerWithValidationBlock:^BOOL(__unsafe_unretained Class sourceClass, __unsafe_unretained Class destinationClass) {
+        return [sourceClass isSubclassOfClass:[NSNumber class]] && [destinationClass isSubclassOfClass:[NSString class]];
+    } transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        return NO;
+    }];
+    [compoundValueTransformer addValueTransformer:numberToStringValueTransformer];
+    
+    expect([compoundValueTransformer validateTransformationFromClass:[NSString class] toClass:[NSValue class]]).to.beTruthy();
+    expect([compoundValueTransformer validateTransformationFromClass:[NSString class] toClass:[NSNumber class]]).to.beTruthy();
+    expect([compoundValueTransformer validateTransformationFromClass:[NSString class] toClass:[NSDecimalNumber class]]).to.beTruthy();
+    expect([compoundValueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSString class]]).to.beTruthy();
+    expect([compoundValueTransformer validateTransformationFromClass:[NSString class] toClass:[NSData class]]).to.beFalsy();
+}
+
+- (void)testTransformingValueSuccessfully
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    RKValueTransformer *firstTransformer = RKTestValueTransformerWithOutputValue(@"1");
+    [compoundValueTransformer addValueTransformer:firstTransformer];
+    NSString *outputValue;
+    NSError *error = nil;
+    BOOL success = [compoundValueTransformer transformValue:@"2" toValue:&outputValue ofClass:[NSString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(outputValue).to.equal(@"1");
+}
+
+- (void)testTransformingValueSuccessfullyRespectsOrderingOfTransformers
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    [compoundValueTransformer addValueTransformer:RKTestValueTransformerWithOutputValue(@"1")];
+    [compoundValueTransformer addValueTransformer:RKTestValueTransformerWithOutputValue(@"2")];
+    [compoundValueTransformer insertValueTransformer:RKTestValueTransformerWithOutputValue(@"3") atIndex:0];
+    NSString *outputValue;
+    NSError *error = nil;
+    BOOL success = [compoundValueTransformer transformValue:@"2" toValue:&outputValue ofClass:[NSString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(outputValue).to.equal(@"3");
+}
+
+- (void)testTransformingValueFailsWithError
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    [compoundValueTransformer addValueTransformer:[RKBlockValueTransformer valueTransformerWithValidationBlock:nil transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        // Always fails
+        RKValueTransformerTestTransformation(NO, error, @"This is an underlying error.");
+        return YES;
+    }]];
+    NSString *outputValue;
+    NSError *error = nil;
+    BOOL success = [compoundValueTransformer transformValue:@"2" toValue:&outputValue ofClass:[NSString class] error:&error];
+    expect(success).to.beFalsy();
+    expect(outputValue).to.beNil();
+    expect(error.code).to.equal(RKValueTransformationErrorTransformationFailed);
+    expect(error.localizedDescription).to.equal(@"Failed transformation of value '2' to NSString: none of the 1 value transformers consulted were successful.");
+}
+
+#pragma mark NSCopying
+
+- (void)testCopying
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    RKValueTransformer *firstTransformer = RKTestValueTransformerWithOutputValue(@"1");
+    [compoundValueTransformer addValueTransformer:firstTransformer];
+    RKValueTransformer *secondTransformer = RKTestValueTransformerWithOutputValue(@"2");
+    [compoundValueTransformer addValueTransformer:secondTransformer];
+    RKCompoundValueTransformer *copiedTransformer = [compoundValueTransformer copy];
+    expect(copiedTransformer).notTo.beNil();
+    NSArray *valueTransformers = [copiedTransformer valueTransformersForTransformingFromClass:Nil toClass:Nil];
+    expect(valueTransformers).to.equal((@[ firstTransformer, secondTransformer ]));
+}
+
+#pragma mark NSFastEnumeration
+
+- (void)testFastEnumeration
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    RKValueTransformer *firstTransformer = RKTestValueTransformerWithOutputValue(@"1");
+    [compoundValueTransformer addValueTransformer:firstTransformer];
+    RKValueTransformer *secondTransformer = RKTestValueTransformerWithOutputValue(@"2");
+    [compoundValueTransformer addValueTransformer:secondTransformer];
+    NSMutableArray *enumeratedTransformers = [NSMutableArray new];
+    for (id<RKValueTransforming> valueTransformer in compoundValueTransformer) {
+        [enumeratedTransformers addObject:valueTransformer];
+    }
+    expect(enumeratedTransformers).to.equal((@[ firstTransformer, secondTransformer ]));
+}
+
+@end
+
+@interface RKValueTransformers_NSNumberFormatterTests : SenTestCase
+@end
+
+@implementation RKValueTransformers_NSNumberFormatterTests
+
+- (void)testValidationFromStringToNumber
+{
+    NSNumberFormatter *valueTransformer = [NSNumberFormatter new];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSNumber class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testValidationFromNumberToString
+{
+    NSNumberFormatter *valueTransformer = [NSNumberFormatter new];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSNumber class] toClass:[NSString class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testValidationFailure
+{
+    NSNumberFormatter *valueTransformer = [NSNumberFormatter new];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSURL class] toClass:[NSString class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testTransformationFromNumberToString
+{
+    NSNumberFormatter *valueTransformer = [NSNumberFormatter new];
+    valueTransformer.numberStyle = NSNumberFormatterCurrencyStyle;
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@932480932840923 toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSString class]);
+    expect(value).to.equal(@"$932,480,932,840,923.00");
+}
+
+- (void)testTransformationFromStringToNumber
+{
+    NSNumberFormatter *valueTransformer = [NSNumberFormatter new];
+    valueTransformer.numberStyle = NSNumberFormatterCurrencyStyle;
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"$932,480,932,840,923.00" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSNumber class]);
+    expect(value).to.equal(@932480932840923);
+}
+
+- (void)testTransformationFailureWithUntransformableInputValue
+{
+    NSNumberFormatter *valueTransformer = [NSNumberFormatter new];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[] toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testTransformationFailureFailureWithInvalidInputValue
+{
+    NSNumberFormatter *valueTransformer = [NSNumberFormatter new];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@":*7vxck#sf#adsa" toValue:&value ofClass:[NSNumber class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorTransformationFailed);
+}
+
+- (void)testTransformationFailureWithInvalidDestinationClass
+{
+    NSNumberFormatter *valueTransformer = [NSNumberFormatter new];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"http://restkit.org" toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+@end
+
+@interface RKValueTransformers_NSDateFormatterTests : SenTestCase
+@end
+
+@implementation RKValueTransformers_NSDateFormatterTests
+
+- (void)testValidationFromStringToDate
+{
+    NSDateFormatter *valueTransformer = [NSDateFormatter new];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSDate class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testValidationFromDateToString
+{
+    NSDateFormatter *valueTransformer = [NSDateFormatter new];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSDate class] toClass:[NSString class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testValidationFailure
+{
+    NSDateFormatter *valueTransformer = [NSDateFormatter new];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSURL class] toClass:[NSString class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testTransformationFromDateToString
+{
+    NSDateFormatter *valueTransformer = [NSDateFormatter new];
+    valueTransformer.dateStyle = NSDateFormatterFullStyle;
+    valueTransformer.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
+    valueTransformer.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSDate dateWithTimeIntervalSince1970:0] toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSString class]);
+    expect(value).to.equal(@"Thursday, January 1, 1970");
+}
+
+- (void)testTransformationFromStringToDAte
+{
+    NSDateFormatter *valueTransformer = [NSDateFormatter new];
+    valueTransformer.dateStyle = NSDateFormatterFullStyle;
+    valueTransformer.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
+    valueTransformer.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"Thursday, January 1, 1970" toValue:&value ofClass:[NSDate class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSDate class]);
+    expect([value description]).to.equal(@"1970-01-01 00:00:00 +0000");
+}
+
+- (void)testTransformationFailureWithUntransformableInputValue
+{
+    NSDateFormatter *valueTransformer = [NSDateFormatter new];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[] toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testTransformationFailureFailureWithInvalidInputValue
+{
+    NSDateFormatter *valueTransformer = [NSDateFormatter new];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@":*7vxck#sf#adsa" toValue:&value ofClass:[NSDate class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorTransformationFailed);
+}
+
+- (void)testTransformationFailureWithInvalidDestinationClass
+{
+    NSDateFormatter *valueTransformer = [NSDateFormatter new];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"http://restkit.org" toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+@end
+
+@interface RKValueTransformers_RKISO8601DateFormatterTests : SenTestCase
+@end
+
+@implementation RKValueTransformers_RKISO8601DateFormatterTests
+
+- (void)testValidationFromStringToDate
+{
+    RKISO8601DateFormatter *valueTransformer = [RKISO8601DateFormatter new];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSString class] toClass:[NSDate class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testValidationFromDateToString
+{
+    RKISO8601DateFormatter *valueTransformer = [RKISO8601DateFormatter new];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSDate class] toClass:[NSString class]];
+    expect(success).to.beTruthy();
+}
+
+- (void)testValidationFailure
+{
+    RKISO8601DateFormatter *valueTransformer = [RKISO8601DateFormatter new];
+    BOOL success = [valueTransformer validateTransformationFromClass:[NSURL class] toClass:[NSString class]];
+    expect(success).to.beFalsy();
+}
+
+- (void)testTransformationFromDateToString
+{
+    RKISO8601DateFormatter *valueTransformer = [RKISO8601DateFormatter new];
+    valueTransformer.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
+    valueTransformer.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+    valueTransformer.includeTime = YES;
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:[NSDate dateWithTimeIntervalSince1970:0] toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSString class]);
+    expect(value).to.equal(@"1970-01-01T00:00:00Z");
+}
+
+- (void)testTransformationFromStringToDAte
+{
+    RKISO8601DateFormatter *valueTransformer = [RKISO8601DateFormatter new];
+    valueTransformer.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
+    valueTransformer.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+    valueTransformer.includeTime = YES;
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"1970-01-01T00:00:00Z" toValue:&value ofClass:[NSDate class] error:&error];
+    expect(success).to.beTruthy();
+    expect(value).to.beKindOf([NSDate class]);
+    expect([value description]).to.equal(@"1970-01-01 00:00:00 +0000");
+}
+
+- (void)testTransformationFailureWithUntransformableInputValue
+{
+    RKISO8601DateFormatter *valueTransformer = [RKISO8601DateFormatter new];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@[] toValue:&value ofClass:[NSString class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUntransformableInputValue);
+}
+
+- (void)testTransformationFailureFailureWithInvalidInputValue
+{
+    RKISO8601DateFormatter *valueTransformer = [RKISO8601DateFormatter new];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@":*7vxck#sf#adsa" toValue:&value ofClass:[NSDate class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorTransformationFailed);
+}
+
+- (void)testTransformationFailureWithInvalidDestinationClass
+{
+    RKISO8601DateFormatter *valueTransformer = [RKISO8601DateFormatter new];
+    id value = nil;
+    NSError *error = nil;
+    BOOL success = [valueTransformer transformValue:@"http://restkit.org" toValue:&value ofClass:[NSData class] error:&error];
+    expect(success).to.beFalsy();
+    expect(value).to.beNil();
+    expect(error).notTo.beNil();
+    expect(error.domain).to.equal(RKErrorDomain);
+    expect(error.code).to.equal(RKValueTransformationErrorUnsupportedOutputClass);
+}
+
+@end
+
+
+// test objectToCollectionValueTransformer, mutableValueTransformer


### PR DESCRIPTION
**Squashed pull request moved from https://github.com/RestKit/RestKit/pull/1583**

This pull request adds a new subsystem to the object mapping engine that enables the use of pluggable value transformers. Common value transformations such as from NSString <-> NSDate and NSNumber <-> NSString have always been a core part of the feature-set of RestKit but up to now have required direct customization of the library source code and could only be changed on a global basis. All value transformations that were previously handled within the internals of RKMappingOperation have been factored out into simple standalone transformers. The transformer API is completely extensible and customizable and transfers full control of the mapping process from the framework back to the end developer.

The API has the following design properties:
- Transformers are implemented via a simple `RKValueTransforming` protocol. The protocol has a single required method: `transformValue:toValue:ofClass:error:` and an optional method for validating transformations `validateTransformationFromClass:toClass:`.
- To ease implementation, a concrete `RKBlockValueTransformer` class is provided that enables the end-developer to implement a transformer via blocks. For third-party extensions, an abstract `RKValueTransformer` base class is provided as well.
- All previous internally implemented transformations are provided as singleton instances on the `RKValueTransformer` class.
- To facilitate transforming a value into an unknown target representation with an arbitrary collection of value transformers the `RKCompoundValueTransformer` class is provided. This class itself implements `RKValueTransforming` and will attempt to transform an input value with each of the transformers it contains in programmer defined order, enabling a simple transformation chain to be expressed.
- The previous Date and Time formatting API's have been harmonized with the new value transformation API by making `NSDateFormatter` conform to the `RKValueTransforming` protocol.

It is notable that this API intentionally does not make use of the `NSValueTransformer` class provided by Cocoa. The API was not a clean architectural fit with the needs of RestKit and the implementation contained in the PR is quite a bit simpler and more straight-forward than an `NSValueTransformer` based implementation would be (we walked quite a ways down this road before changing gears).

Full test coverage is implemented and API documentation should be adequate. Comments and feedback are most welcome.
