### PR TITLE
RKObjectMapping copyWithZone should use initWithClass

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -159,8 +159,7 @@ static RKSourceToDesinationKeyTransformationBlock defaultSourceToDestinationKeyT
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    RKObjectMapping *copy = [[[self class] allocWithZone:zone] init];
-    copy.objectClass = self.objectClass;
+    RKObjectMapping *copy = [[[self class] allocWithZone:zone] initWithClass:self.objectClass];
     [copy copyPropertiesFromMapping:self];
     copy.mutablePropertyMappings = [NSMutableArray new];
 


### PR DESCRIPTION
Fixes issues with copying RKObjectMapping where classes and subclasses are setting defaults in the designated initializer.
Fixes crash with RKTableController which blocks use of init.

This could be a fix that should be done on RKTableController to work with the fact that RKObjectMapping copyWithZone uses init. If so, please comment & close this pull request and I'll fix it over there.
