### PR TITLE
Dynamic mapping equivalence should just check pointer identity

### DIFF
--- a/Code/ObjectMapping/RKDynamicMapping.m
+++ b/Code/ObjectMapping/RKDynamicMapping.m
@@ -95,8 +95,7 @@
 
 - (BOOL)isEqualToMapping:(RKMapping *)otherMapping
 {
-    // Comparison of dynamic mappings is not currently supported
-    return NO;
+    return (self == otherMapping);
 }
 
 @end


### PR DESCRIPTION
The existing implementation of `isEqualToMapping:` in `RKDynamicMapping` simply returns `NO` in all cases. However, if we have a non-nil `RKDynamicMapping` called `mapping`, this expression

```
[mapping isEqualToMapping:mapping]
```

should evaluate to `YES`. It is nonsensical and unexpected to return `NO` in this case. 

I understand that comparing two dynamic mappings on a matcher-by-matcher basis would take a non-trivial amount of care and work to implement correctly. So for now, we should leave this check to be simply pointer equality.
