### PR TITLE
Adds the possibility to use the custom RKObjectRequestOperation class in RKPaginator

### DIFF
--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -803,6 +803,8 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
 	Class HTTPOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredHTTPRequestOperationClasses];
     if (HTTPOperationClass) [paginator setHTTPOperationClass:HTTPOperationClass];
 #endif
+	Class objectRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredObjectRequestOperationClasses];
+	if (objectRequestOperationClass) [paginator setObjectRequestOperationClass:objectRequestOperationClass];
     paginator.operationQueue = self.operationQueue;
     return paginator;
 }

--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -800,10 +800,10 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
     paginator.managedObjectContext = self.managedObjectStore.mainQueueManagedObjectContext;
     paginator.managedObjectCache = self.managedObjectStore.managedObjectCache;
     paginator.fetchRequestBlocks = self.fetchRequestBlocks;
+	Class HTTPOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredHTTPRequestOperationClasses];
+    if (HTTPOperationClass) [paginator setHTTPOperationClass:HTTPOperationClass];
 #endif
     paginator.operationQueue = self.operationQueue;
-    Class HTTPOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredHTTPRequestOperationClasses];
-    if (HTTPOperationClass) [paginator setHTTPOperationClass:HTTPOperationClass];
     return paginator;
 }
 

--- a/Code/Network/RKPaginator.h
+++ b/Code/Network/RKPaginator.h
@@ -111,7 +111,12 @@
  */
 - (void)setHTTPOperationClass:(Class)operationClass;
 
-- (void)setObjectRequestOperationClass:(Class)objectRequestOperation;
+/**
+ Sets the `RKObjectRequestOperation` subclass to be used when constructing HTTP request operations for requests dispatched by the paginator.
+ 
+ **Default**: `[RKObjectRequestOperation class]`
+ */
+- (void)setObjectRequestOperationClass:(Class)operationClass;
 
 ///-----------------------------------
 /// @name Setting the Completion Block

--- a/Code/Network/RKPaginator.h
+++ b/Code/Network/RKPaginator.h
@@ -111,6 +111,8 @@
  */
 - (void)setHTTPOperationClass:(Class)operationClass;
 
+- (void)setObjectRequestOperationClass:(Class)objectRequestOperation;
+
 ///-----------------------------------
 /// @name Setting the Completion Block
 ///-----------------------------------

--- a/Code/Network/RKPaginator.m
+++ b/Code/Network/RKPaginator.m
@@ -38,6 +38,7 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
 @interface RKPaginator ()
 @property (nonatomic, copy) NSURLRequest *request;
 @property (nonatomic, strong) Class HTTPOperationClass;
+@property (nonatomic, strong) Class objectRequestOperationClass;
 @property (nonatomic, copy) NSArray *responseDescriptors;
 @property (nonatomic, assign, readwrite) NSUInteger currentPage;
 @property (nonatomic, assign, readwrite) NSUInteger offset;
@@ -71,6 +72,7 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
     self = [super init];
     if (self) {
         self.HTTPOperationClass = [RKHTTPRequestOperation class];
+		self.objectRequestOperationClass = [RKObjectRequestOperation class];
         self.request = request;
         self.paginationMapping = paginationMapping;
         self.responseDescriptors = responseDescriptors;
@@ -106,6 +108,12 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
 {
     NSAssert(operationClass == nil || [operationClass isSubclassOfClass:[RKHTTPRequestOperation class]], @"The HTTP operation class must be a subclass of `RKHTTPRequestOperation`");
     _HTTPOperationClass = operationClass;
+}
+
+- (void)setObjectRequestOperation:(Class)objectRequestOperation
+{
+	NSAssert(objectRequestOperation == nil || [objectRequestOperation isSubclassOfClass:[RKObjectRequestOperation class]], @"The objectRequestOperation class must be a subclass of `RKObjectRequestOperation`");
+    _objectRequestOperationClass = objectRequestOperation;
 }
 
 - (void)setCompletionBlockWithSuccess:(void (^)(RKPaginator *paginator, NSArray *objects, NSUInteger page))success
@@ -200,10 +208,10 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
         
         self.objectRequestOperation = managedObjectRequestOperation;
     } else {
-        self.objectRequestOperation = [[RKObjectRequestOperation alloc] initWithRequest:mutableRequest responseDescriptors:self.responseDescriptors];
+        self.objectRequestOperation = [[self.objectRequestOperationClass alloc] initWithRequest:mutableRequest responseDescriptors:self.responseDescriptors];
     }
 #else
-    self.objectRequestOperation = [[RKObjectRequestOperation alloc] initWithRequest:mutableRequest responseDescriptors:self.responseDescriptors];
+    self.objectRequestOperation = [[self.objectRequestOperationClass alloc] initWithRequest:mutableRequest responseDescriptors:self.responseDescriptors];
 #endif
     
     // Add KVO to ensure notification of loaded state prior to execution of completion block

--- a/Code/Network/RKPaginator.m
+++ b/Code/Network/RKPaginator.m
@@ -110,7 +110,7 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
     _HTTPOperationClass = operationClass;
 }
 
-- (void)setObjectRequestOperation:(Class)objectRequestOperation
+- (void)setObjectRequestOperationClass:(Class)objectRequestOperation
 {
 	NSAssert(objectRequestOperation == nil || [objectRequestOperation isSubclassOfClass:[RKObjectRequestOperation class]], @"The objectRequestOperation class must be a subclass of `RKObjectRequestOperation`");
     _objectRequestOperationClass = objectRequestOperation;


### PR DESCRIPTION
Set `RKObjectRequestOperation` subclass to be used when constructing HTTP request operations for requests dispatched by the paginator similar to the custom `HTTPOperationClass` implementation. 