### PR TITLE
fixes #1995 - RKMananagedObjectRequestOperation:localObjectsFromFetchRequests parameter not used

### DIFF
--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -568,8 +568,7 @@ BOOL RKDoesArrayOfResponseDescriptorsContainOnlyEntityMappings(NSArray *response
 
 - (void)performMappingOnResponseWithCompletionBlock:(void(^)(RKMappingResult *mappingResult, NSError *error))completionBlock
 {
-    NSURL *URL = RKRelativeURLFromURLAndResponseDescriptors(self.HTTPRequestOperation.response.URL, self.responseDescriptors);
-    NSArray *fetchRequests = RKArrayOfFetchRequestFromBlocksWithURL(self.fetchRequestBlocks, URL);
+    NSArray *fetchRequests = [self fetchRequestsMatchingResponseURL];
     if ([fetchRequests count] && [self canSkipMapping]) {
         RKLogDebug(@"Managed object mapping requested for cached response which was previously mapped: skipping...");
         NSMutableArray *managedObjects = [NSMutableArray array];
@@ -674,34 +673,24 @@ BOOL RKDoesArrayOfResponseDescriptorsContainOnlyEntityMappings(NSArray *response
 
 - (NSSet *)localObjectsFromFetchRequests:(NSArray *)fetchRequests matchingRequestURL:(NSError **)error
 {
-    NSMutableSet *localObjects = [NSMutableSet set];    
+    NSMutableSet *localObjects = [NSMutableSet set];
     __block NSError *_blockError;
     __block NSArray *_blockObjects;
     
-    // Pass the fetch request blocks a relative `NSURL` object if possible
-    NSURL *URL = RKRelativeURLFromURLAndResponseDescriptors(self.HTTPRequestOperation.response.URL, self.responseDescriptors);
-    for (RKFetchRequestBlock fetchRequestBlock in [self.fetchRequestBlocks reverseObjectEnumerator]) {
-        NSFetchRequest *fetchRequest = fetchRequestBlock(URL);
-        if (fetchRequest) {
-            // Workaround for iOS 5 -- The log statement crashes if the entity is not assigned before logging
-            [fetchRequest setEntity:[[[[self.privateContext persistentStoreCoordinator] managedObjectModel] entitiesByName] objectForKey:[fetchRequest entityName]]];
-            RKLogDebug(@"Found fetch request matching URL '%@': %@", URL, fetchRequest);
-
-            [self.privateContext performBlockAndWait:^{
-                _blockObjects = [self.privateContext executeFetchRequest:fetchRequest error:&_blockError];
-            }];
-
-            if (_blockObjects == nil) {
-                if (error) *error = _blockError;
-                return nil;
-            }
-            RKLogTrace(@"Fetched local objects matching URL '%@' with fetch request '%@': %@", URL, fetchRequest, _blockObjects);
-            [localObjects addObjectsFromArray:_blockObjects];
-        } else {
-            RKLogTrace(@"Fetch request block %@ returned nil fetch request for URL: '%@'", fetchRequestBlock, URL);
+    for (NSFetchRequest *fetchRequest in fetchRequests) {
+        [self.privateContext performBlockAndWait:^{
+            _blockObjects = [self.privateContext executeFetchRequest:fetchRequest error:&_blockError];
+        }];
+        
+        if (_blockObjects == nil) {
+            if (error) *error = _blockError;
+            return nil;
         }
+        RKLogTrace(@"Fetched local objects matching URL with fetch request '%@': %@", fetchRequest, _blockObjects);
+        [localObjects addObjectsFromArray:_blockObjects];
+        
     }
-
+    
     return localObjects;
 }
 


### PR DESCRIPTION
This changes provide a single entry point for retrieving the fetch requests from the fetch request blocks, which allows subclasses to extend the behaviour of how the fetch request block are constructed overriding `fetchRequestsMatchingResponseURL`
