### PR TITLE
Don't log potentially sensitive information at Error/Warning/Info log levels

### DIFF
--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -171,7 +171,8 @@ static void *RKOperationFinishDate = &RKOperationFinishDate;
     NSString *statusCodeAndElapsedTime = statusCodeString ? [NSString stringWithFormat:@"(%ld %@) %@", (long)[operation.response statusCode], statusCodeString, elapsedTimeString] : [NSString stringWithFormat:@"(%ld) %@", (long)[operation.response statusCode], elapsedTimeString];
     if (operation.error) {
         if ((_RKlcl_component_level[(__RKlcl_log_symbol(RKlcl_cRestKitNetwork))]) >= (__RKlcl_log_symbol(RKlcl_vTrace))) {
-            RKLogError(@"%@ '%@' %@:\nerror=%@\nresponse.body=%@", [operation.request HTTPMethod], [[operation.request URL] absoluteString], statusCodeAndElapsedTime, operation.error, operation.responseString);
+            RKLogError(@"%@ '%@' %@:\nerror=%@", [operation.request HTTPMethod], [[operation.request URL] absoluteString], statusCodeAndElapsedTime, operation.error);
+            RKLogDebug(@"response.body=%@", operation.responseString);
         } else {
             if (operation.error.code == NSURLErrorCancelled) {
                 RKLogError(@"%@ '%@' %@: Cancelled", [operation.request HTTPMethod], [[operation.request URL] absoluteString], statusCodeAndElapsedTime);
@@ -205,7 +206,8 @@ static void *RKOperationFinishDate = &RKOperationFinishDate;
     NSString *statusCodeAndElapsedTime = [NSString stringWithFormat:@"(%ld%@/ %lu objects) %@", (long)[HTTPRequestOperation.response statusCode], statusCodeDescription, (unsigned long) [objectRequestOperation.mappingResult count], elapsedTimeString];
     if (objectRequestOperation.error) {
         if ((_RKlcl_component_level[(__RKlcl_log_symbol(RKlcl_cRestKitNetwork))]) >= (__RKlcl_log_symbol(RKlcl_vTrace))) {
-            RKLogError(@"%@ '%@' %@:\nerror=%@\nresponse.body=%@", [HTTPRequestOperation.request HTTPMethod], [[HTTPRequestOperation.request URL] absoluteString], statusCodeAndElapsedTime, objectRequestOperation.error, HTTPRequestOperation.responseString);
+            RKLogError(@"%@ '%@' %@:\nerror=%@", [HTTPRequestOperation.request HTTPMethod], [[HTTPRequestOperation.request URL] absoluteString], statusCodeAndElapsedTime, objectRequestOperation.error);
+            RKLogDebug(@"response.body=%@", HTTPRequestOperation.responseString);
         } else {
             if (objectRequestOperation.error.code == NSURLErrorCancelled) {
                 RKLogError(@"%@ '%@' %@: Cancelled", [HTTPRequestOperation.request HTTPMethod], [[HTTPRequestOperation.request URL] absoluteString], statusCodeAndElapsedTime);

--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -339,11 +339,12 @@ static NSString *const RKSelfKeyPathPrefix = @"self.";
         if (!success) {
             self.error = validationError;
             if (validationError) {
-                RKLogError(@"Validation failed while mapping attribute at key path '%@' to value %@. Error: %@", keyPath, *value, [validationError localizedDescription]);
+                RKLogError(@"Validation failed while mapping attribute at key path '%@' to value. Error: %@", keyPath, [validationError localizedDescription]);
                 RKLogValidationError(validationError);
             } else {
-                RKLogWarning(@"Destination object %@ rejected attribute value %@ for keyPath %@. Skipping...", self.destinationObject, *value, keyPath);
+                RKLogWarning(@"Destination object %@ rejected attribute value for keyPath %@. Skipping...", self.destinationObject, keyPath);
             }
+            RKLogDebug(@"(Value for key path '%@': %@)", keyPath, *value);
         }
     }
 
@@ -651,7 +652,8 @@ static NSString *const RKSelfKeyPathPrefix = @"self.";
     NSMutableArray *relationshipCollection = [NSMutableArray arrayWithCapacity:[value count]];
     if (RKObjectIsCollectionOfCollections(value)) {
         RKLogWarning(@"WARNING: Detected a relationship mapping for a collection containing another collection. This is probably not what you want. Consider using a KVC collection operator (such as @unionOfArrays) to flatten your mappable collection.");
-        RKLogWarning(@"Key path '%@' yielded collection containing another collection rather than a collection of objects: %@", relationshipMapping.sourceKeyPath, value);
+        RKLogWarning(@"Key path '%@' yielded collection containing another collection rather than a collection of objects", relationshipMapping.sourceKeyPath);
+        RKLogDebug(@"(Value at key path '%@': %@)", relationshipMapping.sourceKeyPath, value);
     }
     
     if (relationshipMapping.assignmentPolicy == RKUnionAssignmentPolicy) {


### PR DESCRIPTION
Hi folks,
I realize that this idea may require some discussion, but since I already have code written I figured I'd open a PR rather than a regular issue.

**The problem:** some services that are important to development (like Crashlytics) collect the app's logs and send it to their servers. Many companies (such as the one I work for!) have legal requirements that no personally identifiable information (or other sensitive information) gets sent to 3rd parties. We've audited all of our own logging, plus we identified a few places where RestKit would log out the entire response from the server, or key/value pairs of mapped data at the Error and Warning logging levels. This means that if we ship the app with any RestKit logging enabled (other than Critical log level), we risk sending sensitive information to 3rd parties like Crashlytics.

**The proposal:** Apps should be able to ship with RestKit set to log at the Info logging level. With that in mind, the code in this PR identifies sensitive information and demotes logging that information down to the Debug logging level.

I'm happy to have a discussion around whether or not this is the right solution. I'm not tied to the code I've written here, so I'd very much like to hear thoughts from other folks.
