### PR TITLE
Add optional parameters dictionary to paginatorWithPathPattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ fetchRequest.predicate = predicate;
 
 // Contains article1 due to body text containing 'match'
 NSArray *matches = [managedObjectStore.mainQueueManagedObjectContext executeFetchRequest:fetchRequest error:nil];
-NSLog(@"Found the matching articls: %@", matches);
+NSLog(@"Found the matching articles: %@", matches);
 ```
 
 ### Unit Test a Mapping


### PR DESCRIPTION
When `RKObjectManager` calls `requestWithMethod` in `paginatorWithPathPattern` it passes in `nil` for the parameters argument. 

This small change adds a overloaded `paginatorWithPathPattern` method with a `NSDictionary` argument. 
