### PR TITLE
[FIX] -[NSNull hasPrefix:]: unrecognized selector sent to instance

### DIFF
--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -104,6 +104,7 @@ NSArray *RKApplyNestingAttributeValueToMappings(NSString *attributeName, id valu
 static BOOL RKObjectContainsValueForKeyPaths(id representation, NSArray *keyPaths)
 {
     for (NSString *keyPath in keyPaths) {
+        if([keyPath isKindOfClass:[NSNull class]]) return YES;
         if ([representation valueForKeyPath:keyPath]) return YES;
     }
     return NO;


### PR DESCRIPTION
[FIX]  - Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull hasPrefix:]: unrecognized selector sent to instance
