### PR TITLE
Check for a NULL value in *error.

### DIFF
--- a/Code/Testing/RKMappingTest.m
+++ b/Code/Testing/RKMappingTest.m
@@ -232,7 +232,15 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
             if (! success) {
                 if (blockError) {
                     // If the block has given us an error, use the reason
-                    if (error) *error = blockError;
+                    NSMutableDictionary *mutableUserInfo = [userInfo mutableCopy];
+                    [mutableUserInfo setValue:blockError forKey:NSUnderlyingErrorKey];
+                    NSString *reason = [NSString stringWithFormat:@"expected to %@ with value %@ '%@', but it did not",
+                                        expectation, [event.value class], event.value];
+                    if (error) *error = [self errorForExpectation:expectation
+                                                         withCode:RKMappingTestEvaluationBlockError
+                                                         userInfo:mutableUserInfo
+                                                      description:[blockError localizedDescription]
+                                                           reason:reason];
                 } else {
                     NSString *description = [NSString stringWithFormat:@"evaluation block returned `NO` for %@ value '%@'", [event.value class], event.value];
                     NSString *reason = [NSString stringWithFormat:@"expected to %@ with value %@ '%@', but it did not",


### PR DESCRIPTION
These two comments are in reference to Issue #1652.

Not checking for a NULL value in *error was causing an EXC_BAD_ACCESS exception when the block in the following selector returns NO:
- (instancetype)expectationWithSourceKeyPath:(NSString *)sourceKeyPath destinationKeyPath:(NSString *)destinationKeyPath evaluationBlock:(RKMappingTestExpectationEvaluationBlock)evaluationBlock

The second commit was to remove the assignment to *error on line 239; its immediately overwritten on line 254 so it seems pointless.
