### PR TITLE
Exposing ObjectRequestOperation completion blocks

### DIFF
--- a/Code/Network/RKObjectRequestOperation.h
+++ b/Code/Network/RKObjectRequestOperation.h
@@ -164,6 +164,28 @@ extern NSString * const RKResponseHasBeenMappedCacheUserInfoKey;
 - (void)setCompletionBlockWithSuccess:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success
                               failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure;
 
+///------------------------------
+/// @name Accessing Success Block
+///------------------------------
+
+/**
+ The success block associated to the `completionBlock`.
+
+ This property is `nil` if no success block has been attached to the `completionBlock`.
+ */
+@property (nonatomic, copy) void (^successBlock)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult);
+
+///------------------------------
+/// @name Accessing Failure Block
+///------------------------------
+
+/**
+ The failure block associated to the `completionBlock`.
+
+ This property is `nil` if no failure block has been attached to the `completionBlock`.
+ */
+@property (nonatomic, copy) void (^failureBlock)(RKObjectRequestOperation *operation, NSError *error);
+
 /**
  The callback dispatch queue on success. If `NULL` (default), the main queue is used.
  

--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -455,6 +455,10 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
 // See above setCompletionBlock:
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
+
+    self.failureBlock = failure;
+    self.successBlock = success;
+
     self.completionBlock = ^ {
         if ([self isCancelled] && !self.error) {
             self.error = [NSError errorWithDomain:RKErrorDomain code:RKOperationCancelledError userInfo:nil];


### PR DESCRIPTION
In some app I get 401 status code because of user auth token expired. So I had to wrap things like that:
1. Duplicate & backup previous operation
2. Reauthorize user
3. Replay previous operation

But has a reference bug has been fixed about completionBlock, I couldn't access anymore on blocks attached to the completion block.
### Example of operation retry wrapped along 401 status code:

``` objc
+ (void) properlyManagageFailureWithOperation:(RKObjectRequestOperation *)previousOperation
                                        error:(NSError *)error
                                      failure:(void (^)(NSError *error))failure{
    if (previousOperation.HTTPRequestOperation.response.statusCode == 401) {
        [UserManager reauthorizeCustomWithSuccess:^(RKObjectRequestOperation *operation, RKMappingResult *mappingResult) {
            NSMutableURLRequest *newRequest = [previousOperation.HTTPRequestOperation.request mutableCopy];
            [newRequest setAllHTTPHeaderFields:[[RKObjectManager sharedManager].HTTPClient defaultHeaders]];
            RKObjectRequestOperation *newOperation = [[RKObjectRequestOperation alloc] initWithRequest:newRequest
                                                                                   responseDescriptors:previousOperation.responseDescriptors];

            [newOperation setCompletionBlockWithSuccess:previousOperation.successBlock
                                                failure:previousOperation.failureBlock];

            newOperation.targetObject = previousOperation.targetObject;
            newOperation.mappingMetadata = previousOperation.mappingMetadata;
            [[RKObjectManager sharedManager] enqueueObjectRequestOperation:newOperation];

            dispatch_async(dispatch_get_main_queue(), ^{
                [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingOperationDidFinishNotification object:previousOperation.HTTPRequestOperation];
            });

        } failure:^(NSError *error) {
            if (failure) {
                failure(error);
            }
        }];

    } else if(failure) {
        VLRError *vlrError = [VLRError newWithError:error];
        vlrError.originalOperation = previousOperation;
        failure(error);
    }
}
```
