### PR TITLE
Fixes a "Collection was mutated while being enumerated" error

### DIFF
--- a/Code/CoreData/NSManagedObjectContext+RKAdditions.m
+++ b/Code/CoreData/NSManagedObjectContext+RKAdditions.m
@@ -52,7 +52,9 @@
          4. Save the child context to the parent context (the main one) which will work,
          5. Save the main context - a NSObjectInaccessibleException will occur and Core Data will either crash your app or lock it up (a semaphore is not correctly released on the first error so the next fetch request will block forever.
          */
-        [contextToSave obtainPermanentIDsForObjects:[[contextToSave insertedObjects] allObjects] error:&localError];
+         [contextToSave performBlockAndWait:^{
+             [contextToSave obtainPermanentIDsForObjects:[[contextToSave insertedObjects] allObjects] error:&localError];
+         }];
         if (localError) {
             if (error) *error = localError;
             return NO;


### PR DESCRIPTION
I regularly encountered a crash while saving a MOC. This, as far as I can tell, stems from background threads creating new objects in a `[context performBlock:]` while another thread is saving. Those concurrent saves would lead to a  `*** Terminating app due to uncaught exception 'NSGenericException', reason: '*** Collection was mutated while being enumerated.'` error. Encapsulating the `obtainPermanentIDsForObjects:` in a `performBlockAndWait:` seems to fix this problem.
