### PR TITLE
fix SOCKit assertions use

### DIFF
--- a/Vendor/SOCKit/SOCKit.m
+++ b/Vendor/SOCKit/SOCKit.m
@@ -376,7 +376,8 @@ NSString* kTemporaryBackslashToken = @"/backslash/";
   }
 
   NSArray* values = nil;
-  NSAssert([self gatherParameterValues:&values fromString:sourceString], @"The pattern can't be used with this string.");
+  BOOL gathered = [self gatherParameterValues:&values fromString:sourceString];
+  NSAssert(gathered, @"The pattern can't be used with this string.");
 
   id returnValue = nil;
 
@@ -401,7 +402,8 @@ NSString* kTemporaryBackslashToken = @"/backslash/";
   NSMutableDictionary* kvs = [[NSMutableDictionary alloc] initWithCapacity:[_parameters count]];
 
   NSArray* values = nil;
-  NSAssert([self gatherParameterValues:&values fromString:sourceString], @"The pattern can't be used with this string.");
+  BOOL gathered = [self gatherParameterValues:&values fromString:sourceString];
+  NSAssert(gathered, @"The pattern can't be used with this string.");
 
   for (NSInteger ix = 0; ix < [values count]; ++ix) {
     SOCParameter* parameter = [_parameters objectAtIndex:ix];


### PR DESCRIPTION
SOCKit used assertions in a wrong way. It caused RestKit to work incorrect in configurations with "Enable Foundation Assertions" set to "NO", f.e. Release configuration.
