### PR TITLE
RKManagedObjectRequestOperation: revert to main MOC (address #2020)

### DIFF
--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -572,10 +572,10 @@ BOOL RKDoesArrayOfResponseDescriptorsContainOnlyEntityMappings(NSArray *response
     if ([fetchRequests count] && [self canSkipMapping]) {
         RKLogDebug(@"Managed object mapping requested for cached response which was previously mapped: skipping...");
         NSMutableArray *managedObjects = [NSMutableArray array];
-        [self.privateContext performBlockAndWait:^{
+        [self.managedObjectContext performBlockAndWait:^{
             NSError *error = nil;
             for (NSFetchRequest *fetchRequest in fetchRequests) {
-                NSArray *fetchedObjects = [self.privateContext executeFetchRequest:fetchRequest error:&error];
+                NSArray *fetchedObjects = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
                 if (fetchedObjects) {
                     [managedObjects addObjectsFromArray:fetchedObjects];
                 } else {


### PR DESCRIPTION
This change reverts changes introduced by [this commit](https://github.com/RestKit/RestKit/commit/129cc6f052e31116ce12502d1246f04ddd5ad85b). Currently creation of managed objects from inside private context leads to that we get these objects lost when use them from main Managed Object Context (demonstration is in #2020).