### PR TITLE
1757 non restkit http

### DIFF
--- a/Code/Testing/RKTestHelpers.m
+++ b/Code/Testing/RKTestHelpers.m
@@ -80,7 +80,7 @@
     
     // Extract the dynamic portions of the path pattern to construct a set of parameters
     SOCPattern *pattern = [SOCPattern patternWithString:pathPattern];
-    NSArray *parameterNames = [pattern valueForKeyPath:@"parameters.string"];
+    NSArray *parameterNames = [pattern valueForKey:@"parameters.string"];
     NSMutableDictionary *stubbedParameters = [NSMutableDictionary dictionaryWithCapacity:[parameterNames count]];
     for (NSString *parameter in parameterNames) {
         [stubbedParameters setValue:@"value" forKey:parameter];


### PR DESCRIPTION
Addresses https://github.com/RestKit/RestKit/issues/1757. (Sorry about the accidental merge commits.)

I wanted to add a test for this, which leveraged the fact that the RKOperationStartDate is set on the RKHTTPRequestOperation if the notification is actually run. (I would have checked to ensure that RKOperationStartDate is NOT set on a plain-vanilla AFHTTPRequestOperation.) However, the RKOperationStartDate is just a pointer value (not a constant), which I can't check for deterministically. Thoughts?

Thanks!
