### PR TITLE
Passed blocks to newly created object request operations

### DIFF
--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -611,6 +611,8 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
                                            method:(RKRequestMethod)method
                                              path:(NSString *)path
                                        parameters:(NSDictionary *)parameters
+                                          success:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success
+                                          failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     RKObjectRequestOperation *operation = nil;
     NSURLRequest *request = [self requestWithObject:object method:method path:path parameters:parameters];
@@ -636,7 +638,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     if (isManagedObjectRequestOperation && self.managedObjectStore) {
         // Construct a Core Data operation
         NSManagedObjectContext *managedObjectContext = [object respondsToSelector:@selector(managedObjectContext)] ? [object managedObjectContext] : self.managedObjectStore.mainQueueManagedObjectContext;
-        operation = [self managedObjectRequestOperationWithRequest:request responseDescriptors:matchingDescriptors managedObjectContext:managedObjectContext success:nil failure:nil];
+        operation = [self managedObjectRequestOperationWithRequest:request responseDescriptors:matchingDescriptors managedObjectContext:managedObjectContext success:success failure:failure];
 
         if ([object isKindOfClass:[NSManagedObject class]]) {
             static NSPredicate *temporaryObjectsPredicate = nil;
@@ -655,7 +657,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
         }
     } else {
         // Non-Core Data operation
-        operation = [self objectRequestOperationWithRequest:request responseDescriptors:matchingDescriptors success:nil failure:nil];
+        operation = [self objectRequestOperationWithRequest:request responseDescriptors:matchingDescriptors success:success failure:failure];
     }
 #else
     // Non-Core Data operation
@@ -665,6 +667,14 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     if (RKDoesArrayOfResponseDescriptorsContainMappingForClass(self.responseDescriptors, [object class])) operation.targetObject = object;
     operation.mappingMetadata = routingMetadata;
     return operation;
+}
+
+- (id)appropriateObjectRequestOperationWithObject:(id)object
+                                           method:(RKRequestMethod)method
+                                             path:(NSString *)path
+                                       parameters:(NSDictionary *)parameters
+{
+	return [self appropriateObjectRequestOperationWithObject:object method:method path:path parameters:parameters success:nil failure:nil];
 }
 
 - (NSURL *)URLWithRoute:(RKRoute *)route object:(id)object interpolatedParameters:(NSDictionary **)interpolatedParameters
@@ -691,9 +701,8 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     NSDictionary *interpolatedParameters = nil;
     NSURL *URL = [self URLWithRoute:route object:object interpolatedParameters:&interpolatedParameters];
     NSAssert(URL, @"Failed to generate URL for relationship named '%@' for object: %@", relationshipName, object);
-    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:nil method:RKRequestMethodGET path:[URL relativeString] parameters:parameters];
+    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:nil method:RKRequestMethodGET path:[URL relativeString] parameters:parameters success:success failure:failure];
     operation.mappingMetadata = @{ @"routing": @{ @"parameters": interpolatedParameters, @"route": route } };
-    [operation setCompletionBlockWithSuccess:success failure:failure];
     [self enqueueObjectRequestOperation:operation];
 }
 
@@ -710,9 +719,8 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     NSAssert(URL, @"No route found named '%@'", routeName);
     NSAssert(route.method & RKRequestMethodGET, @"Expected route named '%@' to specify a GET, but it does not", routeName);
     
-    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:nil method:RKRequestMethodGET path:[URL relativeString] parameters:parameters];
+    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:nil method:RKRequestMethodGET path:[URL relativeString] parameters:parameters success:success failure:failure];
     operation.mappingMetadata = @{ @"routing": @{ @"parameters": interpolatedParameters, @"route": route } };
-    [operation setCompletionBlockWithSuccess:success failure:failure];
     [self enqueueObjectRequestOperation:operation];
 
 }
@@ -723,8 +731,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
                  failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     NSParameterAssert(path);
-    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:nil method:RKRequestMethodGET path:path parameters:parameters];
-    [operation setCompletionBlockWithSuccess:success failure:failure];
+    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:nil method:RKRequestMethodGET path:path parameters:parameters success:success failure:failure];
     [self enqueueObjectRequestOperation:operation];
 }
 
@@ -735,8 +742,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
           failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     NSAssert(object || path, @"Cannot make a request without an object or a path.");
-    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:object method:RKRequestMethodGET path:path parameters:parameters];
-    [operation setCompletionBlockWithSuccess:success failure:failure];
+    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:object method:RKRequestMethodGET path:path parameters:parameters success:success failure:failure];
     [self enqueueObjectRequestOperation:operation];
 }
 
@@ -747,8 +753,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
            failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     NSAssert(object || path, @"Cannot make a request without an object or a path.");
-    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:object method:RKRequestMethodPOST path:path parameters:parameters];
-    [operation setCompletionBlockWithSuccess:success failure:failure];
+    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:object method:RKRequestMethodPOST path:path parameters:parameters success:success failure:failure];
     [self enqueueObjectRequestOperation:operation];
 }
 
@@ -759,8 +764,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
           failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     NSAssert(object || path, @"Cannot make a request without an object or a path.");
-    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:object method:RKRequestMethodPUT path:path parameters:parameters];
-    [operation setCompletionBlockWithSuccess:success failure:failure];
+    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:object method:RKRequestMethodPUT path:path parameters:parameters success:success failure:failure];
     [self enqueueObjectRequestOperation:operation];
 }
 
@@ -771,8 +775,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
             failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     NSAssert(object || path, @"Cannot make a request without an object or a path.");
-    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:object method:RKRequestMethodPATCH path:path parameters:parameters];
-    [operation setCompletionBlockWithSuccess:success failure:failure];
+    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:object method:RKRequestMethodPATCH path:path parameters:parameters success:success failure:failure];
     [self enqueueObjectRequestOperation:operation];
 }
 
@@ -783,8 +786,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
              failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     NSAssert(object || path, @"Cannot make a request without an object or a path.");
-    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:object method:RKRequestMethodDELETE path:path parameters:parameters];
-    [operation setCompletionBlockWithSuccess:success failure:failure];
+    RKObjectRequestOperation *operation = [self appropriateObjectRequestOperationWithObject:object method:RKRequestMethodDELETE path:path parameters:parameters success:success failure:failure];
     [self enqueueObjectRequestOperation:operation];
 }
 
@@ -925,9 +927,9 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
         NSURL *URL = [self URLWithRoute:route object:object interpolatedParameters:&interpolatedParameters];
         NSAssert(URL, @"Failed to generate URL for route %@ with object %@", route, object);
         if ([route isClassRoute]) {
-            operation = [self appropriateObjectRequestOperationWithObject:object method:route.method path:[URL relativeString] parameters:nil];
+            operation = [self appropriateObjectRequestOperationWithObject:object method:route.method path:[URL relativeString] parameters:nil success:nil failure:nil];
         } else {
-            operation = [self appropriateObjectRequestOperationWithObject:nil method:route.method path:[URL relativeString] parameters:nil];
+            operation = [self appropriateObjectRequestOperationWithObject:nil method:route.method path:[URL relativeString] parameters:nil success:nil failure:nil];
         }
         operation.mappingMetadata = @{ @"routing": interpolatedParameters, @"route": route };
         [operations addObject:operation];


### PR DESCRIPTION
The current implementation of *appropriateObjectRequestOperationWithObject:method:path:parameters:* in the RKObjectManager ignores block params passed by the various request methods. This becomes an issue if you override either the *managedObjectRequestOperationWithRequest* or *objectRequestOperationWithRequest* methods as the callbacks parameters are always set to nil.

To solve this I've added *success* and *failure* arguments to the original method, and set the callbacks at the time the request is created, thereby passing them to an overriden implementation of the *objectRequestOperationWithRequest* methods.

I've ensured the callbacks are passed in.

To ensure backward compatibility I've retained the original method signature, which simply passes nil arguments for the new parameters to the refactored method. This new method is also not publicly exposed, and behaves exactly as the old method did.