### PR TITLE
Include request/response details in mapped error, when possible

### DIFF
--- a/Code/Network/RKResponseMapperOperation.h
+++ b/Code/Network/RKResponseMapperOperation.h
@@ -253,6 +253,8 @@
 ///----------------
 
 /**
+ **Deprecated - code outside of RKResponseMapperOperation should not need to use this function**
+ 
  Returns a representation of a mapping result as an `NSError` value.
  
  The returned `NSError` object is in the `RKErrorDomain` domain and has the `RKMappingErrorFromMappingResult` code. The value for the `NSLocalizedDescriptionKey` is computed by retrieving the objects in the mapping result as an array, evaluating `valueForKeyPath:@"description"` against the array, and joining the returned error messages by comma to form a single string value. The source error objects are returned with the `NSError` in the `userInfo` dictionary under the `RKObjectMapperErrorObjectsKey` key.
@@ -262,4 +264,4 @@
  @return An error object representing the objects contained in the mapping result.
  @see `RKErrorMessage`
  */
-NSError *RKErrorFromMappingResult(RKMappingResult *mappingResult);
+NSError *RKErrorFromMappingResult(RKMappingResult *mappingResult) DEPRECATED_ATTRIBUTE;


### PR DESCRIPTION
#### Summary

This allows RestKit consumers to perform an error mapping on the response, but still inspect the HTTP status code of the response, or any other properties of the request and response objects.
#### Details

When a non-200-series HTTP status code is received and there is no object mapping set up to handle it, an `NSError` is generated that includes the response string, the request's URL, and the request and response objects themselves. This allows consumers of RestKit to inspect these objects (for instance, to find out the
status code) in order to determine the correct course of action. (See `RKHTTPRequestOperation`'s `error` method)

When an object mapping does exist for non 200-series status codes, the `NSError` object does not include this information - it only includes the mapped error(s) and a localized description. This leaves RestKit consumers no idea of what the HTTP status code was, which is usually important information when determining how to react to an error.

This commit adds URL, request, and response to the `NSError`'s `userInfo`, but does not add `responseString`, because the same information is conveyed by the mapped error object(s) (which are stored in `userInfo[RKObjectMapperErrorObjectsKey]`.

We maintain backwards compatibility by implementing this functionality in a new function, which is invoked using `nil` for `request` and `response` when the old function is called. (There are no internal calls to the old function, but it is listed in a `.h` file so some RestKit consumers may be calling it.)
