### PR TITLE
Remove a vestige of an older version of clang - remove &*

### DIFF
--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -601,7 +601,7 @@ BOOL RKDoesArrayOfResponseDescriptorsContainOnlyEntityMappings(NSArray *response
     self.responseMapperOperation.managedObjectCache = self.managedObjectCache;
     [self.responseMapperOperation setWillMapDeserializedResponseBlock:self.willMapDeserializedResponseBlock];
     [self.responseMapperOperation setQueuePriority:[self queuePriority]];    
-    __weak __typeof(&*self)weakSelf = self;
+    __weak __typeof(self)weakSelf = self;
     [self.responseMapperOperation setDidFinishMappingBlock:^(RKMappingResult *mappingResult, NSError *responseMappingError) {
         if ([weakSelf isCancelled]) return completionBlock(mappingResult, responseMappingError);
         

--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -351,7 +351,7 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
         self.HTTPRequestOperation.successCallbackQueue = [[self class] dispatchQueue];
         self.HTTPRequestOperation.failureCallbackQueue = [[self class] dispatchQueue];
         
-        __weak __typeof(&*self)weakSelf = self;
+        __weak __typeof(self)weakSelf = self;
         self.stateMachine = [[RKOperationStateMachine alloc] initWithOperation:self dispatchQueue:[[self class] dispatchQueue]];
         [self.stateMachine setExecutionBlock:^{
             [[NSNotificationCenter defaultCenter] postNotificationName:RKObjectRequestOperationDidStartNotification object:weakSelf];
@@ -496,7 +496,7 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
 
 - (void)execute
 {
-    __weak __typeof(&*self)weakSelf = self;    
+    __weak __typeof(self)weakSelf = self;    
     
     [self.HTTPRequestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (weakSelf.isCancelled) {

--- a/Code/Search/RKSearchIndexer.m
+++ b/Code/Search/RKSearchIndexer.m
@@ -292,7 +292,7 @@ NSString * const RKSearchableAttributeNamesUserInfoKey = @"RestKitSearchableAttr
     
     // Enqueue an operation for each object to index
     NSArray *objectIDsForObjectsToIndex = [objectsToIndex valueForKey:@"objectID"];
-    __weak __typeof(&*self)weakSelf = self;
+    __weak __typeof(self)weakSelf = self;
     __block NSBlockOperation *indexingOperation = [NSBlockOperation blockOperationWithBlock:^{
         if ([indexingOperation isCancelled]) return;
         [weakSelf.indexingContext performBlockAndWait:^{

--- a/Code/Support/RKOperationStateMachine.m
+++ b/Code/Support/RKOperationStateMachine.m
@@ -57,7 +57,7 @@ static NSString *const RKOperationLockName = @"org.restkit.operation.lock";
 
         // NOTE: State transitions are guarded by a lock via start/finish/cancel action methods
         TKState *readyState = [TKState stateWithName:RKOperationStateReady];
-        __weak __typeof(&*self)weakSelf = self;
+        __weak __typeof(self)weakSelf = self;
         [readyState setWillExitStateBlock:^(TKState *state, TKTransition *transition) {
             [weakSelf.operation willChangeValueForKey:@"isReady"];
         }];
@@ -167,7 +167,7 @@ static NSString *const RKOperationLockName = @"org.restkit.operation.lock";
 
 - (void)setExecutionBlock:(void (^)(void))block
 {
-    __weak __typeof(&*self)weakSelf = self;
+    __weak __typeof(self)weakSelf = self;
     TKState *executingState = [self.stateMachine stateNamed:RKOperationStateExecuting];
     [executingState setDidEnterStateBlock:^(TKState *state, TKTransition *transition) {
         [weakSelf.operation didChangeValueForKey:@"isExecuting"];
@@ -179,7 +179,7 @@ static NSString *const RKOperationLockName = @"org.restkit.operation.lock";
 
 - (void)setFinalizationBlock:(void (^)(void))block
 {
-    __weak __typeof(&*self)weakSelf = self;
+    __weak __typeof(self)weakSelf = self;
     TKState *finishedState = [self.stateMachine stateNamed:RKOperationStateFinished];
     [finishedState setWillEnterStateBlock:^(TKState *state, TKTransition *transition) {
         [weakSelf performBlockWithLock:^{

--- a/Tests/Logic/CoreData/RKEntityByAttributeCacheTest.m
+++ b/Tests/Logic/CoreData/RKEntityByAttributeCacheTest.m
@@ -305,7 +305,7 @@
     RKChild *child = [NSEntityDescription insertNewObjectForEntityForName:@"Human" inManagedObjectContext:self.managedObjectStore.persistentStoreManagedObjectContext];
     child.railsID = [NSNumber numberWithInteger:12345];
 
-    __weak __typeof(&*self)weakSelf = self;
+    __weak __typeof(self)weakSelf = self;
     __block BOOL done = NO;
     RKEntityByAttributeCache *cache = self.cache;
     [cache addObjects:[NSSet setWithObject:human] completion:^{


### PR DESCRIPTION
`&*` is no longer needed by clang and can be safely removed
