### PR TITLE
Honor sqlite Store Options

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -225,7 +225,14 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
     if (! persistentStore) return nil;
     if (! [self.persistentStoreCoordinator removePersistentStore:persistentStore error:error]) return nil;
 
-    NSDictionary *seedOptions = @{ RKSQLitePersistentStoreSeedDatabasePathOption: (seedPath ?: [NSNull null]) };
+    NSDictionary *seedOptions = nil;
+    if (nilOrOptions) {
+        NSMutableDictionary *mutableOptions = [nilOrOptions mutableCopy];
+        [mutableOptions setObject:(seedPath ?: [NSNull null]) forKey:RKSQLitePersistentStoreSeedDatabasePathOption];
+        seedOptions = mutableOptions;
+    } else {
+        seedOptions = @{ RKSQLitePersistentStoreSeedDatabasePathOption: (seedPath ?: [NSNull null]) };
+    }
     persistentStore = [self.persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nilOrConfigurationName URL:storeURL options:seedOptions error:error];
     if (! persistentStore) return nil;
     


### PR DESCRIPTION
iOS 7 and osx 10.9 changed the default journal mode for sqite (see https://developer.apple.com/library/mac/releasenotes/DataManagement/WhatsNew_CoreData_OSX/#//apple_ref/doc/uid/TP40013395-CH1-SW1).

Currently RestKit ignores the store option passed to it.  They are used when creating the first store, which is then deleted, but ignored on the second.  That means its no possible for an app to control the journal mode. 

This patch fixes it.  Or maybe this double creation can be removed at this point?
