### PR TITLE
Set default values for non optional and missing attributes

### DIFF
--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -437,7 +437,7 @@ static NSString *const RKSelfKeyPathPrefix = @"self.";
     if (! inputValue) {
         *outputValue = nil;
         // We only want to consider the transformation successful and assign nil if the mapping calls for it
-        return propertyMapping.objectMapping.assignsDefaultValueForMissingAttributes;
+        return !propertyMapping.objectMapping.assignsDefaultValueForMissingAttributes;
     }
     Class transformedValueClass = propertyMapping.propertyValueClass ?: [self.objectMapping classForKeyPath:propertyMapping.destinationKeyPath];
     if (! transformedValueClass) {


### PR DESCRIPTION
Even if setAssignsDefaultValueForMissingAttributes is set to YES on the RKEntityMapping, Restkit does not assign the default value of non optional attributes if the attribute is missing in the xml source, and CoreData fails because the attribute is non optional.