### PR TITLE
Added support for seed databases using WAL

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -245,7 +245,7 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
 
             return NO;
         }
-        if([[NSFileManager defaultManager] fileExistsAtPath:[seedPath stringByAppendingString:@"-shm"]]) {
+        if ([[NSFileManager defaultManager] fileExistsAtPath:[seedPath stringByAppendingString:@"-shm"]]) {
             if (![[NSFileManager defaultManager] copyItemAtPath:[seedPath stringByAppendingString:@"-shm"] toPath:[storePath stringByAppendingString:@"-shm"] error:&localError]) {
                 RKLogError(@"Failed to copy seed database (SHM) from path '%@' to path '%@': %@", seedPath, storePath, [localError localizedDescription]);
                 if (error) *error = localError;
@@ -253,7 +253,7 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
                 return NO;
             }
         }
-        if([[NSFileManager defaultManager] fileExistsAtPath:[seedPath stringByAppendingString:@"-wal"]]) {
+        if ([[NSFileManager defaultManager] fileExistsAtPath:[seedPath stringByAppendingString:@"-wal"]]) {
             if (![[NSFileManager defaultManager] copyItemAtPath:[seedPath stringByAppendingString:@"-wal"] toPath:[storePath stringByAppendingString:@"-wal"] error:&localError]) {
                 RKLogError(@"Failed to copy seed database (WAL) from path '%@' to path '%@': %@", seedPath, storePath, [localError localizedDescription]);
                 if (error) *error = localError;


### PR DESCRIPTION
Databases created in iOS7 have WAL enabled by default, when creating the seed database an extra two files are created:

`database.sqlite-shm`
`database.sqlite-wal`

These need to be copied if they exist from the seed too. I'm happy for this to be replaced with a better implementation but worked fine for me as a fix.
