### PR TITLE
Build the RKPathMatcher for a RKResponseDescriptor only once

### DIFF
--- a/Code/Network/RKResponseDescriptor.m
+++ b/Code/Network/RKResponseDescriptor.m
@@ -63,6 +63,7 @@ extern NSString *RKStringDescribingRequestMethod(RKRequestMethod method);
 @property (nonatomic, strong, readwrite) RKMapping *mapping;
 @property (nonatomic, assign, readwrite) RKRequestMethod method;
 @property (nonatomic, copy, readwrite) NSString *pathPattern;
+@property (nonatomic, strong, readwrite) RKPathMatcher *pathPatternMatcher;
 @property (nonatomic, copy, readwrite) NSString *keyPath;
 @property (nonatomic, copy, readwrite) NSIndexSet *statusCodes;
 @end
@@ -97,6 +98,16 @@ extern NSString *RKStringDescribingRequestMethod(RKRequestMethod method);
     return mappingDescriptor;
 }
 
+- (void)setPathPattern:(NSString *)pathPattern
+{
+    _pathPattern = pathPattern;
+    if (pathPattern) {
+        self.pathPatternMatcher = [RKPathMatcher pathMatcherWithPattern:pathPattern];
+    } else {
+        self.pathPatternMatcher = nil;
+    }
+}
+
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"<%@: %p method=%@ pathPattern=%@ keyPath=%@ statusCodes=%@ : %@>",
@@ -106,8 +117,7 @@ extern NSString *RKStringDescribingRequestMethod(RKRequestMethod method);
 - (BOOL)matchesPath:(NSString *)path
 {
     if (!self.pathPattern || !path) return YES;
-    RKPathMatcher *pathMatcher = [RKPathMatcher pathMatcherWithPattern:self.pathPattern];
-    return [pathMatcher matchesPath:path tokenizeQueryStrings:NO parsedArguments:nil];
+    return [self.pathPatternMatcher matchesPath:path tokenizeQueryStrings:NO parsedArguments:nil];
 }
 
 - (BOOL)matchesURL:(NSURL *)URL


### PR DESCRIPTION
In our project, we use RK extensively and have hundreds of response descriptors. We found that a major hotspot in returning data from the server was that RKFilteredArrayOfResponseDescriptorsMatchingPathAndMethod invokes RKResponseDescriptor's matchesPath selector for every response descriptor. Each request creates a new RKPathMatcher, which compiles an SOCPattern. The time for the compiling really starts to add up.

This code saves a pathPatternMatcher as a private variable in RKResponseDescriptor so that each descriptor only ever creates a RKPathMatcher once. Other than that, it behaves exactly as before.
