### PR TITLE
Updated the podfile so it can find the correct version / information.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,9 +1,9 @@
 inhibit_all_warnings!
 
 def import_pods
-  pod 'RestKit', :path => '.'
-  pod 'RestKit/Testing', :path => '.'
-  pod 'RestKit/Search', :path => '.'
+  pod 'RestKit', :podspec => 'RestKit.podspec'
+  pod 'RestKit/Testing', :podspec => '.'
+  pod 'RestKit/Search', :podspec => '.'
   
   pod 'Specta', '0.1.9'
   pod 'OCMock', '2.1.1'


### PR DESCRIPTION
Ref. Issue #1657

I wasn't able to install the pods without updating :path to be :podspec. I think :path is deprecated in favour of :pod spec in newer version of pod. 
