### PR TITLE
Fix request descriptor lookup class matching.

### DIFF
--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -84,13 +84,18 @@ RKRequestDescriptor *RKRequestDescriptorFromArrayMatchingObjectAndRequestMethod(
 RKRequestDescriptor *RKRequestDescriptorFromArrayMatchingObjectAndRequestMethod(NSArray *requestDescriptors, id object, RKRequestMethod requestMethod)
 {
     Class searchClass = [object class];
+    NSString *searchClassName = NSStringFromClass(searchClass);
     do {
         for (RKRequestDescriptor *requestDescriptor in requestDescriptors) {
-            if ([requestDescriptor.objectClass isEqual:searchClass] && (requestMethod == requestDescriptor.method)) return requestDescriptor;
-        }
-        
-        for (RKRequestDescriptor *requestDescriptor in requestDescriptors) {
-            if ([requestDescriptor.objectClass isEqual:searchClass] && (requestMethod & requestDescriptor.method)) return requestDescriptor;
+            BOOL matchesRequestMethod = requestMethod & requestDescriptor.method;
+            if (matchesRequestMethod) {
+                Class requestDescriptorClass = requestDescriptor.objectClass;
+                NSString *requestDescriptorClassName = NSStringFromClass(requestDescriptorClass);
+                BOOL matchesClass = [requestDescriptorClassName isEqualToString:searchClassName];
+                if (matchesClass) {
+                    return requestDescriptor;
+                }
+            }
         }
         searchClass = [searchClass superclass];
     } while (searchClass);


### PR DESCRIPTION
`Class` matching was done based on address equality of the `Class`.
Almost always that is enough, but two different `Class` structs can be
created to represent the same thing.  When this happens RestKit could
not match the registered `RequestDescriptor`.

This happened to me and I have no way to create a good reproducable
test.  I found a [StackOverflow
thread](http://stackoverflow.com/questions/16424298/why-is-class-nsclass
fromstringnsstringfromclass-class-on-os-x) on this happening.
