### PR TITLE
NSUnknownKeyException when using an RKDynamicMapping as relationship target

### DIFF
--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -707,7 +707,7 @@ static NSString *const RKRootKeyPathPrefix = @"@root.";
             }
             
             if (! objectMapping) continue; // Mapping declined
-            NSArray *propertyKeyPaths = [relationshipMapping valueForKeyPath:@"mapping.propertyMappings.sourceKeyPath"];
+            NSArray *propertyKeyPaths = [objectMapping valueForKeyPath:@"propertyMappings.sourceKeyPath"];
             if (! RKObjectContainsValueForKeyPaths(value, propertyKeyPaths)) {
                 continue;
             }


### PR DESCRIPTION
This is the call stack for the exception:
```
*** Terminating app due to uncaught exception 'NSUnknownKeyException', reason: '[<RKDynamicMapping 0xb8213a0> valueForUndefinedKey:]: this class is not key value coding-compliant for the key propertyMappings.'
*** First throw call stack:
(
	0   CoreFoundation                      0x00b1d5e4 __exceptionPreprocess + 180
	1   libobjc.A.dylib                     0x007958b6 objc_exception_throw + 44
	2   CoreFoundation                      0x00bad6a1 -[NSException raise] + 17
	3   Foundation                          0x000f18ca -[NSObject(NSKeyValueCoding) valueForUndefinedKey:] + 282
	4   Foundation                          0x0005e921 _NSGetUsingKeyValueGetter + 81
	5   Foundation                          0x0005df5b -[NSObject(NSKeyValueCoding) valueForKey:] + 260
	6   Foundation                          0x0007da02 -[NSObject(NSKeyValueCoding) valueForKeyPath:] + 321
	7   Foundation                          0x0007da18 -[NSObject(NSKeyValueCoding) valueForKeyPath:] + 343
	8   Tests                               0x02cbce6d -[RKMappingOperation applyRelationshipMappings] + 1597
	9   Tests                               0x02cc0610 -[RKMappingOperation main] + 4224
	10  Foundation                          0x00105829 -[__NSOperationInternal _start:] + 671
	11  Foundation                          0x00082558 -[NSOperation start] + 83
	12  Tests                               0x02cb99ea -[RKMappingOperation mapNestedObject:toObject:withRelationshipMapping:metadata:] + 1706
	13  Tests                               0x02cbc527 __64-[RKMappingOperation mapOneToManyRelationshipWithValue:mapping:]_block_invoke + 567
	14  CoreFoundation                      0x00b175eb __NSArrayEnumerate + 571
	15  CoreFoundation                      0x00b17196 -[NSArray enumerateObjectsWithOptions:usingBlock:] + 102
	16  CoreFoundation                      0x00b170a5 -[NSArray enumerateObjectsUsingBlock:] + 53
	17  Tests                               0x02cbbd45 -[RKMappingOperation mapOneToManyRelationshipWithValue:mapping:] + 2261
	18  Tests                               0x02cbe2a1 -[RKMappingOperation applyRelationshipMappings] + 6769
	19  Tests                               0x02cc0610 -[RKMappingOperation main] + 4224
	20  Foundation                          0x00105829 -[__NSOperationInternal _start:] + 671
	21  Foundation                          0x00082558 -[NSOperation start] + 83
	22  Tests                               0x02caef05 -[RKMapperOperation mapRepresentation:toObject:atKeyPath:usingMapping:metadata:] + 1957
	23  Tests                               0x02cad780 -[RKMapperOperation mapRepresentation:atKeyPath:usingMapping:] + 1904
	24  Tests                               0x02cb026d -[RKMapperOperation mapRepresentationOrRepresentations:atKeyPath:usingMapping:] + 829
	25  Tests                               0x02cb0bc2 -[RKMapperOperation mapSourceRepresentationWithMappingsDictionary:] + 2210
	26  Tests                               0x02cb158b -[RKMapperOperation main] + 1403
	27  Foundation                          0x00105829 -[__NSOperationInternal _start:] + 671
	28  Foundation                          0x00082558 -[NSOperation start] + 83
	29  Tests                               0x02d03d07 __73-[RKManagedObjectResponseMapperOperation performMappingWithObject:error:]_block_invoke + 4887
	30  CoreData                            0x05731fef developerSubmittedBlockToNSManagedObjectContextPerform + 95
	31  libdispatch.dylib                   0x013c34b0 _dispatch_client_callout + 14
	32  libdispatch.dylib                   0x013b0778 _dispatch_barrier_sync_f_invoke + 58
	33  libdispatch.dylib                   0x013b0422 dispatch_barrier_sync_f + 89
	34  CoreData                            0x05731f1f -[NSManagedObjectContext performBlockAndWait:] + 127
	35  Tests                               0x02d024f1 -[RKManagedObjectResponseMapperOperation performMappingWithObject:error:] + 993
	36  Tests                               0x02cffe33 -[RKResponseMapperOperation main] + 2371
	37  Foundation                          0x00105829 -[__NSOperationInternal _start:] + 671
	38  Foundation                          0x00082558 -[NSOperation start] + 83
	39  Foundation                          0x00107af4 __NSOQSchedule_f + 62
	40  libdispatch.dylib                   0x013c34b0 _dispatch_client_callout + 14
	41  libdispatch.dylib                   0x013b107f _dispatch_queue_drain + 452
	42  libdispatch.dylib                   0x013b0e7a _dispatch_queue_invoke + 128
	43  libdispatch.dylib                   0x013b1e1f _dispatch_root_queue_drain + 83
	44  libdispatch.dylib                   0x013b2137 _dispatch_worker_thread2 + 39
	45  libsystem_pthread.dylib             0x0174fdab _pthread_wqthread + 336
	46  libsystem_pthread.dylib             0x01753cce start_wqthread + 30
)
```

A mapping generated with this code should be able to reproduce the issue:
```objc
    RKDynamicMapping *dynamicMapping = [[RKDynamicMapping alloc] init];
    
    [dynamicMapping setObjectMappingForRepresentationBlock:^RKObjectMapping *(id representation) {
        return <# something not nil #>
    }];
    
    RKEntityMapping *mapping = [RKEntityMapping mappingForEntityForName:<# entity name #> inManagedObjectStore:self.managedObjectStore];
    [mapping addRelationshipMappingWithSourceKeyPath:<# whatever #> mapping:dynamicMapping];
```