### PR TITLE
Update project format from the old XML using Xcode 6.1 (5.x-compatible)

### DIFF
--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -1,12882 +1,2917 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>04D69B4B2A54475834B333CF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-osx.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>061E3E4524CE8EF78257C26C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-ios.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-ios/Pods-ios.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>0779C6DD2283438BA5EAB1FB</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-resources.sh"
-</string>
-		</dict>
-		<key>147F950728350A64F103F55D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-ios.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15BB5BBD8E8B9B2C9C8B11BC</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>147F950728350A64F103F55D</string>
-				<string>061E3E4524CE8EF78257C26C</string>
-				<string>D8EFCBE1978F7946E0081FAD</string>
-				<string>04D69B4B2A54475834B333CF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>212C92B936E847348494D6F7</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-resources.sh"
-</string>
-		</dict>
-		<key>2501405215366000004E0466</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>RKObjectiveCppTest.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2502C8E715F79CF70060FD75</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>CoreData.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2502C8E815F79CF70060FD75</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Network.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2502C8E915F79CF70060FD75</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ObjectMapping.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2502C8EA15F79CF70060FD75</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Search.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2502C8EB15F79CF70060FD75</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Support.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2502C8EC15F79CF70060FD75</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Testing.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2502C8ED15F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8E715F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8EE15F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8E715F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8EF15F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8E815F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8F015F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8E815F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8F115F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8E915F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8F215F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8E915F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8F315F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8EA15F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8F415F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8EA15F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8F515F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8EB15F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8F615F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8EB15F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8F715F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8EC15F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2502C8F815F79CF70060FD75</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2502C8EC15F79CF70060FD75</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25055B8014EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RKMappingTest.h</string>
-			<key>path</key>
-			<string>Testing/RKMappingTest.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25055B8114EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RKMappingTest.m</string>
-			<key>path</key>
-			<string>Testing/RKMappingTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25055B8214EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RKTestFactory.h</string>
-			<key>path</key>
-			<string>Testing/RKTestFactory.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25055B8314EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RKTestFactory.m</string>
-			<key>path</key>
-			<string>Testing/RKTestFactory.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25055B8414EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8014EEF32A00B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25055B8514EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8014EEF32A00B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25055B8614EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8114EEF32A00B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25055B8714EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8114EEF32A00B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25055B8814EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8214EEF32A00B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25055B8914EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8214EEF32A00B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25055B8A14EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8314EEF32A00B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25055B8B14EEF32A00B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8314EEF32A00B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25055B8D14EEF40000B9C4DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RKPropertyMappingTestExpectation.h</string>
-			<key>path</key>
-			<string>Testing/RKPropertyMappingTestExpectation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25055B8E14EEF40000B9C4DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RKPropertyMappingTestExpectation.m</string>
-			<key>path</key>
-			<string>Testing/RKPropertyMappingTestExpectation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25055B8F14EEF40000B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8D14EEF40000B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25055B9014EEF40000B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8D14EEF40000B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25055B9114EEF40000B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8E14EEF40000B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25055B9214EEF40000B9C4DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25055B8E14EEF40000B9C4DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2506759F162DEA25003210B0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FC91456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>250675A1162DEA27003210B0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FC91456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25079C75151B952200266AE7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>NSEntityDescription+RKAdditionsTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2507C325161BD5C700EA71FF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RKTestHelpers.h</string>
-			<key>path</key>
-			<string>Testing/RKTestHelpers.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2507C326161BD5C700EA71FF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RKTestHelpers.m</string>
-			<key>path</key>
-			<string>Testing/RKTestHelpers.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2507C327161BD5C700EA71FF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2507C325161BD5C700EA71FF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2507C328161BD5C700EA71FF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2507C325161BD5C700EA71FF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2507C329161BD5C700EA71FF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2507C326161BD5C700EA71FF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2507C32A161BD5C700EA71FF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2507C326161BD5C700EA71FF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>250CA67F147D8EEC0047D347</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>dstPath</key>
-			<string></string>
-			<key>dstSubfolderSpec</key>
-			<string>16</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXCopyFilesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25104F0E15C30C7900829135</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25104F1315C30CD900829135</string>
-				<string>25104F1415C30CD900829135</string>
-				<string>25104F2715C30D1700829135</string>
-				<string>25104F2815C30D1700829135</string>
-				<string>25104F2D15C30E7400829135</string>
-				<string>25104F2E15C30E7400829135</string>
-				<string>25104F3315C30EF500829135</string>
-				<string>25104F3415C30EF500829135</string>
-				<string>25104F3915C30F2000829135</string>
-				<string>25104F3A15C30F2100829135</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Search</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F1315C30CD900829135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKSearchWord.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F1415C30CD900829135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKSearchWord.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F1F15C30CD900829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F1315C30CD900829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25104F2015C30CD900829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F1315C30CD900829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25104F2115C30CD900829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F1415C30CD900829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25104F2215C30CD900829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F1415C30CD900829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25104F2715C30D1700829135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKManagedObjectStore+RKSearchAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F2815C30D1700829135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKManagedObjectStore+RKSearchAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F2915C30D1700829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F2715C30D1700829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25104F2A15C30D1700829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F2715C30D1700829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25104F2B15C30D1700829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F2815C30D1700829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25104F2C15C30D1700829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F2815C30D1700829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25104F2D15C30E7400829135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKSearchIndexer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F2E15C30E7400829135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKSearchIndexer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F2F15C30E7400829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F2D15C30E7400829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25104F3015C30E7400829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F2D15C30E7400829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25104F3115C30E7400829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F2E15C30E7400829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25104F3215C30E7400829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F2E15C30E7400829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25104F3315C30EF500829135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKSearchPredicate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F3415C30EF500829135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKSearchPredicate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F3515C30EF500829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F3315C30EF500829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25104F3615C30EF500829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F3315C30EF500829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25104F3715C30EF500829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F3415C30EF500829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25104F3815C30EF500829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F3415C30EF500829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25104F3915C30F2000829135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKSearchWordEntity.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F3A15C30F2100829135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKSearchWordEntity.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25104F3B15C30F2100829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F3915C30F2000829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25104F3C15C30F2100829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F3915C30F2000829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25104F3D15C30F2100829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F3A15C30F2100829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25104F3E15C30F2100829135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25104F3A15C30F2100829135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25104F9B15C33E3A00829135</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25A763E415C7424500A9DF31</string>
-				<string>25C246A315C83B090032212E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Search</string>
-			<key>path</key>
-			<string>Logic/Search</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25119FB5154A34B400C6BC58</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>parents_and_children.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25119FB6154A34B400C6BC58</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25119FB5154A34B400C6BC58</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25119FB7154A34B400C6BC58</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25119FB5154A34B400C6BC58</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160D0B14564E810060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160D44145650490060A5C5</string>
-				<string>25160FC51456F2330060A5C5</string>
-				<string>25EC1AD614F8022600C3CF3F</string>
-				<string>25160E8D145652E40060A5C5</string>
-				<string>25160D1814564E810060A5C5</string>
-				<string>25160D1714564E810060A5C5</string>
-				<string>15BB5BBD8E8B9B2C9C8B11BC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D0D14564E810060A5C5</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastTestingUpgradeCheck</key>
-				<string>0510</string>
-				<key>LastUpgradeCheck</key>
-				<string>0600</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>RestKit</string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>25160D1014564E810060A5C5</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>25160D0B14564E810060A5C5</string>
-			<key>productRefGroup</key>
-			<string>25160D1714564E810060A5C5</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>25160D1514564E810060A5C5</string>
-				<string>25160D2514564E820060A5C5</string>
-				<string>25160E61145651060060A5C5</string>
-				<string>25160E77145651060060A5C5</string>
-			</array>
-		</dict>
-		<key>25160D1014564E810060A5C5</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>25160D3814564E820060A5C5</string>
-				<string>25160D3914564E820060A5C5</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>25160D1214564E810060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>253B495F14E35EC300B0483F</string>
-				<string>25160DDC145650490060A5C5</string>
-				<string>25160DE0145650490060A5C5</string>
-				<string>25160DE2145650490060A5C5</string>
-				<string>25160DE6145650490060A5C5</string>
-				<string>25160E0A145650490060A5C5</string>
-				<string>25160E0C145650490060A5C5</string>
-				<string>25DA35711836741D001A56A0</string>
-				<string>25160E10145650490060A5C5</string>
-				<string>25160E17145650490060A5C5</string>
-				<string>25160E1B145650490060A5C5</string>
-				<string>25160E1E145650490060A5C5</string>
-				<string>25160E22145650490060A5C5</string>
-				<string>252CCE7817E0CA2700B7F0BF</string>
-				<string>25160E24145650490060A5C5</string>
-				<string>25160E26145650490060A5C5</string>
-				<string>252CCE7417E0CA2700B7F0BF</string>
-				<string>25160E48145650490060A5C5</string>
-				<string>25160E4B145650490060A5C5</string>
-				<string>25160E4D145650490060A5C5</string>
-				<string>25160EE41456532C0060A5C5</string>
-				<string>25160EFA1456532C0060A5C5</string>
-				<string>25160F0A1456532C0060A5C5</string>
-				<string>25B408281491CDDC00F21111</string>
-				<string>25B6E95814CF7A1C00B1E881</string>
-				<string>25FABED114E3796400E609E7</string>
-				<string>25CA7A8F14EC570200888FF8</string>
-				<string>25055B8614EEF32A00B9C4DD</string>
-				<string>25055B8A14EEF32A00B9C4DD</string>
-				<string>25055B9114EEF40000B9C4DD</string>
-				<string>25EC1A3B14F72B1300C3CF3F</string>
-				<string>25EC1A3F14F72B3100C3CF3F</string>
-				<string>257ABAB215112DD500CCAA76</string>
-				<string>257ABAB81511371E00CCAA76</string>
-				<string>25C954A715542A47005C9E08</string>
-				<string>259D98561550C69A008C90F5</string>
-				<string>259D9860155218E5008C90F5</string>
-				<string>252028FE1577AE0B00076FB4</string>
-				<string>252029051577AE1800076FB4</string>
-				<string>25FBB854159272DD00955D27</string>
-				<string>258EA4AA15A38BC0007E07A6</string>
-				<string>25AA23D015AF2920006EF62D</string>
-				<string>2597F99E15AF6DC400E547D7</string>
-				<string>25104F2115C30CD900829135</string>
-				<string>25104F2B15C30D1700829135</string>
-				<string>25104F3115C30E7400829135</string>
-				<string>25104F3715C30EF500829135</string>
-				<string>25104F3D15C30F2100829135</string>
-				<string>25F53AE415E7B612008B54E6</string>
-				<string>2598888F15EC169E006CAE95</string>
-				<string>254372A915F54995006E8424</string>
-				<string>254372BA15F54C3F006E8424</string>
-				<string>254372BE15F54C3F006E8424</string>
-				<string>254372C215F54C3F006E8424</string>
-				<string>254372C615F54C3F006E8424</string>
-				<string>254372CA15F54C3F006E8424</string>
-				<string>C0F11CE4190883380054AEA0</string>
-				<string>254372CE15F54C3F006E8424</string>
-				<string>254372D215F54C3F006E8424</string>
-				<string>254372D815F54CE3006E8424</string>
-				<string>2595B47115F670530087A59B</string>
-				<string>2595B47515F670530087A59B</string>
-				<string>252CCE6817E08E2D00B7F0BF</string>
-				<string>253477F315FFBC61002C0E4E</string>
-				<string>2534781615FFD4A6002C0E4E</string>
-				<string>259B96D71604CCCC0000C250</string>
-				<string>259B96DB1604CCCC0000C250</string>
-				<string>259B96DF1604CCCC0000C250</string>
-				<string>259B96E31604CCCC0000C250</string>
-				<string>259B96E51604CCCC0000C250</string>
-				<string>259B96E91604CCCC0000C250</string>
-				<string>259B96ED1604CCCC0000C250</string>
-				<string>259B96F11604CCCC0000C250</string>
-				<string>259B96F31604CCCC0000C250</string>
-				<string>25A226D81618A57500952D72</string>
-				<string>2507C329161BD5C700EA71FF</string>
-				<string>25E88C8A165C5CC30042ABD0</string>
-				<string>25A8C2361673BD480014D9A6</string>
-				<string>258BEA02168D058300C74C8C</string>
-				<string>25A199D616ED035A00792629</string>
-				<string>25C6C0BF1716F6F800C98A73</string>
-				<string>25C6C0C31716F6F800C98A73</string>
-				<string>25C6C0C71716F6F800C98A73</string>
-				<string>25C6C0EA1716F79B00C98A73</string>
-				<string>54CDB45D17B408B100FAC285</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160D1314564E810060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>25C20466160ABC4800D418D5</string>
-				<string>25160D1A14564E810060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160D1414564E810060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>25160DDB145650490060A5C5</string>
-				<string>25160DDF145650490060A5C5</string>
-				<string>25160DE1145650490060A5C5</string>
-				<string>25160DE5145650490060A5C5</string>
-				<string>25160E09145650490060A5C5</string>
-				<string>25160E0B145650490060A5C5</string>
-				<string>252CCE7217E0CA2700B7F0BF</string>
-				<string>25160E0F145650490060A5C5</string>
-				<string>25160E16145650490060A5C5</string>
-				<string>25160E18145650490060A5C5</string>
-				<string>25160E1A145650490060A5C5</string>
-				<string>25160E1C145650490060A5C5</string>
-				<string>25160E1D145650490060A5C5</string>
-				<string>25160E21145650490060A5C5</string>
-				<string>25160E23145650490060A5C5</string>
-				<string>25160E25145650490060A5C5</string>
-				<string>25160E31145650490060A5C5</string>
-				<string>25160E32145650490060A5C5</string>
-				<string>25160E33145650490060A5C5</string>
-				<string>25160E44145650490060A5C5</string>
-				<string>25160E47145650490060A5C5</string>
-				<string>25160E4A145650490060A5C5</string>
-				<string>252CCE7617E0CA2700B7F0BF</string>
-				<string>25160E4C145650490060A5C5</string>
-				<string>25160E4E145650490060A5C5</string>
-				<string>25160EE21456532C0060A5C5</string>
-				<string>25160EF81456532C0060A5C5</string>
-				<string>25160F081456532C0060A5C5</string>
-				<string>25160E2E145650490060A5C5</string>
-				<string>25B408261491CDDC00F21111</string>
-				<string>25B6E95514CF795D00B1E881</string>
-				<string>25B6E95C14CF7E3C00B1E881</string>
-				<string>253B495214E35D1A00B0483F</string>
-				<string>25FABED214E3796B00E609E7</string>
-				<string>25055B8414EEF32A00B9C4DD</string>
-				<string>25055B8814EEF32A00B9C4DD</string>
-				<string>25055B8F14EEF40000B9C4DD</string>
-				<string>25EC1A3914F72B0900C3CF3F</string>
-				<string>25EC1A3D14F72B2800C3CF3F</string>
-				<string>25EC1A6314F7402A00C3CF3F</string>
-				<string>257ABAB015112DD500CCAA76</string>
-				<string>257ABAB61511371E00CCAA76</string>
-				<string>259D98541550C69A008C90F5</string>
-				<string>259D985E155218E5008C90F5</string>
-				<string>252028FC1577AE0B00076FB4</string>
-				<string>252029031577AE1800076FB4</string>
-				<string>25FBB852159272DD00955D27</string>
-				<string>258EA4A815A38BC0007E07A6</string>
-				<string>258EA4AE15A38E7E007E07A6</string>
-				<string>258EA4B215A39090007E07A6</string>
-				<string>2597F99C15AF6DC400E547D7</string>
-				<string>25AFF8F115B4CF1F0051877F</string>
-				<string>5CCC295615B7124A0045F0F5</string>
-				<string>25104F1F15C30CD900829135</string>
-				<string>25104F2915C30D1700829135</string>
-				<string>25104F2F15C30E7400829135</string>
-				<string>25104F3515C30EF500829135</string>
-				<string>25104F3B15C30F2100829135</string>
-				<string>25F53AE215E7B612008B54E6</string>
-				<string>2598888D15EC169E006CAE95</string>
-				<string>254372A815F54995006E8424</string>
-				<string>254372B815F54C3F006E8424</string>
-				<string>254372BC15F54C3F006E8424</string>
-				<string>254372C015F54C3F006E8424</string>
-				<string>254372C415F54C3F006E8424</string>
-				<string>254372C815F54C3F006E8424</string>
-				<string>254372CC15F54C3F006E8424</string>
-				<string>254372D015F54C3F006E8424</string>
-				<string>254372D615F54CE3006E8424</string>
-				<string>2595B46F15F670530087A59B</string>
-				<string>2595B47315F670530087A59B</string>
-				<string>2502C8ED15F79CF70060FD75</string>
-				<string>2502C8EF15F79CF70060FD75</string>
-				<string>2502C8F115F79CF70060FD75</string>
-				<string>2502C8F315F79CF70060FD75</string>
-				<string>2502C8F515F79CF70060FD75</string>
-				<string>2502C8F715F79CF70060FD75</string>
-				<string>2534781815FFD4A6002C0E4E</string>
-				<string>253477F115FFBC61002C0E4E</string>
-				<string>259B96D51604CCCC0000C250</string>
-				<string>259B96D91604CCCC0000C250</string>
-				<string>259B96DD1604CCCC0000C250</string>
-				<string>259B96E11604CCCC0000C250</string>
-				<string>259B96E71604CCCC0000C250</string>
-				<string>259B96EB1604CCCC0000C250</string>
-				<string>259B96EF1604CCCC0000C250</string>
-				<string>259B96F51604CCCC0000C250</string>
-				<string>259B96F71604CCCC0000C250</string>
-				<string>259B96F91604CCCC0000C250</string>
-				<string>25F53F391606269400A093BE</string>
-				<string>25A226D61618A57500952D72</string>
-				<string>C0F11CE3190883380054AEA0</string>
-				<string>252CCE6617E08E2D00B7F0BF</string>
-				<string>2507C327161BD5C700EA71FF</string>
-				<string>C0F11CE81908C7E60054AEA0</string>
-				<string>25E88C88165C5CC30042ABD0</string>
-				<string>25A8C2341673BD480014D9A6</string>
-				<string>25A199D416ED035A00792629</string>
-				<string>25C6C0BD1716F6F800C98A73</string>
-				<string>25C6C0C11716F6F800C98A73</string>
-				<string>25C6C0C51716F6F800C98A73</string>
-				<string>25C6C0CB1716F6F800C98A73</string>
-				<string>25C6C0E81716F79B00C98A73</string>
-				<string>25DA356F1836741D001A56A0</string>
-				<string>54CDB45B17B408B100FAC285</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160D1514564E810060A5C5</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>25160D3A14564E820060A5C5</string>
-			<key>buildPhases</key>
-			<array>
-				<string>25160D1214564E810060A5C5</string>
-				<string>25160D1314564E810060A5C5</string>
-				<string>25160D1414564E810060A5C5</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>RestKit</string>
-			<key>productName</key>
-			<string>RestKit</string>
-			<key>productReference</key>
-			<string>25160D1614564E810060A5C5</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>25160D1614564E810060A5C5</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libRestKit.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>25160D1714564E810060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160D1614564E810060A5C5</string>
-				<string>25160D2614564E820060A5C5</string>
-				<string>25160E62145651060060A5C5</string>
-				<string>25160E78145651060060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D1814564E810060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25565958161FC3CD00F5BB20</string>
-				<string>25565955161FC3C300F5BB20</string>
-				<string>25B6EA0714CF947D00B1E881</string>
-				<string>25B6EA0514CF946300B1E881</string>
-				<string>25A34244147D8AAA0009758D</string>
-				<string>251611311456F56C0060A5C5</string>
-				<string>2516112F1456F5590060A5C5</string>
-				<string>2516112D1456F5520060A5C5</string>
-				<string>2516112A1456F5170060A5C5</string>
-				<string>251611281456F50F0060A5C5</string>
-				<string>25160F7D1456572F0060A5C5</string>
-				<string>25160F7B145657220060A5C5</string>
-				<string>25160F161456538B0060A5C5</string>
-				<string>25160D1914564E810060A5C5</string>
-				<string>25160D2914564E820060A5C5</string>
-				<string>25160E63145651060060A5C5</string>
-				<string>25EC1B0014F8078100C3CF3F</string>
-				<string>25160E65145651060060A5C5</string>
-				<string>E457EFC3D502479D8B4FCF2A</string>
-				<string>86EC453810D648768BF62304</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D1914564E810060A5C5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>25160D1A14564E810060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D1914564E810060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160D2114564E820060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>251610601456F2330060A5C5</string>
-				<string>251610A21456F2330060A5C5</string>
-				<string>251610A41456F2330060A5C5</string>
-				<string>251610A61456F2330060A5C5</string>
-				<string>251610A81456F2330060A5C5</string>
-				<string>251610AA1456F2330060A5C5</string>
-				<string>251610AC1456F2330060A5C5</string>
-				<string>251610AE1456F2330060A5C5</string>
-				<string>251610B01456F2330060A5C5</string>
-				<string>251610B21456F2330060A5C5</string>
-				<string>251610B41456F2330060A5C5</string>
-				<string>251610B61456F2330060A5C5</string>
-				<string>251610B81456F2330060A5C5</string>
-				<string>251610D21456F2330060A5C5</string>
-				<string>251610DC1456F2330060A5C5</string>
-				<string>251610DE1456F2330060A5C5</string>
-				<string>251610E21456F2330060A5C5</string>
-				<string>251610E81456F2330060A5C5</string>
-				<string>251610F01456F2340060A5C5</string>
-				<string>2516110E1456F2340060A5C5</string>
-				<string>251611101456F2340060A5C5</string>
-				<string>251611121456F2340060A5C5</string>
-				<string>251611161456F2340060A5C5</string>
-				<string>25B6E9DB14CF912500B1E881</string>
-				<string>25B6E9DD14CF912500B1E881</string>
-				<string>25B6E9DF14CF912500B1E881</string>
-				<string>252EFAFA14D8EAEC004863C8</string>
-				<string>25E36E0215195CED00F9E448</string>
-				<string>25DB7508151BD551009F01AF</string>
-				<string>259D985A1550C6BE008C90F5</string>
-				<string>259D986415521B20008C90F5</string>
-				<string>252029091577C78600076FB4</string>
-				<string>2519764315823BA1004FE9DD</string>
-				<string>2519764815824455004FE9DD</string>
-				<string>2519764C158244F8004FE9DD</string>
-				<string>25AA23D815AF5085006EF62D</string>
-				<string>258EFF7A15C0CE1400EE4E0D</string>
-				<string>25A763E515C7424500A9DF31</string>
-				<string>25C246A415C83B090032212E</string>
-				<string>5C927E141608FFFD00DC8B07</string>
-				<string>25E9C8F01612523400647F84</string>
-				<string>25EDFCE3161538F6008BAA1D</string>
-				<string>2564E40B16173F7B00C12D7D</string>
-				<string>25CDA0E7161E828D00F583F3</string>
-				<string>25BB392E161F4FD700E5C72A</string>
-				<string>25565965161FDD8800F5BB20</string>
-				<string>259AC481162B05C80012D2F9</string>
-				<string>252205CC162B242400F7B11E</string>
-				<string>2549D646162B376F003DD135</string>
-				<string>2506759F162DEA25003210B0</string>
-				<string>255F87911656B22D00914D57</string>
-				<string>2543A25D1664FD3100821D5B</string>
-				<string>2536D1FD167270F100DF9BB0</string>
-				<string>2551338F167838590017E4B6</string>
-				<string>255133CF167AC7600017E4B6</string>
-				<string>25B639CC16961EFA0065EB7B</string>
-				<string>25A73362169C8C230090A930</string>
-				<string>25A9827516A5FF4F0088A3CA</string>
-				<string>2550DA2316B1FB62005A0CB8</string>
-				<string>2582F56D173038760043B8BB</string>
-				<string>BE05BDD11782109F00F7C9C9</string>
-				<string>25AABCED17B698940061DC5B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160D2214564E820060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>25B6EA0814CF947E00B1E881</string>
-				<string>25B6EA0614CF946400B1E881</string>
-				<string>251611321456F56C0060A5C5</string>
-				<string>251611301456F5590060A5C5</string>
-				<string>2516112E1456F5520060A5C5</string>
-				<string>2516112C1456F51D0060A5C5</string>
-				<string>2516112B1456F5170060A5C5</string>
-				<string>251611291456F50F0060A5C5</string>
-				<string>25160D2A14564E820060A5C5</string>
-				<string>25160D2B14564E820060A5C5</string>
-				<string>E2F2B89961FC462B981CEB7A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160D2314564E820060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>251610641456F2330060A5C5</string>
-				<string>251610661456F2330060A5C5</string>
-				<string>251610681456F2330060A5C5</string>
-				<string>2516106A1456F2330060A5C5</string>
-				<string>2516106C1456F2330060A5C5</string>
-				<string>2516106E1456F2330060A5C5</string>
-				<string>251610701456F2330060A5C5</string>
-				<string>251610721456F2330060A5C5</string>
-				<string>251610741456F2330060A5C5</string>
-				<string>251610761456F2330060A5C5</string>
-				<string>251610781456F2330060A5C5</string>
-				<string>2516107A1456F2330060A5C5</string>
-				<string>2516107C1456F2330060A5C5</string>
-				<string>2516107E1456F2330060A5C5</string>
-				<string>251610801456F2330060A5C5</string>
-				<string>251610821456F2330060A5C5</string>
-				<string>251610841456F2330060A5C5</string>
-				<string>251610861456F2330060A5C5</string>
-				<string>251610881456F2330060A5C5</string>
-				<string>2516108A1456F2330060A5C5</string>
-				<string>2516108C1456F2330060A5C5</string>
-				<string>2516108E1456F2330060A5C5</string>
-				<string>251610901456F2330060A5C5</string>
-				<string>251610961456F2330060A5C5</string>
-				<string>251610981456F2330060A5C5</string>
-				<string>2516109A1456F2330060A5C5</string>
-				<string>2516109C1456F2330060A5C5</string>
-				<string>2516109E1456F2330060A5C5</string>
-				<string>251610A01456F2330060A5C5</string>
-				<string>73D3907414CA1AE00093E3D6</string>
-				<string>73D3907614CA1AE60093E3D6</string>
-				<string>73D3907914CA1DD40093E3D6</string>
-				<string>252EFB2814DA0689004863C8</string>
-				<string>25CAAA9415254E7800CAE5D7</string>
-				<string>25119FB6154A34B400C6BC58</string>
-				<string>259D983C154F6C90008C90F5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160D2414564E820060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string># Run the unit tests in this test bundle.
-"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests"</string>
-		</dict>
-		<key>25160D2514564E820060A5C5</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>25160D3D14564E820060A5C5</string>
-			<key>buildPhases</key>
-			<array>
-				<string>25160D2114564E820060A5C5</string>
-				<string>25160D2214564E820060A5C5</string>
-				<string>25160D2314564E820060A5C5</string>
-				<string>212C92B936E847348494D6F7</string>
-				<string>25160D2414564E820060A5C5</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>25160D2D14564E820060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>RestKitTests</string>
-			<key>productName</key>
-			<string>RestKitTests</string>
-			<key>productReference</key>
-			<string>25160D2614564E820060A5C5</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>25160D2614564E820060A5C5</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>RestKitTests.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>25160D2914564E820060A5C5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>25160D2A14564E820060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D2914564E820060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160D2B14564E820060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D1914564E810060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160D2C14564E820060A5C5</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>25160D0D14564E810060A5C5</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>25160D1514564E810060A5C5</string>
-			<key>remoteInfo</key>
-			<string>RestKit</string>
-		</dict>
-		<key>25160D2D14564E820060A5C5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>25160D1514564E810060A5C5</string>
-			<key>targetProxy</key>
-			<string>25160D2C14564E820060A5C5</string>
-		</dict>
-		<key>25160D3814564E820060A5C5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_MISSING_PROTOTYPES</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>5.1.1</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>25160D3914564E820060A5C5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_VERSION</key>
-				<string>com.apple.compilers.llvm.clang.1_0</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_MISSING_PROTOTYPES</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>5.1.1</string>
-				<key>OTHER_CFLAGS</key>
-				<string>-DNS_BLOCK_ASSERTIONS=1</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>25160D3A14564E820060A5C5</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>25160D3B14564E820060A5C5</string>
-				<string>25160D3C14564E820060A5C5</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>25160D3B14564E820060A5C5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Code/Support/RestKit-Prefix.pch</string>
-				<key>GCC_WARN_ABOUT_MISSING_NEWLINE</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>@rpath</string>
-				<key>OBJROOT</key>
-				<string>$(SRCROOT)/Build</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>-ObjC</string>
-				<key>PRIVATE_HEADERS_FOLDER_PATH</key>
-				<string>$(PUBLIC_HEADERS_FOLDER_PATH)/Private</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>../../Headers/RestKit</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SYMROOT</key>
-				<string>$(SRCROOT)/Build/Products</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>25160D3C14564E820060A5C5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Code/Support/RestKit-Prefix.pch</string>
-				<key>GCC_WARN_ABOUT_MISSING_NEWLINE</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>@rpath</string>
-				<key>OBJROOT</key>
-				<string>$(SRCROOT)/Build</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>-ObjC</string>
-				<key>PRIVATE_HEADERS_FOLDER_PATH</key>
-				<string>$(PUBLIC_HEADERS_FOLDER_PATH)/Private</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>../../Headers/RestKit</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>SYMROOT</key>
-				<string>$(SRCROOT)/Build/Products</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>25160D3D14564E820060A5C5</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>25160D3E14564E820060A5C5</string>
-				<string>25160D3F14564E820060A5C5</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>25160D3E14564E820060A5C5</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>147F950728350A64F103F55D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>"$(SDKROOT)/Developer/Library/Frameworks"</string>
-					<string>"$(DEVELOPER_LIBRARY_DIR)/Frameworks"</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Code/Support/RestKit-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Resources/PLISTs/RestKitTests-Info.plist</string>
-				<key>OBJROOT</key>
-				<string>$(SRCROOT)/Build</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>$(inherited)</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SYMROOT</key>
-				<string>$(SRCROOT)/Build/Products</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>25160D3F14564E820060A5C5</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>061E3E4524CE8EF78257C26C</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>"$(SDKROOT)/Developer/Library/Frameworks"</string>
-					<string>"$(DEVELOPER_LIBRARY_DIR)/Frameworks"</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Code/Support/RestKit-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Resources/PLISTs/RestKitTests-Info.plist</string>
-				<key>OBJROOT</key>
-				<string>$(SRCROOT)/Build</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>$(inherited)</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SYMROOT</key>
-				<string>$(SRCROOT)/Build/Products</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>25160D44145650490060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160DA1145650490060A5C5</string>
-				<string>2502C8E915F79CF70060FD75</string>
-				<string>25160D7A145650490060A5C5</string>
-				<string>2502C8E815F79CF70060FD75</string>
-				<string>25160D58145650490060A5C5</string>
-				<string>2502C8E715F79CF70060FD75</string>
-				<string>25160D45145650490060A5C5</string>
-				<string>2502C8EB15F79CF70060FD75</string>
-				<string>25160DA2145650490060A5C5</string>
-				<string>2502C8EC15F79CF70060FD75</string>
-				<string>252EFB1F14D9A8D4004863C8</string>
-				<string>2502C8EA15F79CF70060FD75</string>
-				<string>25104F0E15C30C7900829135</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Code</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D45145650490060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E4081DFC15FB89DF00364948</string>
-				<string>E4081E0715FB8FC400364948</string>
-				<string>E4081DFE15FB8A1D00364948</string>
-				<string>E4081E0915FB8FD800364948</string>
-				<string>25160D52145650490060A5C5</string>
-				<string>25160D53145650490060A5C5</string>
-				<string>2597F99A15AF6DC400E547D7</string>
-				<string>2597F99B15AF6DC400E547D7</string>
-				<string>C0F11CE71908C7E60054AEA0</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>CoreData</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D4C145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKEntityMapping.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D4D145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKEntityMapping.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D50145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKManagedObjectImporter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D51145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKManagedObjectImporter.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D52145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKManagedObjectStore.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D53145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKManagedObjectStore.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D56145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKPropertyInspector+CoreData.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D57145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKPropertyInspector+CoreData.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D58145650490060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E4081E0015FB8B5900364948</string>
-				<string>E4081DFF15FB8B4000364948</string>
-				<string>254372AC15F54C3F006E8424</string>
-				<string>254372AD15F54C3F006E8424</string>
-				<string>254372AE15F54C3F006E8424</string>
-				<string>254372AF15F54C3F006E8424</string>
-				<string>254372B215F54C3F006E8424</string>
-				<string>254372B315F54C3F006E8424</string>
-				<string>254372B415F54C3F006E8424</string>
-				<string>254372B515F54C3F006E8424</string>
-				<string>254372B615F54C3F006E8424</string>
-				<string>254372B715F54C3F006E8424</string>
-				<string>254372A615F54995006E8424</string>
-				<string>254372A715F54995006E8424</string>
-				<string>25F53AE015E7B611008B54E6</string>
-				<string>25F53AE115E7B612008B54E6</string>
-				<string>C0F11CE1190883380054AEA0</string>
-				<string>C0F11CE2190883380054AEA0</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Network</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D7A145650490060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>258BEA01168D058300C74C8C</string>
-				<string>25B6E95A14CF7E3C00B1E881</string>
-				<string>25160D7C145650490060A5C5</string>
-				<string>25160D7D145650490060A5C5</string>
-				<string>25160D7E145650490060A5C5</string>
-				<string>25160D7F145650490060A5C5</string>
-				<string>25160D82145650490060A5C5</string>
-				<string>25160D83145650490060A5C5</string>
-				<string>25160D89145650490060A5C5</string>
-				<string>25160D8A145650490060A5C5</string>
-				<string>25160D8B145650490060A5C5</string>
-				<string>25160D8D145650490060A5C5</string>
-				<string>25160D8E145650490060A5C5</string>
-				<string>25160D8F145650490060A5C5</string>
-				<string>25CA7A8E14EC570100888FF8</string>
-				<string>25160D90145650490060A5C5</string>
-				<string>25160D91145650490060A5C5</string>
-				<string>25160D94145650490060A5C5</string>
-				<string>25160D95145650490060A5C5</string>
-				<string>25160D96145650490060A5C5</string>
-				<string>25160D97145650490060A5C5</string>
-				<string>25160D98145650490060A5C5</string>
-				<string>25160D99145650490060A5C5</string>
-				<string>258EA4A615A38BBF007E07A6</string>
-				<string>258EA4A715A38BBF007E07A6</string>
-				<string>258EA4AD15A38E7D007E07A6</string>
-				<string>25AFF8F015B4CF1F0051877F</string>
-				<string>2598888B15EC169E006CAE95</string>
-				<string>2598888C15EC169E006CAE95</string>
-				<string>25A226D41618A57500952D72</string>
-				<string>25A226D51618A57500952D72</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>ObjectMapping</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D7C145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKDynamicMapping.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D7D145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKDynamicMapping.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D7E145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKErrorMessage.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D7F145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKErrorMessage.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D82145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKAttributeMapping.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D83145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKAttributeMapping.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D89145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMapperOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D8A145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKMapperOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D8B145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMapperOperation_Private.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D8D145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKObjectMapping.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D8E145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectMapping.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D8F145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMapping.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D90145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMappingOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D91145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>RKMappingOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D94145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMappingResult.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D95145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKMappingResult.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D96145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKPropertyInspector.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D97145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKPropertyInspector.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D98145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKRelationshipMapping.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160D99145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRelationshipMapping.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DA1145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RestKit.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DA2145650490060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>54CDB45917B408B100FAC285</string>
-				<string>54CDB45A17B408B100FAC285</string>
-				<string>2534781515FFD4A6002C0E4E</string>
-				<string>2534781415FFD4A6002C0E4E</string>
-				<string>2595B46B15F670530087A59B</string>
-				<string>2595B46C15F670530087A59B</string>
-				<string>2595B46D15F670530087A59B</string>
-				<string>2595B46E15F670530087A59B</string>
-				<string>25160DA5145650490060A5C5</string>
-				<string>25160DA6145650490060A5C5</string>
-				<string>25160DA7145650490060A5C5</string>
-				<string>25160DBB145650490060A5C5</string>
-				<string>25160DBE145650490060A5C5</string>
-				<string>25160DBF145650490060A5C5</string>
-				<string>25160DC1145650490060A5C5</string>
-				<string>25160DC2145650490060A5C5</string>
-				<string>25160DC3145650490060A5C5</string>
-				<string>25160DC4145650490060A5C5</string>
-				<string>25160DC5145650490060A5C5</string>
-				<string>25B408241491CDDB00F21111</string>
-				<string>25B408251491CDDB00F21111</string>
-				<string>25B6E95414CF795D00B1E881</string>
-				<string>25B6E95714CF7A1C00B1E881</string>
-				<string>5CCC295515B7124A0045F0F5</string>
-				<string>253477EF15FFBC60002C0E4E</string>
-				<string>253477F015FFBC60002C0E4E</string>
-				<string>25C6C0E61716F79B00C98A73</string>
-				<string>25C6C0E71716F79B00C98A73</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Support</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DA5145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>lcl_config_components_RK.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DA6145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>lcl_config_extensions_RK.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DA7145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>lcl_config_logger_RK.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DBB145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RestKit-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DBE145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKDotNetDateFormatter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DBF145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKDotNetDateFormatter.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DC1145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKLog.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DC2145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKLog.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DC3145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMIMETypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DC4145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKMIMETypes.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DC5145650490060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKSerialization.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160DDB145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D4C145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160DDC145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D4D145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160DDF145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D50145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160DE0145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D51145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160DE1145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D52145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160DE2145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D53145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160DE5145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D56145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160DE6145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D57145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E09145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D7C145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E0A145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D7D145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E0B145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D7E145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E0C145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D7F145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E0F145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D82145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E10145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D83145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E16145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D89145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E17145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D8A145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E18145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D8B145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Private</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E1A145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D8D145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E1B145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D8E145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E1C145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D8F145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E1D145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D90145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E1E145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D91145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E21145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D94145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E22145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D95145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E23145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D96145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E24145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D97145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E25145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D98145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E26145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D99145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E2E145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DA1145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E31145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DA5145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E32145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DA6145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E33145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DA7145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E44145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DBB145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array/>
-			</dict>
-		</dict>
-		<key>25160E47145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DBE145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E48145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DBF145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E4A145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DC1145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E4B145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DC2145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E4C145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DC3145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E4D145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DC4145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E4E145650490060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DC5145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160E5D145651060060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>25160EE51456532C0060A5C5</string>
-				<string>25160EFB1456532C0060A5C5</string>
-				<string>25160F0B1456532C0060A5C5</string>
-				<string>25160F45145655C60060A5C5</string>
-				<string>25160F47145655C60060A5C5</string>
-				<string>25160F4B145655C60060A5C5</string>
-				<string>25160F52145655C60060A5C5</string>
-				<string>25DA35721836741D001A56A0</string>
-				<string>25160F56145655C60060A5C5</string>
-				<string>25160F59145655C60060A5C5</string>
-				<string>25160F5D145655C60060A5C5</string>
-				<string>25160F5F145655C60060A5C5</string>
-				<string>25160F61145655C60060A5C5</string>
-				<string>252CCE7917E0CA2700B7F0BF</string>
-				<string>25160F70145655D10060A5C5</string>
-				<string>25160F74145655D10060A5C5</string>
-				<string>252CCE7517E0CA2700B7F0BF</string>
-				<string>25160F76145655D10060A5C5</string>
-				<string>25160F7A145655D10060A5C5</string>
-				<string>25160F911456576C0060A5C5</string>
-				<string>25160F941456576C0060A5C5</string>
-				<string>25160F961456576C0060A5C5</string>
-				<string>25B408291491CDDC00F21111</string>
-				<string>25B6E95914CF7A1C00B1E881</string>
-				<string>25FABED014E3796400E609E7</string>
-				<string>25CA7A9014EC570200888FF8</string>
-				<string>25CA7A9114EC5C2D00888FF8</string>
-				<string>25055B8714EEF32A00B9C4DD</string>
-				<string>25055B8B14EEF32A00B9C4DD</string>
-				<string>25055B9214EEF40000B9C4DD</string>
-				<string>25EC1A3C14F72B1400C3CF3F</string>
-				<string>25EC1A4014F72B3300C3CF3F</string>
-				<string>257ABAB315112DD500CCAA76</string>
-				<string>257ABAB91511371E00CCAA76</string>
-				<string>25C954A815542A47005C9E08</string>
-				<string>259D98571550C69A008C90F5</string>
-				<string>259D9861155218E5008C90F5</string>
-				<string>252028FF1577AE0B00076FB4</string>
-				<string>252029061577AE1800076FB4</string>
-				<string>25FBB855159272DD00955D27</string>
-				<string>258EA4AB15A38BC0007E07A6</string>
-				<string>25AA23D115AF2920006EF62D</string>
-				<string>2597F99F15AF6DC400E547D7</string>
-				<string>25104F2215C30CD900829135</string>
-				<string>25104F2C15C30D1700829135</string>
-				<string>25104F3215C30E7400829135</string>
-				<string>25104F3815C30EF500829135</string>
-				<string>25104F3E15C30F2100829135</string>
-				<string>25F53AE515E7B612008B54E6</string>
-				<string>2598889015EC169E006CAE95</string>
-				<string>254372BB15F54C3F006E8424</string>
-				<string>254372BF15F54C3F006E8424</string>
-				<string>254372C315F54C3F006E8424</string>
-				<string>254372C715F54C3F006E8424</string>
-				<string>254372CB15F54C3F006E8424</string>
-				<string>254372CF15F54C3F006E8424</string>
-				<string>C0F11CE6190883460054AEA0</string>
-				<string>254372D315F54C3F006E8424</string>
-				<string>254372D915F54CE3006E8424</string>
-				<string>2595B47215F670530087A59B</string>
-				<string>2595B47615F670530087A59B</string>
-				<string>253477F415FFBC61002C0E4E</string>
-				<string>252CCE6917E08E2D00B7F0BF</string>
-				<string>2534781715FFD4A6002C0E4E</string>
-				<string>259B96D81604CCCC0000C250</string>
-				<string>259B96DC1604CCCC0000C250</string>
-				<string>259B96E01604CCCC0000C250</string>
-				<string>259B96E41604CCCC0000C250</string>
-				<string>259B96E61604CCCC0000C250</string>
-				<string>259B96EA1604CCCC0000C250</string>
-				<string>259B96EE1604CCCC0000C250</string>
-				<string>259B96F21604CCCC0000C250</string>
-				<string>259B96F41604CCCC0000C250</string>
-				<string>25E9C8F1161290D500647F84</string>
-				<string>25A226D91618A57500952D72</string>
-				<string>2507C32A161BD5C700EA71FF</string>
-				<string>25E88C8B165C5CC30042ABD0</string>
-				<string>25A8C2371673BD480014D9A6</string>
-				<string>258BEA03168D058300C74C8C</string>
-				<string>25A199D716ED035A00792629</string>
-				<string>25C6C0C01716F6F800C98A73</string>
-				<string>25C6C0C41716F6F800C98A73</string>
-				<string>25C6C0C81716F6F800C98A73</string>
-				<string>25C6C0EB1716F79B00C98A73</string>
-				<string>54CDB45E17B408B100FAC285</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160E5E145651060060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>25A34245147D8AAA0009758D</string>
-				<string>25160F7E145657300060A5C5</string>
-				<string>25160F7C145657220060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160E5F145651060060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>25160EE31456532C0060A5C5</string>
-				<string>25160EF91456532C0060A5C5</string>
-				<string>25160F091456532C0060A5C5</string>
-				<string>25160F44145655C60060A5C5</string>
-				<string>25160F46145655C60060A5C5</string>
-				<string>25160F4A145655C60060A5C5</string>
-				<string>252CCE7317E0CA2700B7F0BF</string>
-				<string>25160F51145655C60060A5C5</string>
-				<string>25160F53145655C60060A5C5</string>
-				<string>25160F55145655C60060A5C5</string>
-				<string>25160F57145655C60060A5C5</string>
-				<string>25160F58145655C60060A5C5</string>
-				<string>25160F5C145655C60060A5C5</string>
-				<string>25160F5E145655C60060A5C5</string>
-				<string>25160F60145655C60060A5C5</string>
-				<string>25160F6F145655D10060A5C5</string>
-				<string>25160F73145655D10060A5C5</string>
-				<string>25160F75145655D10060A5C5</string>
-				<string>25160F79145655D10060A5C5</string>
-				<string>25160F85145657650060A5C5</string>
-				<string>25160F86145657650060A5C5</string>
-				<string>25160F87145657650060A5C5</string>
-				<string>252CCE7717E0CA2700B7F0BF</string>
-				<string>25160F901456576C0060A5C5</string>
-				<string>25160F931456576C0060A5C5</string>
-				<string>25160F951456576C0060A5C5</string>
-				<string>25160F971456576C0060A5C5</string>
-				<string>25160F25145655AF0060A5C5</string>
-				<string>25B408271491CDDC00F21111</string>
-				<string>25B6E95614CF795D00B1E881</string>
-				<string>25B6E95D14CF7E3C00B1E881</string>
-				<string>25FABED314E3796C00E609E7</string>
-				<string>25055B8514EEF32A00B9C4DD</string>
-				<string>25055B8914EEF32A00B9C4DD</string>
-				<string>C0F11CE91908C7E60054AEA0</string>
-				<string>25055B9014EEF40000B9C4DD</string>
-				<string>25EC1A3A14F72B0A00C3CF3F</string>
-				<string>25EC1A3E14F72B2900C3CF3F</string>
-				<string>25EC1A6514F7402A00C3CF3F</string>
-				<string>257ABAB115112DD500CCAA76</string>
-				<string>257ABAB71511371E00CCAA76</string>
-				<string>259D98551550C69A008C90F5</string>
-				<string>259D985F155218E5008C90F5</string>
-				<string>252028FD1577AE0B00076FB4</string>
-				<string>252029041577AE1800076FB4</string>
-				<string>25FBB853159272DD00955D27</string>
-				<string>258EA4A915A38BC0007E07A6</string>
-				<string>258EA4AF15A38E7E007E07A6</string>
-				<string>258EA4B315A39090007E07A6</string>
-				<string>2597F99D15AF6DC400E547D7</string>
-				<string>25AFF8F215B4CF1F0051877F</string>
-				<string>5CCC295715B7124A0045F0F5</string>
-				<string>25104F2015C30CD900829135</string>
-				<string>25104F2A15C30D1700829135</string>
-				<string>25104F3015C30E7400829135</string>
-				<string>25104F3615C30EF500829135</string>
-				<string>25104F3C15C30F2100829135</string>
-				<string>25F53AE315E7B612008B54E6</string>
-				<string>2598888E15EC169E006CAE95</string>
-				<string>254372B915F54C3F006E8424</string>
-				<string>254372BD15F54C3F006E8424</string>
-				<string>254372C115F54C3F006E8424</string>
-				<string>254372C515F54C3F006E8424</string>
-				<string>254372C915F54C3F006E8424</string>
-				<string>254372CD15F54C3F006E8424</string>
-				<string>254372D115F54C3F006E8424</string>
-				<string>254372D715F54CE3006E8424</string>
-				<string>2595B47015F670530087A59B</string>
-				<string>2595B47415F670530087A59B</string>
-				<string>2502C8EE15F79CF70060FD75</string>
-				<string>2502C8F015F79CF70060FD75</string>
-				<string>2502C8F215F79CF70060FD75</string>
-				<string>2502C8F415F79CF70060FD75</string>
-				<string>2502C8F615F79CF70060FD75</string>
-				<string>2502C8F815F79CF70060FD75</string>
-				<string>253477F215FFBC61002C0E4E</string>
-				<string>2534781915FFD4A6002C0E4E</string>
-				<string>259B96D61604CCCC0000C250</string>
-				<string>259B96DA1604CCCC0000C250</string>
-				<string>259B96DE1604CCCC0000C250</string>
-				<string>259B96E21604CCCC0000C250</string>
-				<string>259B96E81604CCCC0000C250</string>
-				<string>259B96EC1604CCCC0000C250</string>
-				<string>259B96F01604CCCC0000C250</string>
-				<string>259B96F61604CCCC0000C250</string>
-				<string>259B96F81604CCCC0000C250</string>
-				<string>259B96FA1604CCCC0000C250</string>
-				<string>25F53F3A1606269400A093BE</string>
-				<string>25A226D71618A57500952D72</string>
-				<string>2507C328161BD5C700EA71FF</string>
-				<string>25E88C89165C5CC30042ABD0</string>
-				<string>252CCE6717E08E2D00B7F0BF</string>
-				<string>C0F11CE5190883460054AEA0</string>
-				<string>255893E3166BA6A20010C70B</string>
-				<string>255893E4166BA7400010C70B</string>
-				<string>255893E5166BA7700010C70B</string>
-				<string>25A8C2351673BD480014D9A6</string>
-				<string>25A199D516ED035A00792629</string>
-				<string>25C6C0BE1716F6F800C98A73</string>
-				<string>25C6C0C21716F6F800C98A73</string>
-				<string>25C6C0C61716F6F800C98A73</string>
-				<string>25C6C0CC1716F6F800C98A73</string>
-				<string>25C6C0E91716F79B00C98A73</string>
-				<string>25DA35701836741D001A56A0</string>
-				<string>54CDB45C17B408B100FAC285</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160E60145651060060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160E61145651060060A5C5</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>25160E87145651060060A5C5</string>
-			<key>buildPhases</key>
-			<array>
-				<string>25160E5D145651060060A5C5</string>
-				<string>25160E5E145651060060A5C5</string>
-				<string>25160E5F145651060060A5C5</string>
-				<string>25160E60145651060060A5C5</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>RestKitFramework</string>
-			<key>productName</key>
-			<string>RestKitFramework</string>
-			<key>productReference</key>
-			<string>25160E62145651060060A5C5</string>
-			<key>productType</key>
-			<string>com.apple.product-type.framework</string>
-		</dict>
-		<key>25160E62145651060060A5C5</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.framework</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>RestKit.framework</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>25160E63145651060060A5C5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Cocoa.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/Cocoa.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>25160E65145651060060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160E66145651060060A5C5</string>
-				<string>25160E67145651060060A5C5</string>
-				<string>25160E68145651060060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Other Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160E66145651060060A5C5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AppKit.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/AppKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>25160E67145651060060A5C5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreData.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/CoreData.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>25160E68145651060060A5C5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>25160E73145651060060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>7AF2905218DF249C009AEB94</string>
-				<string>251610611456F2330060A5C5</string>
-				<string>251610A31456F2330060A5C5</string>
-				<string>251610A51456F2330060A5C5</string>
-				<string>251610A71456F2330060A5C5</string>
-				<string>251610A91456F2330060A5C5</string>
-				<string>251610AB1456F2330060A5C5</string>
-				<string>251610AD1456F2330060A5C5</string>
-				<string>251610AF1456F2330060A5C5</string>
-				<string>251610B11456F2330060A5C5</string>
-				<string>251610B31456F2330060A5C5</string>
-				<string>251610B51456F2330060A5C5</string>
-				<string>251610B71456F2330060A5C5</string>
-				<string>251610B91456F2330060A5C5</string>
-				<string>251610D31456F2330060A5C5</string>
-				<string>251610DD1456F2330060A5C5</string>
-				<string>251610DF1456F2330060A5C5</string>
-				<string>251610E31456F2330060A5C5</string>
-				<string>251610E71456F2330060A5C5</string>
-				<string>251610E91456F2330060A5C5</string>
-				<string>251610F11456F2340060A5C5</string>
-				<string>2516110F1456F2340060A5C5</string>
-				<string>251611111456F2340060A5C5</string>
-				<string>251611131456F2340060A5C5</string>
-				<string>251611171456F2340060A5C5</string>
-				<string>25B6E9DC14CF912500B1E881</string>
-				<string>25B6E9DE14CF912500B1E881</string>
-				<string>25B6E9E014CF912500B1E881</string>
-				<string>252EFAFB14D8EAEC004863C8</string>
-				<string>25E36E0315195CED00F9E448</string>
-				<string>25DB7509151BD551009F01AF</string>
-				<string>259D985B1550C6BE008C90F5</string>
-				<string>259D986515521B20008C90F5</string>
-				<string>2520290A1577C78600076FB4</string>
-				<string>2519764415823BA1004FE9DD</string>
-				<string>2519764915824455004FE9DD</string>
-				<string>2519764D158244F8004FE9DD</string>
-				<string>25AA23D915AF5086006EF62D</string>
-				<string>258EFF7B15C0CE1400EE4E0D</string>
-				<string>25A763E615C7424500A9DF31</string>
-				<string>25C246A515C83B090032212E</string>
-				<string>5C927E151608FFFD00DC8B07</string>
-				<string>25EDFCE5161538F8008BAA1D</string>
-				<string>2564E40C16173F7B00C12D7D</string>
-				<string>25CDA0E8161E828E00F583F3</string>
-				<string>25BB392F161F4FD700E5C72A</string>
-				<string>25565966161FDD8800F5BB20</string>
-				<string>259AC482162B05C80012D2F9</string>
-				<string>252205CD162B242400F7B11E</string>
-				<string>2549D647162B376F003DD135</string>
-				<string>250675A1162DEA27003210B0</string>
-				<string>2548AC6E162F5E00009E79BF</string>
-				<string>255F87921656B22F00914D57</string>
-				<string>2546A95916628EDD0078E044</string>
-				<string>2543A25E1664FD3200821D5B</string>
-				<string>2536D1FE167270F100DF9BB0</string>
-				<string>25513390167838590017E4B6</string>
-				<string>25B639CD16961EFA0065EB7B</string>
-				<string>25A73363169C8C230090A930</string>
-				<string>2550DA2416B1FB62005A0CB8</string>
-				<string>2582F56E173038760043B8BB</string>
-				<string>BE05BDD2178214AA00F7C9C9</string>
-				<string>25AABCEE17B698940061DC5B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160E74145651060060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>25565959161FC3CD00F5BB20</string>
-				<string>25565956161FC3C300F5BB20</string>
-				<string>25160E7A145651060060A5C5</string>
-				<string>7F9CBC6174004E31AEC35813</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160E75145651060060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>251610651456F2330060A5C5</string>
-				<string>251610671456F2330060A5C5</string>
-				<string>251610691456F2330060A5C5</string>
-				<string>2516106B1456F2330060A5C5</string>
-				<string>2516106D1456F2330060A5C5</string>
-				<string>2516106F1456F2330060A5C5</string>
-				<string>251610711456F2330060A5C5</string>
-				<string>251610731456F2330060A5C5</string>
-				<string>251610751456F2330060A5C5</string>
-				<string>251610771456F2330060A5C5</string>
-				<string>251610791456F2330060A5C5</string>
-				<string>2516107B1456F2330060A5C5</string>
-				<string>2516107D1456F2330060A5C5</string>
-				<string>2516107F1456F2330060A5C5</string>
-				<string>251610811456F2330060A5C5</string>
-				<string>251610831456F2330060A5C5</string>
-				<string>251610851456F2330060A5C5</string>
-				<string>251610871456F2330060A5C5</string>
-				<string>251610891456F2330060A5C5</string>
-				<string>2516108B1456F2330060A5C5</string>
-				<string>2516108D1456F2330060A5C5</string>
-				<string>2516108F1456F2330060A5C5</string>
-				<string>251610911456F2330060A5C5</string>
-				<string>251610931456F2330060A5C5</string>
-				<string>251610971456F2330060A5C5</string>
-				<string>251610991456F2330060A5C5</string>
-				<string>2516109B1456F2330060A5C5</string>
-				<string>2516109D1456F2330060A5C5</string>
-				<string>2516109F1456F2330060A5C5</string>
-				<string>251610A11456F2330060A5C5</string>
-				<string>2516110D1456F2340060A5C5</string>
-				<string>73D3907514CA1AE20093E3D6</string>
-				<string>73D3907714CA1AE60093E3D6</string>
-				<string>73D3907A14CA1DD50093E3D6</string>
-				<string>252EFB2914DA0689004863C8</string>
-				<string>25CAAA9515254E7800CAE5D7</string>
-				<string>25119FB7154A34B400C6BC58</string>
-				<string>259D983D154F6C90008C90F5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>25160E76145651060060A5C5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string># Run the unit tests in this test bundle.
-"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests"
-</string>
-		</dict>
-		<key>25160E77145651060060A5C5</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>25160E8A145651060060A5C5</string>
-			<key>buildPhases</key>
-			<array>
-				<string>25160E73145651060060A5C5</string>
-				<string>25160E74145651060060A5C5</string>
-				<string>25160E75145651060060A5C5</string>
-				<string>250CA67F147D8EEC0047D347</string>
-				<string>0779C6DD2283438BA5EAB1FB</string>
-				<string>25160E76145651060060A5C5</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>25160E7C145651060060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>RestKitFrameworkTests</string>
-			<key>productName</key>
-			<string>RestKitFrameworkTests</string>
-			<key>productReference</key>
-			<string>25160E78145651060060A5C5</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>25160E78145651060060A5C5</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>RestKitFrameworkTests.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>25160E7A145651060060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160E63145651060060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160E7B145651060060A5C5</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>25160D0D14564E810060A5C5</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>25160E61145651060060A5C5</string>
-			<key>remoteInfo</key>
-			<string>RestKitFramework</string>
-		</dict>
-		<key>25160E7C145651060060A5C5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>25160E61145651060060A5C5</string>
-			<key>targetProxy</key>
-			<string>25160E7B145651060060A5C5</string>
-		</dict>
-		<key>25160E87145651060060A5C5</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>25160E88145651060060A5C5</string>
-				<string>25160E89145651060060A5C5</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>25160E88145651060060A5C5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>"$(DEVELOPER_FRAMEWORKS_DIR)"</string>
-				</array>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_INLINES_ARE_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Code/Support/RestKit-Prefix.pch</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Resources/PLISTs/RestKitFramework-Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>@rpath</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.7</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>RestKit</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>framework</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>25160E89145651060060A5C5</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>DYLIB_COMPATIBILITY_VERSION</key>
-				<string>1</string>
-				<key>DYLIB_CURRENT_VERSION</key>
-				<string>1</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>"$(DEVELOPER_FRAMEWORKS_DIR)"</string>
-				</array>
-				<key>FRAMEWORK_VERSION</key>
-				<string>A</string>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_INLINES_ARE_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Code/Support/RestKit-Prefix.pch</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Resources/PLISTs/RestKitFramework-Info.plist</string>
-				<key>INSTALL_PATH</key>
-				<string>@rpath</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.7</string>
-				<key>PRODUCT_NAME</key>
-				<string>RestKit</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>framework</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>25160E8A145651060060A5C5</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>25160E8B145651060060A5C5</string>
-				<string>25160E8C145651060060A5C5</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>25160E8B145651060060A5C5</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>D8EFCBE1978F7946E0081FAD</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<string>$(inherited)</string>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Code/Support/RestKit-Prefix.pch</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Resources/PLISTs/RestKitFrameworkTests-Info.plist</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.7</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>25160E8C145651060060A5C5</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>04D69B4B2A54475834B333CF</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>COMBINE_HIDPI_IMAGES</key>
-				<string>YES</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<string>$(inherited)</string>
-				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Code/Support/RestKit-Prefix.pch</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Resources/PLISTs/RestKitFrameworkTests-Info.plist</string>
-				<key>MACOSX_DEPLOYMENT_TARGET</key>
-				<string>10.7</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>macosx</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>25160E8D145652E40060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>252CCE6D17E0CA2700B7F0BF</string>
-				<string>252CCE5D17E08E2D00B7F0BF</string>
-				<string>25C6C0A21716F6F800C98A73</string>
-				<string>25BCB31715ED57D500EE84DD</string>
-				<string>25160EA01456532C0060A5C5</string>
-				<string>25160EB71456532C0060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Vendor</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EA01456532C0060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160EA11456532C0060A5C5</string>
-				<string>25160EAE1456532C0060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>LibComponentLogging</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EA11456532C0060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160EA21456532C0060A5C5</string>
-				<string>25160EA31456532C0060A5C5</string>
-				<string>25160EA71456532C0060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Core</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EA21456532C0060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>lcl_RK.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EA31456532C0060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>lcl_RK.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EA71456532C0060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>README.md</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EAE1456532C0060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160EB01456532C0060A5C5</string>
-				<string>25160EB11456532C0060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>NSLog</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EB01456532C0060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>LCLNSLog_RK.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EB11456532C0060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>LCLNSLog_RK.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EB71456532C0060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160EBD1456532C0060A5C5</string>
-				<string>25160EBE1456532C0060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>SOCKit</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EBD1456532C0060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SOCKit.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EBE1456532C0060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>SOCKit.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160EE21456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EA21456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160EE31456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EA21456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160EE41456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EA31456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160EE51456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EA31456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160EF81456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EB01456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160EF91456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EB01456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160EFA1456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EB11456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160EFB1456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EB11456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F081456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EBD1456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F091456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EBD1456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F0A1456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EBE1456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>25160F0B1456532C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160EBE1456532C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>25160F161456538B0060A5C5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>compiled.mach-o.dylib</string>
-			<key>name</key>
-			<string>libxml2.dylib</string>
-			<key>path</key>
-			<string>usr/lib/libxml2.dylib</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>25160F25145655AF0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DA1145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F44145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D7C145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F45145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D7D145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F46145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D7E145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F47145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D7F145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F4A145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D82145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F4B145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D83145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F51145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D89145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F52145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D8A145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F53145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D8B145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Private</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F55145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D8D145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F56145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D8E145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F57145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D8F145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F58145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D90145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F59145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D91145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F5C145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D94145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F5D145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D95145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F5E145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D96145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F5F145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D97145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F60145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D98145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F61145655C60060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D99145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F6F145655D10060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D4C145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F70145655D10060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D4D145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F73145655D10060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D50145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F74145655D10060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D51145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F75145655D10060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D52145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F76145655D10060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D53145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F79145655D10060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D56145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F7A145655D10060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160D57145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F7B145657220060A5C5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>SystemConfiguration.framework</string>
-			<key>path</key>
-			<string>SDKs/MacOSX10.7.sdk/System/Library/Frameworks/SystemConfiguration.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>25160F7C145657220060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160F7B145657220060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F7D1456572F0060A5C5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Cocoa.framework</string>
-			<key>path</key>
-			<string>SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Cocoa.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>25160F7E145657300060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160F7D1456572F0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F85145657650060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DA5145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F86145657650060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DA6145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F87145657650060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DA7145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F901456576C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DBE145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F911456576C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DBF145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F931456576C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DC1145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F941456576C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DC2145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F951456576C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DC3145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160F961456576C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DC4145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25160F971456576C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DC5145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25160FC51456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>251610351456F2330060A5C5</string>
-				<string>251610361456F2330060A5C5</string>
-				<string>25160FC61456F2330060A5C5</string>
-				<string>25160FCD1456F2330060A5C5</string>
-				<string>25160FF31456F2330060A5C5</string>
-				<string>2516100B1456F2330060A5C5</string>
-				<string>2516101B1456F2330060A5C5</string>
-				<string>251610511456F2330060A5C5</string>
-				<string>25104F9B15C33E3A00829135</string>
-				<string>25B639C816961EC70065EB7B</string>
-				<string>251610471456F2330060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Tests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FC61456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160FC71456F2330060A5C5</string>
-				<string>25160FC91456F2330060A5C5</string>
-				<string>25160FCB1456F2330060A5C5</string>
-				<string>25E36E0115195CED00F9E448</string>
-				<string>25079C75151B952200266AE7</string>
-				<string>25DB7507151BD551009F01AF</string>
-				<string>259D98591550C6BE008C90F5</string>
-				<string>259D986315521B1F008C90F5</string>
-				<string>25AA23D315AF4F25006EF62D</string>
-				<string>258EFF7915C0CE1400EE4E0D</string>
-				<string>2564E40A16173F7B00C12D7D</string>
-				<string>2546A95716628EDD0078E044</string>
-				<string>2582F56C173038750043B8BB</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>CoreData</string>
-			<key>path</key>
-			<string>Logic/CoreData</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FC71456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKManagedObjectLoaderTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FC91456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKEntityMappingTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FCB1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKManagedObjectStoreTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FCD1456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160FCE1456F2330060A5C5</string>
-				<string>25160FD01456F2330060A5C5</string>
-				<string>25160FE91456F2330060A5C5</string>
-				<string>25160FEC1456F2330060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Fixtures</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FCE1456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160FCF1456F2330060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Assets</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FCF1456F2330060A5C5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.png</string>
-			<key>path</key>
-			<string>blake.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FD01456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>259D983B154F6C90008C90F5</string>
-				<string>252EFB2714DA0689004863C8</string>
-				<string>25160FD11456F2330060A5C5</string>
-				<string>25160FD21456F2330060A5C5</string>
-				<string>25160FD31456F2330060A5C5</string>
-				<string>25160FD41456F2330060A5C5</string>
-				<string>25160FD51456F2330060A5C5</string>
-				<string>25160FDA1456F2330060A5C5</string>
-				<string>25160FDB1456F2330060A5C5</string>
-				<string>25160FDC1456F2330060A5C5</string>
-				<string>25160FDD1456F2330060A5C5</string>
-				<string>25160FDE1456F2330060A5C5</string>
-				<string>25160FDF1456F2330060A5C5</string>
-				<string>25160FE01456F2330060A5C5</string>
-				<string>25160FE41456F2330060A5C5</string>
-				<string>25160FE51456F2330060A5C5</string>
-				<string>25160FE61456F2330060A5C5</string>
-				<string>25160FE71456F2330060A5C5</string>
-				<string>25160FE81456F2330060A5C5</string>
-				<string>25CAAA9315254E7800CAE5D7</string>
-				<string>25119FB5154A34B400C6BC58</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>JSON</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FD11456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>ArrayOfNestedDictionaries.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FD21456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>ArrayOfResults.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FD31456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>ComplexNestedUser.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FD41456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>ConnectingParents.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FD51456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160FD61456F2330060A5C5</string>
-				<string>73D3907314CA1A4A0093E3D6</string>
-				<string>25160FD71456F2330060A5C5</string>
-				<string>25160FD81456F2330060A5C5</string>
-				<string>25160FD91456F2330060A5C5</string>
-				<string>73D3907114CA19F90093E3D6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Dynamic</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FD61456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>boy.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FD71456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>friends.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FD81456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>girl.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FD91456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>mixed.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FDA1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>DynamicKeys.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FDB1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>DynamicKeysWithNestedRelationship.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FDC1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>DynamicKeysWithRelationship.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FDD1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>error.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FDE1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>errors.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FDF1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>Foursquare.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FE01456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160FE11456F2330060A5C5</string>
-				<string>25160FE21456F2330060A5C5</string>
-				<string>3EB0D83816ADCEFC00E9CEA2</string>
-				<string>3E886DC0169E10A70069C56B</string>
-				<string>25160FE31456F2330060A5C5</string>
-				<string>F66056291744FF9000A87A45</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>humans</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FE11456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>1.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FE21456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>all.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FE31456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>with_to_one_relationship.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FE41456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>nested_user.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FE51456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>RailsUser.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FE61456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>SameKeyDifferentTargetClasses.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FE71456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>user.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FE81456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>users.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FE91456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160FEA1456F2330060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Uploads</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FEA1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>.gitignore</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FEC1456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160FED1456F2330060A5C5</string>
-				<string>73D3907814CA1D710093E3D6</string>
-				<string>25160FEE1456F2330060A5C5</string>
-				<string>25160FEF1456F2330060A5C5</string>
-				<string>25160FF01456F2330060A5C5</string>
-				<string>25160FF11456F2330060A5C5</string>
-				<string>25160FF21456F2330060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>XML</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FED1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xml</string>
-			<key>path</key>
-			<string>attributes_without_text_content.xml</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FEE1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xml</string>
-			<key>path</key>
-			<string>container_attributes.xml</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FEF1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xml</string>
-			<key>path</key>
-			<string>national_weather_service.xml</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FF01456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xml</string>
-			<key>path</key>
-			<string>orders.xml</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FF11456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xml</string>
-			<key>path</key>
-			<string>tab_data.xml</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FF21456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xml</string>
-			<key>path</key>
-			<string>zend.xml</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FF31456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>252EFAF814D8EAEC004863C8</string>
-				<string>252EFAF914D8EAEC004863C8</string>
-				<string>25B6E9D514CF912500B1E881</string>
-				<string>25B6E9D614CF912500B1E881</string>
-				<string>25B6E9D714CF912500B1E881</string>
-				<string>25B6E9D814CF912500B1E881</string>
-				<string>25B6E9D914CF912500B1E881</string>
-				<string>25B6E9DA14CF912500B1E881</string>
-				<string>25160FF41456F2330060A5C5</string>
-				<string>25160FF51456F2330060A5C5</string>
-				<string>25160FF61456F2330060A5C5</string>
-				<string>25160FF71456F2330060A5C5</string>
-				<string>25160FF81456F2330060A5C5</string>
-				<string>25160FF91456F2330060A5C5</string>
-				<string>25160FFA1456F2330060A5C5</string>
-				<string>25160FFB1456F2330060A5C5</string>
-				<string>25160FFC1456F2330060A5C5</string>
-				<string>25160FFD1456F2330060A5C5</string>
-				<string>25160FFE1456F2330060A5C5</string>
-				<string>25160FFF1456F2330060A5C5</string>
-				<string>251610001456F2330060A5C5</string>
-				<string>251610011456F2330060A5C5</string>
-				<string>251610021456F2330060A5C5</string>
-				<string>251610031456F2330060A5C5</string>
-				<string>251610041456F2330060A5C5</string>
-				<string>251610051456F2330060A5C5</string>
-				<string>251610061456F2330060A5C5</string>
-				<string>251610071456F2330060A5C5</string>
-				<string>251610081456F2330060A5C5</string>
-				<string>251610091456F2330060A5C5</string>
-				<string>2516100A1456F2330060A5C5</string>
-				<string>25A73360169C8C230090A930</string>
-				<string>2550DA2116B1FB62005A0CB8</string>
-				<string>2550DA2216B1FB62005A0CB8</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Models</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FF41456F2330060A5C5</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.xcdatamodel</string>
-			<key>path</key>
-			<string>Data Model.xcdatamodel</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FF51456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKCat.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FF61456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKCat.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FF71456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKChild.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FF81456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKChild.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FF91456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKDynamicMappingModels.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FFA1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKDynamicMappingModels.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FFB1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKHouse.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FFC1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKHouse.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FFD1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKHuman.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FFE1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKHuman.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25160FFF1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMappableAssociation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610001456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKMappableAssociation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610011456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMappableObject.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610021456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKMappableObject.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610031456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKObjectLoaderTestResultModel.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610041456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectLoaderTestResultModel.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610051456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKObjectMapperTestModel.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610061456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectMapperTestModel.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610071456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKParent.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610081456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKParent.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610091456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKResident.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2516100A1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKResident.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2516100B1456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25CC5C58161DDADD0008BD21</string>
-				<string>BE05BDCF1782109F00F7C9C9</string>
-				<string>252029081577C78600076FB4</string>
-				<string>25565964161FDD8800F5BB20</string>
-				<string>259AC480162B05C80012D2F9</string>
-				<string>2549D645162B376F003DD135</string>
-				<string>2548AC6C162F5E00009E79BF</string>
-				<string>2536D1FC167270F100DF9BB0</string>
-				<string>2551338E167838590017E4B6</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Network</string>
-			<key>path</key>
-			<string>Logic/Network</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2516101B1456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>2516101C1456F2330060A5C5</string>
-				<string>2516101F1456F2330060A5C5</string>
-				<string>251610211456F2330060A5C5</string>
-				<string>251610221456F2330060A5C5</string>
-				<string>251610241456F2330060A5C5</string>
-				<string>251610261456F2330060A5C5</string>
-				<string>251610271456F2330060A5C5</string>
-				<string>254A62BF14AD591C00939BEE</string>
-				<string>2519764215823BA1004FE9DD</string>
-				<string>2519764715824455004FE9DD</string>
-				<string>2519764B158244F8004FE9DD</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>ObjectMapping</string>
-			<key>path</key>
-			<string>Logic/ObjectMapping</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2516101C1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKDynamicMappingTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2516101F1456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectManagerTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610211456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>RKObjectMappingNextGenTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.objc</string>
-		</dict>
-		<key>251610221456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>RKMappingOperationTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.objc</string>
-		</dict>
-		<key>251610241456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKMappingResultTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610261456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectParameterizationTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610271456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKMIMETypeSerializationTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610351456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKTestEnvironment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610361456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKTestEnvironment.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610471456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>251610481456F2330060A5C5</string>
-				<string>251610501456F2330060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Server</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610481456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>251610491456F2330060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>lib</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610491456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>restkit</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610501456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.ruby</string>
-			<key>path</key>
-			<string>server.rb</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610511456F2330060A5C5</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25AABCEC17B698940061DC5B</string>
-				<string>5C927E131608FFFD00DC8B07</string>
-				<string>251610521456F2330060A5C5</string>
-				<string>251610531456F2330060A5C5</string>
-				<string>251610541456F2330060A5C5</string>
-				<string>251610561456F2330060A5C5</string>
-				<string>2501405215366000004E0466</string>
-				<string>25CDA0E2161E821000F583F3</string>
-				<string>25BB392D161F4FD700E5C72A</string>
-				<string>252205CB162B242400F7B11E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support</string>
-			<key>path</key>
-			<string>Logic/Support</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610521456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKURLEncodedSerializationTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610531456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>NSStringRestKitTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610541456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKDotNetDateFormatterTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610561456F2330060A5C5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKPathMatcherTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>251610601456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FCB1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610611456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FCB1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610641456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FCF1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610651456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FCF1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610661456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD11456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610671456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD11456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610681456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD21456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610691456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD21456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516106A1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD31456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516106B1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD31456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516106C1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD41456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516106D1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD41456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516106E1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD61456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516106F1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD61456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610701456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD71456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610711456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD71456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610721456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD81456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610731456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD81456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610741456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD91456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610751456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FD91456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610761456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDA1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610771456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDA1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610781456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDB1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610791456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDB1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516107A1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDC1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516107B1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDC1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516107C1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDD1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516107D1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDD1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516107E1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDE1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516107F1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDE1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610801456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDF1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610811456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FDF1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610821456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE11456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610831456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE11456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610841456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE21456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610851456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE21456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610861456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE31456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610871456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE31456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610881456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE41456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610891456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE41456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516108A1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE51456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516108B1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE51456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516108C1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE61456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516108D1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE61456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516108E1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE71456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516108F1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE71456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610901456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE81456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610911456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FE81456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610931456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FEA1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610961456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FED1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610971456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FED1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610981456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FEE1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610991456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FEE1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516109A1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FEF1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516109B1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FEF1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516109C1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF01456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516109D1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF01456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516109E1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF11456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516109F1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF11456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610A01456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF21456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610A11456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF21456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610A21456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF41456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610A31456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF41456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610A41456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF61456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610A51456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF61456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610A61456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF81456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610A71456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FF81456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610A81456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FFA1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610A91456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FFA1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610AA1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FFC1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610AB1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FFC1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610AC1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FFE1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610AD1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160FFE1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610AE1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610001456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610AF1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610001456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610B01456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610021456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610B11456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610021456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610B21456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610041456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610B31456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610041456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610B41456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610061456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610B51456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610061456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610B61456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610081456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610B71456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610081456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610B81456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2516100A1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610B91456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2516100A1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610D21456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2516101C1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610D31456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2516101C1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610DC1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610211456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610DD1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610211456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-fno-objc-arc</string>
-			</dict>
-		</dict>
-		<key>251610DE1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610221456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610DF1456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610221456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610E21456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610241456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610E31456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610241456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610E71456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610261456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610E81456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610271456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610E91456F2330060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610271456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610F01456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610361456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251610F11456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610361456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516110D1456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610501456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516110E1456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610521456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516110F1456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610521456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251611101456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610531456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251611111456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610531456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251611121456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610541456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251611131456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610541456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251611161456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610561456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251611171456F2340060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610561456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251611281456F50F0060A5C5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>SystemConfiguration.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/SystemConfiguration.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>251611291456F50F0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251611281456F50F0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516112A1456F5170060A5C5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CFNetwork.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CFNetwork.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>2516112B1456F5170060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2516112A1456F5170060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516112C1456F51D0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160F161456538B0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516112D1456F5520060A5C5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreData.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreData.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>2516112E1456F5520060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2516112D1456F5520060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2516112F1456F5590060A5C5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Security.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Security.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>251611301456F5590060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2516112F1456F5590060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>251611311456F56C0060A5C5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>MobileCoreServices.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/MobileCoreServices.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>251611321456F56C0060A5C5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251611311456F56C0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2519764215823BA1004FE9DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKAttributeMappingTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2519764315823BA1004FE9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2519764215823BA1004FE9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2519764415823BA1004FE9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2519764215823BA1004FE9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2519764715824455004FE9DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRelationshipMappingTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2519764815824455004FE9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2519764715824455004FE9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2519764915824455004FE9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2519764715824455004FE9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2519764B158244F8004FE9DD</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectMappingTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2519764C158244F8004FE9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2519764B158244F8004FE9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2519764D158244F8004FE9DD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2519764B158244F8004FE9DD</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252028FA1577AE0B00076FB4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKRouteSet.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252028FB1577AE0B00076FB4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRouteSet.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252028FC1577AE0B00076FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252028FA1577AE0B00076FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252028FD1577AE0B00076FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252028FA1577AE0B00076FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252028FE1577AE0B00076FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252028FB1577AE0B00076FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252028FF1577AE0B00076FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252028FB1577AE0B00076FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252029011577AE1800076FB4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKRoute.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252029021577AE1800076FB4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRoute.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252029031577AE1800076FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252029011577AE1800076FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252029041577AE1800076FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252029011577AE1800076FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252029051577AE1800076FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252029021577AE1800076FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252029061577AE1800076FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252029021577AE1800076FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252029081577C78600076FB4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRouteSetTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252029091577C78600076FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252029081577C78600076FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2520290A1577C78600076FB4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252029081577C78600076FB4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252205CB162B242400F7B11E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKHTTPUtilitiesTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252205CC162B242400F7B11E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252205CB162B242400F7B11E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252205CD162B242400F7B11E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252205CB162B242400F7B11E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252CCE5D17E08E2D00B7F0BF</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>252CCE6017E08E2D00B7F0BF</string>
-				<string>252CCE6117E08E2D00B7F0BF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>RKValueTransformers</string>
-			<key>path</key>
-			<string>RKValueTransformers/Code</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252CCE6017E08E2D00B7F0BF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKValueTransformers.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252CCE6117E08E2D00B7F0BF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKValueTransformers.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252CCE6617E08E2D00B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE6017E08E2D00B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252CCE6717E08E2D00B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE6017E08E2D00B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252CCE6817E08E2D00B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE6117E08E2D00B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252CCE6917E08E2D00B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE6117E08E2D00B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252CCE6D17E0CA2700B7F0BF</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>252CCE6E17E0CA2700B7F0BF</string>
-				<string>252CCE6F17E0CA2700B7F0BF</string>
-				<string>252CCE7017E0CA2700B7F0BF</string>
-				<string>252CCE7117E0CA2700B7F0BF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>ISO8601DateFormatterValueTransformer</string>
-			<key>path</key>
-			<string>ISO8601DateFormatterValueTransformer/Code</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252CCE6E17E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ISO8601DateFormatterValueTransformer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252CCE6F17E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ISO8601DateFormatterValueTransformer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252CCE7017E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKISO8601DateFormatter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252CCE7117E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKISO8601DateFormatter.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252CCE7217E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE6E17E0CA2700B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252CCE7317E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE6E17E0CA2700B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252CCE7417E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE6F17E0CA2700B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252CCE7517E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE6F17E0CA2700B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252CCE7617E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE7017E0CA2700B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252CCE7717E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE7017E0CA2700B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>252CCE7817E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE7117E0CA2700B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252CCE7917E0CA2700B7F0BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252CCE7117E0CA2700B7F0BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252EFAF814D8EAEC004863C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKEvent.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252EFAF914D8EAEC004863C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKEvent.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252EFAFA14D8EAEC004863C8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFAF914D8EAEC004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252EFAFB14D8EAEC004863C8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFAF914D8EAEC004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252EFAFC14D8EB30004863C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RKTestNotificationObserver.h</string>
-			<key>path</key>
-			<string>Testing/RKTestNotificationObserver.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252EFAFD14D8EB30004863C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RKTestNotificationObserver.m</string>
-			<key>path</key>
-			<string>Testing/RKTestNotificationObserver.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252EFB1F14D9A8D4004863C8</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25A199D216ED035A00792629</string>
-				<string>25A199D316ED035A00792629</string>
-				<string>25055B8214EEF32A00B9C4DD</string>
-				<string>25055B8314EEF32A00B9C4DD</string>
-				<string>252EFB2014D9B35D004863C8</string>
-				<string>252EFB2114D9B35D004863C8</string>
-				<string>252EFAFC14D8EB30004863C8</string>
-				<string>252EFAFD14D8EB30004863C8</string>
-				<string>25055B8014EEF32A00B9C4DD</string>
-				<string>25055B8114EEF32A00B9C4DD</string>
-				<string>25055B8D14EEF40000B9C4DD</string>
-				<string>25055B8E14EEF40000B9C4DD</string>
-				<string>25A8C2321673BD480014D9A6</string>
-				<string>25A8C2331673BD480014D9A6</string>
-				<string>25C954A415542A47005C9E08</string>
-				<string>2507C325161BD5C700EA71FF</string>
-				<string>2507C326161BD5C700EA71FF</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Testing</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252EFB2014D9B35D004863C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RKTestFixture.h</string>
-			<key>path</key>
-			<string>Testing/RKTestFixture.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252EFB2114D9B35D004863C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RKTestFixture.m</string>
-			<key>path</key>
-			<string>Testing/RKTestFixture.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252EFB2714DA0689004863C8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>NakedEvents.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>252EFB2814DA0689004863C8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFB2714DA0689004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>252EFB2914DA0689004863C8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFB2714DA0689004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>253477EF15FFBC60002C0E4E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKDictionaryUtilities.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>253477F015FFBC60002C0E4E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKDictionaryUtilities.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>253477F115FFBC61002C0E4E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>253477EF15FFBC60002C0E4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>253477F215FFBC61002C0E4E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>253477EF15FFBC60002C0E4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>253477F315FFBC61002C0E4E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>253477F015FFBC60002C0E4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>253477F415FFBC61002C0E4E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>253477F015FFBC60002C0E4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2534781415FFD4A6002C0E4E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKURLEncodedSerialization.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2534781515FFD4A6002C0E4E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKURLEncodedSerialization.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2534781615FFD4A6002C0E4E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2534781415FFD4A6002C0E4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2534781715FFD4A6002C0E4E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2534781415FFD4A6002C0E4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2534781815FFD4A6002C0E4E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2534781515FFD4A6002C0E4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2534781915FFD4A6002C0E4E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2534781515FFD4A6002C0E4E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2536D1FC167270F100DF9BB0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRouterTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2536D1FD167270F100DF9BB0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2536D1FC167270F100DF9BB0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2536D1FE167270F100DF9BB0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2536D1FC167270F100DF9BB0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>253B495214E35D1A00B0483F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFB2014D9B35D004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>253B495F14E35EC300B0483F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFB2114D9B35D004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372A615F54995006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKObjectParameterization.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372A715F54995006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectParameterization.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372A815F54995006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372A615F54995006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372A915F54995006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372A715F54995006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372AA15F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKHTTPRequestOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372AB15F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKHTTPRequestOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372AC15F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKObjectManager.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372AD15F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectManager.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372AE15F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKPaginator.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372AF15F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKPaginator.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372B015F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKObjectRequestOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372B115F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectRequestOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372B215F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKRequestDescriptor.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372B315F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRequestDescriptor.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372B415F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKResponseDescriptor.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372B515F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKResponseDescriptor.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372B615F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKResponseMapperOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372B715F54C3F006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKResponseMapperOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372B815F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AA15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372B915F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AA15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372BA15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AB15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372BB15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AB15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372BC15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AC15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372BD15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AC15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372BE15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AD15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372BF15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AD15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372C015F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AE15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372C115F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AE15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372C215F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AF15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372C315F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372AF15F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372C415F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B015F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372C515F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B015F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372C615F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B115F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372C715F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B115F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372C815F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B215F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372C915F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B215F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372CA15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B315F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372CB15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B315F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372CC15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B415F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372CD15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B415F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372CE15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B515F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372CF15F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B515F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372D015F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B615F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372D115F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B615F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372D215F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B715F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372D315F54C3F006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372B715F54C3F006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372D415F54CE3006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKManagedObjectRequestOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372D515F54CE3006E8424</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKManagedObjectRequestOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>254372D615F54CE3006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372D415F54CE3006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372D715F54CE3006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372D415F54CE3006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>254372D815F54CE3006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372D515F54CE3006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254372D915F54CE3006E8424</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372D515F54CE3006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2543A25D1664FD3100821D5B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25CC5C58161DDADD0008BD21</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2543A25E1664FD3200821D5B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25CC5C58161DDADD0008BD21</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2546A95716628EDD0078E044</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKConnectionDescriptionTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2546A95916628EDD0078E044</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2546A95716628EDD0078E044</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2548AC6C162F5E00009E79BF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKManagedObjectRequestOperationTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2548AC6E162F5E00009E79BF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2548AC6C162F5E00009E79BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2549D645162B376F003DD135</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRequestDescriptorTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2549D646162B376F003DD135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2549D645162B376F003DD135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2549D647162B376F003DD135</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2549D645162B376F003DD135</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>254A62BF14AD591C00939BEE</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKPaginatorTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2550DA2116B1FB62005A0CB8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKPost.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2550DA2216B1FB62005A0CB8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKPost.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2550DA2316B1FB62005A0CB8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2550DA2216B1FB62005A0CB8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2550DA2416B1FB62005A0CB8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2550DA2216B1FB62005A0CB8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2551338E167838590017E4B6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKHTTPRequestOperationTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2551338F167838590017E4B6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2551338E167838590017E4B6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25513390167838590017E4B6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2551338E167838590017E4B6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>255133CF167AC7600017E4B6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2548AC6C162F5E00009E79BF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25565955161FC3C300F5BB20</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreServices.framework</string>
-			<key>path</key>
-			<string>Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/System/Library/Frameworks/CoreServices.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>25565956161FC3C300F5BB20</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25565955161FC3C300F5BB20</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25565958161FC3CD00F5BB20</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>SystemConfiguration.framework</string>
-			<key>path</key>
-			<string>Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/System/Library/Frameworks/SystemConfiguration.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>25565959161FC3CD00F5BB20</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25565958161FC3CD00F5BB20</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25565964161FDD8800F5BB20</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKResponseMapperOperationTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25565965161FDD8800F5BB20</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25565964161FDD8800F5BB20</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25565966161FDD8800F5BB20</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25565964161FDD8800F5BB20</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>255893E3166BA6A20010C70B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372A615F54995006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>255893E4166BA7400010C70B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25160DBB145650490060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>255893E5166BA7700010C70B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFB2014D9B35D004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>255F87911656B22D00914D57</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254A62BF14AD591C00939BEE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>255F87921656B22F00914D57</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254A62BF14AD591C00939BEE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2564E40A16173F7B00C12D7D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRelationshipConnectionOperationTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2564E40B16173F7B00C12D7D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2564E40A16173F7B00C12D7D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2564E40C16173F7B00C12D7D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2564E40A16173F7B00C12D7D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257ABAAE15112DD400CCAA76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>NSManagedObjectContext+RKAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257ABAAF15112DD400CCAA76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>NSManagedObjectContext+RKAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257ABAB015112DD500CCAA76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257ABAAE15112DD400CCAA76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>257ABAB115112DD500CCAA76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257ABAAE15112DD400CCAA76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>257ABAB215112DD500CCAA76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257ABAAF15112DD400CCAA76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257ABAB315112DD500CCAA76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257ABAAF15112DD400CCAA76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257ABAB41511371C00CCAA76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>NSManagedObject+RKAdditions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257ABAB51511371D00CCAA76</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>NSManagedObject+RKAdditions.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>257ABAB61511371E00CCAA76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257ABAB41511371C00CCAA76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>257ABAB71511371E00CCAA76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257ABAB41511371C00CCAA76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>257ABAB81511371E00CCAA76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257ABAB51511371D00CCAA76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>257ABAB91511371E00CCAA76</key>
-		<dict>
-			<key>fileRef</key>
-			<string>257ABAB51511371D00CCAA76</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2582F56C173038750043B8BB</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKInMemoryManagedObjectCacheTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2582F56D173038760043B8BB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2582F56C173038750043B8BB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2582F56E173038760043B8BB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2582F56C173038750043B8BB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>258BEA01168D058300C74C8C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectMappingMatcher.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>258BEA02168D058300C74C8C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258BEA01168D058300C74C8C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>258BEA03168D058300C74C8C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258BEA01168D058300C74C8C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>258EA4A615A38BBF007E07A6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKObjectMappingOperationDataSource.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>258EA4A715A38BBF007E07A6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectMappingOperationDataSource.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>258EA4A815A38BC0007E07A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258EA4A615A38BBF007E07A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>258EA4A915A38BC0007E07A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258EA4A615A38BBF007E07A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>258EA4AA15A38BC0007E07A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258EA4A715A38BBF007E07A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>258EA4AB15A38BC0007E07A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258EA4A715A38BBF007E07A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>258EA4AD15A38E7D007E07A6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMappingOperationDataSource.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>258EA4AE15A38E7E007E07A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258EA4AD15A38E7D007E07A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>258EA4AF15A38E7E007E07A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258EA4AD15A38E7D007E07A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>258EA4B015A3908F007E07A6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKManagedObjectMappingOperationDataSource.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>258EA4B215A39090007E07A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258EA4B015A3908F007E07A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>258EA4B315A39090007E07A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258EA4B015A3908F007E07A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>258EFF7915C0CE1400EE4E0D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKManagedObjectSeederTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>258EFF7A15C0CE1400EE4E0D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258EFF7915C0CE1400EE4E0D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>258EFF7B15C0CE1400EE4E0D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>258EFF7915C0CE1400EE4E0D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2595B46B15F670530087A59B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMIMETypeSerialization.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2595B46C15F670530087A59B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKMIMETypeSerialization.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2595B46D15F670530087A59B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKNSJSONSerialization.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2595B46E15F670530087A59B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKNSJSONSerialization.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2595B46F15F670530087A59B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2595B46B15F670530087A59B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2595B47015F670530087A59B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2595B46B15F670530087A59B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2595B47115F670530087A59B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2595B46C15F670530087A59B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2595B47215F670530087A59B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2595B46C15F670530087A59B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2595B47315F670530087A59B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2595B46D15F670530087A59B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2595B47415F670530087A59B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2595B46D15F670530087A59B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2595B47515F670530087A59B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2595B46E15F670530087A59B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2595B47615F670530087A59B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2595B46E15F670530087A59B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2597F99A15AF6DC400E547D7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKRelationshipConnectionOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2597F99B15AF6DC400E547D7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRelationshipConnectionOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2597F99C15AF6DC400E547D7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2597F99A15AF6DC400E547D7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2597F99D15AF6DC400E547D7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2597F99A15AF6DC400E547D7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2597F99E15AF6DC400E547D7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2597F99B15AF6DC400E547D7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2597F99F15AF6DC400E547D7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2597F99B15AF6DC400E547D7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2598888B15EC169E006CAE95</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKPropertyMapping.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2598888C15EC169E006CAE95</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKPropertyMapping.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2598888D15EC169E006CAE95</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2598888B15EC169E006CAE95</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2598888E15EC169E006CAE95</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2598888B15EC169E006CAE95</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>2598888F15EC169E006CAE95</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2598888C15EC169E006CAE95</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>2598889015EC169E006CAE95</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2598888C15EC169E006CAE95</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259AC480162B05C80012D2F9</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectRequestOperationTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259AC481162B05C80012D2F9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259AC480162B05C80012D2F9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259AC482162B05C80012D2F9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259AC480162B05C80012D2F9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96C21604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AFHTTPClient.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96C31604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AFHTTPClient.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96C41604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AFHTTPRequestOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96C51604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AFHTTPRequestOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96C61604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AFImageRequestOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96C71604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AFImageRequestOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96C81604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AFJSONRequestOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96C91604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AFJSONRequestOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96CA1604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AFNetworkActivityIndicatorManager.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96CB1604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AFPropertyListRequestOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96CC1604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AFPropertyListRequestOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96CD1604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AFURLConnectionOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96CE1604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AFURLConnectionOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96CF1604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AFXMLRequestOperation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96D01604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AFXMLRequestOperation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96D11604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>UIImageView+AFNetworking.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96D21604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AFNetworkActivityIndicatorManager.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96D31604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>UIImageView+AFNetworking.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96D41604CCCC0000C250</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AFNetworking.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259B96D51604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C21604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96D61604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C21604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96D71604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C31604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96D81604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C31604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96D91604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C41604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96DA1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C41604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96DB1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C51604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96DC1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C51604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96DD1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C61604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96DE1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C61604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96DF1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C71604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96E01604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C71604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96E11604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C81604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96E21604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C81604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96E31604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C91604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96E41604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96C91604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96E51604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CA1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96E61604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CA1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96E71604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CB1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96E81604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CB1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96E91604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CC1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96EA1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CC1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96EB1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CD1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96EC1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CD1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96ED1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CE1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96EE1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CE1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96EF1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CF1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96F01604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96CF1604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96F11604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96D01604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96F21604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96D01604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96F31604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96D11604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96F41604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96D11604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259B96F51604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96D21604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96F61604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96D21604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96F71604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96D31604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96F81604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96D31604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96F91604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96D41604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259B96FA1604CCCC0000C250</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259B96D41604CCCC0000C250</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259D983B154F6C90008C90F5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>benchmark_parents_and_children.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259D983C154F6C90008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D983B154F6C90008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259D983D154F6C90008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D983B154F6C90008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259D98521550C69A008C90F5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKEntityByAttributeCache.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259D98531550C69A008C90F5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKEntityByAttributeCache.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259D98541550C69A008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D98521550C69A008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259D98551550C69A008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D98521550C69A008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259D98561550C69A008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D98531550C69A008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259D98571550C69A008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D98531550C69A008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259D98591550C6BE008C90F5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKEntityByAttributeCacheTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259D985A1550C6BE008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D98591550C6BE008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259D985B1550C6BE008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D98591550C6BE008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259D985C155218E4008C90F5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKEntityCache.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259D985D155218E4008C90F5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKEntityCache.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259D985E155218E5008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D985C155218E4008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259D985F155218E5008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D985C155218E4008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>259D9860155218E5008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D985D155218E4008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259D9861155218E5008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D985D155218E4008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259D986315521B1F008C90F5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKEntityCacheTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>259D986415521B20008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D986315521B1F008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>259D986515521B20008C90F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>259D986315521B1F008C90F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A199D216ED035A00792629</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RKBenchmark.h</string>
-			<key>path</key>
-			<string>Testing/RKBenchmark.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A199D316ED035A00792629</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RKBenchmark.m</string>
-			<key>path</key>
-			<string>Testing/RKBenchmark.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A199D416ED035A00792629</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A199D216ED035A00792629</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25A199D516ED035A00792629</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A199D216ED035A00792629</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25A199D616ED035A00792629</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A199D316ED035A00792629</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A199D716ED035A00792629</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A199D316ED035A00792629</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A226D41618A57500952D72</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKObjectUtilities.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A226D51618A57500952D72</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKObjectUtilities.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A226D61618A57500952D72</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A226D41618A57500952D72</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25A226D71618A57500952D72</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A226D41618A57500952D72</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25A226D81618A57500952D72</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A226D51618A57500952D72</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A226D91618A57500952D72</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A226D51618A57500952D72</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A34244147D8AAA0009758D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Security.framework</string>
-			<key>path</key>
-			<string>SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Security.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>25A34245147D8AAA0009758D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A34244147D8AAA0009758D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A73360169C8C230090A930</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25A73365169C8CD80090A930</string>
-				<string>25A73366169C8CF30090A930</string>
-				<string>25A73367169C8D500090A930</string>
-				<string>25A73361169C8C230090A930</string>
-			</array>
-			<key>currentVersion</key>
-			<string>25A73367169C8D500090A930</string>
-			<key>isa</key>
-			<string>XCVersionGroup</string>
-			<key>path</key>
-			<string>VersionedModel.xcdatamodeld</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>versionGroupType</key>
-			<string>wrapper.xcdatamodel</string>
-		</dict>
-		<key>25A73361169C8C230090A930</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.xcdatamodel</string>
-			<key>path</key>
-			<string>VersionedModel.xcdatamodel</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A73362169C8C230090A930</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A73360169C8C230090A930</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A73363169C8C230090A930</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A73360169C8C230090A930</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A73365169C8CD80090A930</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.xcdatamodel</string>
-			<key>path</key>
-			<string>VersionedModel 2.xcdatamodel</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A73366169C8CF30090A930</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.xcdatamodel</string>
-			<key>path</key>
-			<string>VersionedModel 3.xcdatamodel</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A73367169C8D500090A930</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.xcdatamodel</string>
-			<key>path</key>
-			<string>VersionedModel 4.xcdatamodel</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A763E415C7424500A9DF31</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKSearchIndexerTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A763E515C7424500A9DF31</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A763E415C7424500A9DF31</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A763E615C7424500A9DF31</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A763E415C7424500A9DF31</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A8C2321673BD480014D9A6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RKConnectionTestExpectation.h</string>
-			<key>path</key>
-			<string>Testing/RKConnectionTestExpectation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A8C2331673BD480014D9A6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RKConnectionTestExpectation.m</string>
-			<key>path</key>
-			<string>Testing/RKConnectionTestExpectation.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25A8C2341673BD480014D9A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A8C2321673BD480014D9A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25A8C2351673BD480014D9A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A8C2321673BD480014D9A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25A8C2361673BD480014D9A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A8C2331673BD480014D9A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A8C2371673BD480014D9A6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25A8C2331673BD480014D9A6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25A9827516A5FF4F0088A3CA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2546A95716628EDD0078E044</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25AA23CF15AF291F006EF62D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKManagedObjectMappingOperationDataSource.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25AA23D015AF2920006EF62D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25AA23CF15AF291F006EF62D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25AA23D115AF2920006EF62D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25AA23CF15AF291F006EF62D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25AA23D315AF4F25006EF62D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKManagedObjectMappingOperationDataSourceTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25AA23D815AF5085006EF62D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25AA23D315AF4F25006EF62D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25AA23D915AF5086006EF62D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25AA23D315AF4F25006EF62D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25AABCEC17B698940061DC5B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKStringTokenizerTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25AABCED17B698940061DC5B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25AABCEC17B698940061DC5B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25AABCEE17B698940061DC5B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25AABCEC17B698940061DC5B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25AFF8F015B4CF1F0051877F</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>RKMappingErrors.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25AFF8F115B4CF1F0051877F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25AFF8F015B4CF1F0051877F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25AFF8F215B4CF1F0051877F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25AFF8F015B4CF1F0051877F</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25B408241491CDDB00F21111</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKPathUtilities.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B408251491CDDB00F21111</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKPathUtilities.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B408261491CDDC00F21111</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B408241491CDDB00F21111</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25B408271491CDDC00F21111</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B408241491CDDB00F21111</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25B408281491CDDC00F21111</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B408251491CDDB00F21111</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B408291491CDDC00F21111</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B408251491CDDB00F21111</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B639C816961EC70065EB7B</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25B639CB16961EFA0065EB7B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Testing</string>
-			<key>path</key>
-			<string>Logic/Testing</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B639CB16961EFA0065EB7B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKMappingTestTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B639CC16961EFA0065EB7B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B639CB16961EFA0065EB7B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B639CD16961EFA0065EB7B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B639CB16961EFA0065EB7B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B6E95414CF795D00B1E881</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKErrors.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B6E95514CF795D00B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E95414CF795D00B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25B6E95614CF795D00B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E95414CF795D00B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25B6E95714CF7A1C00B1E881</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKErrors.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B6E95814CF7A1C00B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E95714CF7A1C00B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B6E95914CF7A1C00B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E95714CF7A1C00B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B6E95A14CF7E3C00B1E881</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKObjectMappingMatcher.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B6E95C14CF7E3C00B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E95A14CF7E3C00B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25B6E95D14CF7E3C00B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E95A14CF7E3C00B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25B6E9D514CF912500B1E881</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKSearchable.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B6E9D614CF912500B1E881</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKSearchable.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B6E9D714CF912500B1E881</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKTestAddress.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B6E9D814CF912500B1E881</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKTestAddress.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B6E9D914CF912500B1E881</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKTestUser.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B6E9DA14CF912500B1E881</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKTestUser.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25B6E9DB14CF912500B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E9D614CF912500B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B6E9DC14CF912500B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E9D614CF912500B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B6E9DD14CF912500B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E9D814CF912500B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B6E9DE14CF912500B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E9D814CF912500B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B6E9DF14CF912500B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E9DA14CF912500B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B6E9E014CF912500B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6E9DA14CF912500B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B6EA0514CF946300B1E881</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>QuartzCore.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/QuartzCore.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>25B6EA0614CF946400B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6EA0514CF946300B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25B6EA0714CF947D00B1E881</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>25B6EA0814CF947E00B1E881</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25B6EA0714CF947D00B1E881</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25BB392D161F4FD700E5C72A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKPathUtilitiesTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25BB392E161F4FD700E5C72A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25BB392D161F4FD700E5C72A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25BB392F161F4FD700E5C72A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25BB392D161F4FD700E5C72A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25BCB31715ED57D500EE84DD</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>259B96C21604CCCC0000C250</string>
-				<string>259B96C31604CCCC0000C250</string>
-				<string>259B96C41604CCCC0000C250</string>
-				<string>259B96C51604CCCC0000C250</string>
-				<string>259B96C61604CCCC0000C250</string>
-				<string>259B96C71604CCCC0000C250</string>
-				<string>259B96C81604CCCC0000C250</string>
-				<string>259B96C91604CCCC0000C250</string>
-				<string>259B96CA1604CCCC0000C250</string>
-				<string>259B96CB1604CCCC0000C250</string>
-				<string>259B96CC1604CCCC0000C250</string>
-				<string>259B96CD1604CCCC0000C250</string>
-				<string>259B96CE1604CCCC0000C250</string>
-				<string>259B96CF1604CCCC0000C250</string>
-				<string>259B96D01604CCCC0000C250</string>
-				<string>259B96D11604CCCC0000C250</string>
-				<string>259B96D21604CCCC0000C250</string>
-				<string>259B96D31604CCCC0000C250</string>
-				<string>259B96D41604CCCC0000C250</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>AFNetworking</string>
-			<key>path</key>
-			<string>AFNetworking/AFNetworking</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C20466160ABC4800D418D5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251611281456F50F0060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C246A315C83B090032212E</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKSearchTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C246A415C83B090032212E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C246A315C83B090032212E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C246A515C83B090032212E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C246A315C83B090032212E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C6C0A21716F6F800C98A73</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25DA356D1836741C001A56A0</string>
-				<string>25DA356E1836741C001A56A0</string>
-				<string>25C6C0A51716F6F800C98A73</string>
-				<string>25C6C0A61716F6F800C98A73</string>
-				<string>25C6C0A71716F6F800C98A73</string>
-				<string>25C6C0A81716F6F800C98A73</string>
-				<string>25C6C0A91716F6F800C98A73</string>
-				<string>25C6C0AA1716F6F800C98A73</string>
-				<string>25C6C0AC1716F6F800C98A73</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>TransitionKit</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C6C0A51716F6F800C98A73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>TKEvent.h</string>
-			<key>path</key>
-			<string>Code/TKEvent.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C6C0A61716F6F800C98A73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>TKEvent.m</string>
-			<key>path</key>
-			<string>Code/TKEvent.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C6C0A71716F6F800C98A73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>TKState.h</string>
-			<key>path</key>
-			<string>Code/TKState.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C6C0A81716F6F800C98A73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>TKState.m</string>
-			<key>path</key>
-			<string>Code/TKState.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C6C0A91716F6F800C98A73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>TKStateMachine.h</string>
-			<key>path</key>
-			<string>Code/TKStateMachine.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C6C0AA1716F6F800C98A73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>TKStateMachine.m</string>
-			<key>path</key>
-			<string>Code/TKStateMachine.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C6C0AC1716F6F800C98A73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>TransitionKit.h</string>
-			<key>path</key>
-			<string>Code/TransitionKit.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C6C0BD1716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0A51716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25C6C0BE1716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0A51716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25C6C0BF1716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0A61716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C6C0C01716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0A61716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C6C0C11716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0A71716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25C6C0C21716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0A71716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25C6C0C31716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0A81716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C6C0C41716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0A81716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C6C0C51716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0A91716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25C6C0C61716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0A91716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25C6C0C71716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0AA1716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C6C0C81716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0AA1716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C6C0CB1716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0AC1716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25C6C0CC1716F6F800C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0AC1716F6F800C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25C6C0E61716F79B00C98A73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKOperationStateMachine.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C6C0E71716F79B00C98A73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKOperationStateMachine.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C6C0E81716F79B00C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0E61716F79B00C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25C6C0E91716F79B00C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0E61716F79B00C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25C6C0EA1716F79B00C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0E71716F79B00C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C6C0EB1716F79B00C98A73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C6C0E71716F79B00C98A73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C954A415542A47005C9E08</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RKTestConstants.m</string>
-			<key>path</key>
-			<string>Testing/RKTestConstants.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25C954A715542A47005C9E08</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C954A415542A47005C9E08</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25C954A815542A47005C9E08</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25C954A415542A47005C9E08</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25CA7A8E14EC570100888FF8</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKMapping.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25CA7A8F14EC570200888FF8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25CA7A8E14EC570100888FF8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25CA7A9014EC570200888FF8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25CA7A8E14EC570100888FF8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25CA7A9114EC5C2D00888FF8</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFB2114D9B35D004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25CAAA9315254E7800CAE5D7</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>ArrayOfHumans.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25CAAA9415254E7800CAE5D7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25CAAA9315254E7800CAE5D7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25CAAA9515254E7800CAE5D7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25CAAA9315254E7800CAE5D7</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25CC5C58161DDADD0008BD21</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKResponseDescriptorTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25CDA0E2161E821000F583F3</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKISODateFormatterTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25CDA0E7161E828D00F583F3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25CDA0E2161E821000F583F3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25CDA0E8161E828E00F583F3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25CDA0E2161E821000F583F3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25DA356D1836741C001A56A0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>TKTransition.h</string>
-			<key>path</key>
-			<string>Code/TKTransition.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25DA356E1836741C001A56A0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>TKTransition.m</string>
-			<key>path</key>
-			<string>Code/TKTransition.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25DA356F1836741D001A56A0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25DA356D1836741C001A56A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25DA35701836741D001A56A0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25DA356D1836741C001A56A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25DA35711836741D001A56A0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25DA356E1836741C001A56A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25DA35721836741D001A56A0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25DA356E1836741C001A56A0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25DB7507151BD551009F01AF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>NSManagedObjectContext+RKAdditionsTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25DB7508151BD551009F01AF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25DB7507151BD551009F01AF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25DB7509151BD551009F01AF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25DB7507151BD551009F01AF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25E36E0115195CED00F9E448</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKFetchRequestMappingCacheTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25E36E0215195CED00F9E448</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25E36E0115195CED00F9E448</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25E36E0315195CED00F9E448</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25E36E0115195CED00F9E448</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25E88C86165C5CC30042ABD0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKConnectionDescription.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25E88C87165C5CC30042ABD0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKConnectionDescription.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25E88C88165C5CC30042ABD0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25E88C86165C5CC30042ABD0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25E88C89165C5CC30042ABD0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25E88C86165C5CC30042ABD0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25E88C8A165C5CC30042ABD0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25E88C87165C5CC30042ABD0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25E88C8B165C5CC30042ABD0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25E88C87165C5CC30042ABD0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25E9C8F01612523400647F84</key>
-		<dict>
-			<key>fileRef</key>
-			<string>251610261456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25E9C8F1161290D500647F84</key>
-		<dict>
-			<key>fileRef</key>
-			<string>254372A715F54995006E8424</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25EC1A3914F72B0900C3CF3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7394DF3814CF168C00CE7BCE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25EC1A3A14F72B0A00C3CF3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7394DF3814CF168C00CE7BCE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25EC1A3B14F72B1300C3CF3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7394DF3914CF168C00CE7BCE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25EC1A3C14F72B1400C3CF3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7394DF3914CF168C00CE7BCE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25EC1A3D14F72B2800C3CF3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7394DF3C14CF19F200CE7BCE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25EC1A3E14F72B2900C3CF3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7394DF3C14CF19F200CE7BCE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25EC1A3F14F72B3100C3CF3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7394DF3D14CF19F200CE7BCE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25EC1A4014F72B3300C3CF3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7394DF3D14CF19F200CE7BCE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25EC1A6314F7402A00C3CF3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7394DF3514CF157A00CE7BCE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25EC1A6514F7402A00C3CF3F</key>
-		<dict>
-			<key>fileRef</key>
-			<string>7394DF3514CF157A00CE7BCE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25EC1AD614F8022600C3CF3F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25EC1B1E14F821B500C3CF3F</string>
-				<string>25EC1AD714F8022600C3CF3F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Resources</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25EC1AD714F8022600C3CF3F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25EC1B1F14F8220800C3CF3F</string>
-				<string>25EC1AD814F8022600C3CF3F</string>
-				<string>25EC1AD914F8022600C3CF3F</string>
-				<string>25EC1ADA14F8022600C3CF3F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>PLISTs</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25EC1AD814F8022600C3CF3F</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>RestKitFramework-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25EC1AD914F8022600C3CF3F</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>RestKitFrameworkTests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25EC1ADA14F8022600C3CF3F</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>RestKitTests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25EC1B0014F8078100C3CF3F</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreFoundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreFoundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>25EC1B1E14F821B500C3CF3F</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RestKitResources-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25EC1B1F14F8220800C3CF3F</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>RestKitResources-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25EDFCE3161538F6008BAA1D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2516101F1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25EDFCE5161538F8008BAA1D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2516101F1456F2330060A5C5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25F53AE015E7B611008B54E6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>RKHTTPUtilities.h</string>
-			<key>path</key>
-			<string>../ObjectMapping/RKHTTPUtilities.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25F53AE115E7B612008B54E6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>RKHTTPUtilities.m</string>
-			<key>path</key>
-			<string>../ObjectMapping/RKHTTPUtilities.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25F53AE215E7B612008B54E6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25F53AE015E7B611008B54E6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25F53AE315E7B612008B54E6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25F53AE015E7B611008B54E6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25F53AE415E7B612008B54E6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25F53AE115E7B612008B54E6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25F53AE515E7B612008B54E6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25F53AE115E7B612008B54E6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25F53F381606269400A093BE</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKObjectRequestOperationSubclass.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25F53F391606269400A093BE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25F53F381606269400A093BE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25F53F3A1606269400A093BE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25F53F381606269400A093BE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25FABED014E3796400E609E7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFAFD14D8EB30004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25FABED114E3796400E609E7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFAFD14D8EB30004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25FABED214E3796B00E609E7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFAFC14D8EB30004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25FABED314E3796C00E609E7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>252EFAFC14D8EB30004863C8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25FBB850159272DD00955D27</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKRouter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25FBB851159272DD00955D27</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRouter.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>25FBB852159272DD00955D27</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25FBB850159272DD00955D27</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25FBB853159272DD00955D27</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25FBB850159272DD00955D27</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>25FBB854159272DD00955D27</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25FBB851159272DD00955D27</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>25FBB855159272DD00955D27</key>
-		<dict>
-			<key>fileRef</key>
-			<string>25FBB851159272DD00955D27</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3E886DC0169E10A70069C56B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>has_many_with_to_one_relationship.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3EB0D83816ADCEFC00E9CEA2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>empty_human.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>54CDB45917B408B100FAC285</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKStringTokenizer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>54CDB45A17B408B100FAC285</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKStringTokenizer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>54CDB45B17B408B100FAC285</key>
-		<dict>
-			<key>fileRef</key>
-			<string>54CDB45917B408B100FAC285</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>54CDB45C17B408B100FAC285</key>
-		<dict>
-			<key>fileRef</key>
-			<string>54CDB45917B408B100FAC285</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>54CDB45D17B408B100FAC285</key>
-		<dict>
-			<key>fileRef</key>
-			<string>54CDB45A17B408B100FAC285</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>54CDB45E17B408B100FAC285</key>
-		<dict>
-			<key>fileRef</key>
-			<string>54CDB45A17B408B100FAC285</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5C927E131608FFFD00DC8B07</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKDictionaryUtilitiesTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5C927E141608FFFD00DC8B07</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5C927E131608FFFD00DC8B07</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5C927E151608FFFD00DC8B07</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5C927E131608FFFD00DC8B07</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5CCC295515B7124A0045F0F5</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKMacros.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5CCC295615B7124A0045F0F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5CCC295515B7124A0045F0F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>5CCC295715B7124A0045F0F5</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5CCC295515B7124A0045F0F5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>7394DF3514CF157A00CE7BCE</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKManagedObjectCaching.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7394DF3814CF168C00CE7BCE</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKFetchRequestManagedObjectCache.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7394DF3914CF168C00CE7BCE</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKFetchRequestManagedObjectCache.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7394DF3C14CF19F200CE7BCE</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKInMemoryManagedObjectCache.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>7394DF3D14CF19F200CE7BCE</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKInMemoryManagedObjectCache.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>73D3907114CA19F90093E3D6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>parent.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>73D3907314CA1A4A0093E3D6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>child.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>73D3907414CA1AE00093E3D6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>73D3907114CA19F90093E3D6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>73D3907514CA1AE20093E3D6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>73D3907114CA19F90093E3D6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>73D3907614CA1AE60093E3D6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>73D3907314CA1A4A0093E3D6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>73D3907714CA1AE60093E3D6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>73D3907314CA1A4A0093E3D6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>73D3907814CA1D710093E3D6</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xml</string>
-			<key>path</key>
-			<string>channels.xml</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>73D3907914CA1DD40093E3D6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>73D3907814CA1D710093E3D6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>73D3907A14CA1DD50093E3D6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>73D3907814CA1D710093E3D6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7AF2905218DF249C009AEB94</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2501405215366000004E0466</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>7F9CBC6174004E31AEC35813</key>
-		<dict>
-			<key>fileRef</key>
-			<string>86EC453810D648768BF62304</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>86EC453810D648768BF62304</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-osx.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>BE05BDCF1782109F00F7C9C9</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKRouteTest.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BE05BDD11782109F00F7C9C9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BE05BDCF1782109F00F7C9C9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BE05BDD2178214AA00F7C9C9</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BE05BDCF1782109F00F7C9C9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C0F11CE1190883380054AEA0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKPathMatcher.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C0F11CE2190883380054AEA0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RKPathMatcher.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C0F11CE3190883380054AEA0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C0F11CE1190883380054AEA0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>C0F11CE4190883380054AEA0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C0F11CE2190883380054AEA0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C0F11CE5190883460054AEA0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C0F11CE1190883380054AEA0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>C0F11CE6190883460054AEA0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C0F11CE2190883380054AEA0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>C0F11CE71908C7E60054AEA0</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RKCoreData.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C0F11CE81908C7E60054AEA0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C0F11CE71908C7E60054AEA0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>C0F11CE91908C7E60054AEA0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C0F11CE71908C7E60054AEA0</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>ATTRIBUTES</key>
-				<array>
-					<string>Public</string>
-				</array>
-			</dict>
-		</dict>
-		<key>D8EFCBE1978F7946E0081FAD</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-osx.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-osx/Pods-osx.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E2F2B89961FC462B981CEB7A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E457EFC3D502479D8B4FCF2A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4081DFC15FB89DF00364948</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>7394DF3814CF168C00CE7BCE</string>
-				<string>7394DF3914CF168C00CE7BCE</string>
-				<string>7394DF3C14CF19F200CE7BCE</string>
-				<string>7394DF3D14CF19F200CE7BCE</string>
-				<string>7394DF3514CF157A00CE7BCE</string>
-				<string>259D98521550C69A008C90F5</string>
-				<string>259D98531550C69A008C90F5</string>
-				<string>259D985C155218E4008C90F5</string>
-				<string>259D985D155218E4008C90F5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>ManagedObjectCaching</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4081DFE15FB8A1D00364948</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160D56145650490060A5C5</string>
-				<string>25160D57145650490060A5C5</string>
-				<string>257ABAAE15112DD400CCAA76</string>
-				<string>257ABAAF15112DD400CCAA76</string>
-				<string>257ABAB41511371C00CCAA76</string>
-				<string>257ABAB51511371D00CCAA76</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Additions</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4081DFF15FB8B4000364948</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>254372D415F54CE3006E8424</string>
-				<string>254372D515F54CE3006E8424</string>
-				<string>254372AA15F54C3F006E8424</string>
-				<string>254372AB15F54C3F006E8424</string>
-				<string>254372B015F54C3F006E8424</string>
-				<string>254372B115F54C3F006E8424</string>
-				<string>25F53F381606269400A093BE</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>ObjectRequestOperations</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4081E0015FB8B5900364948</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>252028FA1577AE0B00076FB4</string>
-				<string>252028FB1577AE0B00076FB4</string>
-				<string>252029011577AE1800076FB4</string>
-				<string>252029021577AE1800076FB4</string>
-				<string>25FBB850159272DD00955D27</string>
-				<string>25FBB851159272DD00955D27</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Routing</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4081E0715FB8FC400364948</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160D50145650490060A5C5</string>
-				<string>25160D51145650490060A5C5</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Importing</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4081E0915FB8FD800364948</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>25160D4C145650490060A5C5</string>
-				<string>25160D4D145650490060A5C5</string>
-				<string>258EA4B015A3908F007E07A6</string>
-				<string>25AA23CF15AF291F006EF62D</string>
-				<string>25E88C86165C5CC30042ABD0</string>
-				<string>25E88C87165C5CC30042ABD0</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Mapping</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E457EFC3D502479D8B4FCF2A</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-ios.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>F66056291744FF9000A87A45</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.json</string>
-			<key>path</key>
-			<string>and_cats.json</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>25160D0D14564E810060A5C5</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2502C8ED15F79CF70060FD75 /* CoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8E715F79CF70060FD75 /* CoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8EE15F79CF70060FD75 /* CoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8E715F79CF70060FD75 /* CoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8EF15F79CF70060FD75 /* Network.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8E815F79CF70060FD75 /* Network.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8F015F79CF70060FD75 /* Network.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8E815F79CF70060FD75 /* Network.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8F115F79CF70060FD75 /* ObjectMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8E915F79CF70060FD75 /* ObjectMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8F215F79CF70060FD75 /* ObjectMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8E915F79CF70060FD75 /* ObjectMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8F315F79CF70060FD75 /* Search.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8EA15F79CF70060FD75 /* Search.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8F415F79CF70060FD75 /* Search.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8EA15F79CF70060FD75 /* Search.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8F515F79CF70060FD75 /* Support.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8EB15F79CF70060FD75 /* Support.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8F615F79CF70060FD75 /* Support.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8EB15F79CF70060FD75 /* Support.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8F715F79CF70060FD75 /* Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8EC15F79CF70060FD75 /* Testing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2502C8F815F79CF70060FD75 /* Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8EC15F79CF70060FD75 /* Testing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25055B8414EEF32A00B9C4DD /* RKMappingTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 25055B8014EEF32A00B9C4DD /* RKMappingTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25055B8514EEF32A00B9C4DD /* RKMappingTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 25055B8014EEF32A00B9C4DD /* RKMappingTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25055B8614EEF32A00B9C4DD /* RKMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25055B8114EEF32A00B9C4DD /* RKMappingTest.m */; };
+		25055B8714EEF32A00B9C4DD /* RKMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25055B8114EEF32A00B9C4DD /* RKMappingTest.m */; };
+		25055B8814EEF32A00B9C4DD /* RKTestFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 25055B8214EEF32A00B9C4DD /* RKTestFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25055B8914EEF32A00B9C4DD /* RKTestFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 25055B8214EEF32A00B9C4DD /* RKTestFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25055B8A14EEF32A00B9C4DD /* RKTestFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 25055B8314EEF32A00B9C4DD /* RKTestFactory.m */; };
+		25055B8B14EEF32A00B9C4DD /* RKTestFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 25055B8314EEF32A00B9C4DD /* RKTestFactory.m */; };
+		25055B8F14EEF40000B9C4DD /* RKPropertyMappingTestExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25055B8D14EEF40000B9C4DD /* RKPropertyMappingTestExpectation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25055B9014EEF40000B9C4DD /* RKPropertyMappingTestExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25055B8D14EEF40000B9C4DD /* RKPropertyMappingTestExpectation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25055B9114EEF40000B9C4DD /* RKPropertyMappingTestExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 25055B8E14EEF40000B9C4DD /* RKPropertyMappingTestExpectation.m */; };
+		25055B9214EEF40000B9C4DD /* RKPropertyMappingTestExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 25055B8E14EEF40000B9C4DD /* RKPropertyMappingTestExpectation.m */; };
+		2506759F162DEA25003210B0 /* RKEntityMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FC91456F2330060A5C5 /* RKEntityMappingTest.m */; };
+		250675A1162DEA27003210B0 /* RKEntityMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FC91456F2330060A5C5 /* RKEntityMappingTest.m */; };
+		2507C327161BD5C700EA71FF /* RKTestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 2507C325161BD5C700EA71FF /* RKTestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2507C328161BD5C700EA71FF /* RKTestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 2507C325161BD5C700EA71FF /* RKTestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2507C329161BD5C700EA71FF /* RKTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 2507C326161BD5C700EA71FF /* RKTestHelpers.m */; };
+		2507C32A161BD5C700EA71FF /* RKTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 2507C326161BD5C700EA71FF /* RKTestHelpers.m */; };
+		25104F1F15C30CD900829135 /* RKSearchWord.h in Headers */ = {isa = PBXBuildFile; fileRef = 25104F1315C30CD900829135 /* RKSearchWord.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25104F2015C30CD900829135 /* RKSearchWord.h in Headers */ = {isa = PBXBuildFile; fileRef = 25104F1315C30CD900829135 /* RKSearchWord.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25104F2115C30CD900829135 /* RKSearchWord.m in Sources */ = {isa = PBXBuildFile; fileRef = 25104F1415C30CD900829135 /* RKSearchWord.m */; };
+		25104F2215C30CD900829135 /* RKSearchWord.m in Sources */ = {isa = PBXBuildFile; fileRef = 25104F1415C30CD900829135 /* RKSearchWord.m */; };
+		25104F2915C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 25104F2715C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25104F2A15C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 25104F2715C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25104F2B15C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 25104F2815C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.m */; };
+		25104F2C15C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 25104F2815C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.m */; };
+		25104F2F15C30E7400829135 /* RKSearchIndexer.h in Headers */ = {isa = PBXBuildFile; fileRef = 25104F2D15C30E7400829135 /* RKSearchIndexer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25104F3015C30E7400829135 /* RKSearchIndexer.h in Headers */ = {isa = PBXBuildFile; fileRef = 25104F2D15C30E7400829135 /* RKSearchIndexer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25104F3115C30E7400829135 /* RKSearchIndexer.m in Sources */ = {isa = PBXBuildFile; fileRef = 25104F2E15C30E7400829135 /* RKSearchIndexer.m */; };
+		25104F3215C30E7400829135 /* RKSearchIndexer.m in Sources */ = {isa = PBXBuildFile; fileRef = 25104F2E15C30E7400829135 /* RKSearchIndexer.m */; };
+		25104F3515C30EF500829135 /* RKSearchPredicate.h in Headers */ = {isa = PBXBuildFile; fileRef = 25104F3315C30EF500829135 /* RKSearchPredicate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25104F3615C30EF500829135 /* RKSearchPredicate.h in Headers */ = {isa = PBXBuildFile; fileRef = 25104F3315C30EF500829135 /* RKSearchPredicate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25104F3715C30EF500829135 /* RKSearchPredicate.m in Sources */ = {isa = PBXBuildFile; fileRef = 25104F3415C30EF500829135 /* RKSearchPredicate.m */; };
+		25104F3815C30EF500829135 /* RKSearchPredicate.m in Sources */ = {isa = PBXBuildFile; fileRef = 25104F3415C30EF500829135 /* RKSearchPredicate.m */; };
+		25104F3B15C30F2100829135 /* RKSearchWordEntity.h in Headers */ = {isa = PBXBuildFile; fileRef = 25104F3915C30F2000829135 /* RKSearchWordEntity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25104F3C15C30F2100829135 /* RKSearchWordEntity.h in Headers */ = {isa = PBXBuildFile; fileRef = 25104F3915C30F2000829135 /* RKSearchWordEntity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25104F3D15C30F2100829135 /* RKSearchWordEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = 25104F3A15C30F2100829135 /* RKSearchWordEntity.m */; };
+		25104F3E15C30F2100829135 /* RKSearchWordEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = 25104F3A15C30F2100829135 /* RKSearchWordEntity.m */; };
+		25119FB6154A34B400C6BC58 /* parents_and_children.json in Resources */ = {isa = PBXBuildFile; fileRef = 25119FB5154A34B400C6BC58 /* parents_and_children.json */; };
+		25119FB7154A34B400C6BC58 /* parents_and_children.json in Resources */ = {isa = PBXBuildFile; fileRef = 25119FB5154A34B400C6BC58 /* parents_and_children.json */; };
+		25160D1A14564E810060A5C5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25160D1914564E810060A5C5 /* Foundation.framework */; };
+		25160D2A14564E820060A5C5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25160D2914564E820060A5C5 /* UIKit.framework */; };
+		25160D2B14564E820060A5C5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25160D1914564E810060A5C5 /* Foundation.framework */; };
+		25160DDB145650490060A5C5 /* RKEntityMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D4C145650490060A5C5 /* RKEntityMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160DDC145650490060A5C5 /* RKEntityMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D4D145650490060A5C5 /* RKEntityMapping.m */; };
+		25160DDF145650490060A5C5 /* RKManagedObjectImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D50145650490060A5C5 /* RKManagedObjectImporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160DE0145650490060A5C5 /* RKManagedObjectImporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D51145650490060A5C5 /* RKManagedObjectImporter.m */; };
+		25160DE1145650490060A5C5 /* RKManagedObjectStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D52145650490060A5C5 /* RKManagedObjectStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160DE2145650490060A5C5 /* RKManagedObjectStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D53145650490060A5C5 /* RKManagedObjectStore.m */; };
+		25160DE5145650490060A5C5 /* RKPropertyInspector+CoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D56145650490060A5C5 /* RKPropertyInspector+CoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160DE6145650490060A5C5 /* RKPropertyInspector+CoreData.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D57145650490060A5C5 /* RKPropertyInspector+CoreData.m */; };
+		25160E09145650490060A5C5 /* RKDynamicMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D7C145650490060A5C5 /* RKDynamicMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E0A145650490060A5C5 /* RKDynamicMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D7D145650490060A5C5 /* RKDynamicMapping.m */; };
+		25160E0B145650490060A5C5 /* RKErrorMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D7E145650490060A5C5 /* RKErrorMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E0C145650490060A5C5 /* RKErrorMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D7F145650490060A5C5 /* RKErrorMessage.m */; };
+		25160E0F145650490060A5C5 /* RKAttributeMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D82145650490060A5C5 /* RKAttributeMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E10145650490060A5C5 /* RKAttributeMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D83145650490060A5C5 /* RKAttributeMapping.m */; };
+		25160E16145650490060A5C5 /* RKMapperOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D89145650490060A5C5 /* RKMapperOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E17145650490060A5C5 /* RKMapperOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D8A145650490060A5C5 /* RKMapperOperation.m */; };
+		25160E18145650490060A5C5 /* RKMapperOperation_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D8B145650490060A5C5 /* RKMapperOperation_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		25160E1A145650490060A5C5 /* RKObjectMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D8D145650490060A5C5 /* RKObjectMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E1B145650490060A5C5 /* RKObjectMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D8E145650490060A5C5 /* RKObjectMapping.m */; };
+		25160E1C145650490060A5C5 /* RKMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D8F145650490060A5C5 /* RKMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E1D145650490060A5C5 /* RKMappingOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D90145650490060A5C5 /* RKMappingOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E1E145650490060A5C5 /* RKMappingOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D91145650490060A5C5 /* RKMappingOperation.m */; };
+		25160E21145650490060A5C5 /* RKMappingResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D94145650490060A5C5 /* RKMappingResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E22145650490060A5C5 /* RKMappingResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D95145650490060A5C5 /* RKMappingResult.m */; };
+		25160E23145650490060A5C5 /* RKPropertyInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D96145650490060A5C5 /* RKPropertyInspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E24145650490060A5C5 /* RKPropertyInspector.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D97145650490060A5C5 /* RKPropertyInspector.m */; };
+		25160E25145650490060A5C5 /* RKRelationshipMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D98145650490060A5C5 /* RKRelationshipMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E26145650490060A5C5 /* RKRelationshipMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D99145650490060A5C5 /* RKRelationshipMapping.m */; };
+		25160E2E145650490060A5C5 /* RestKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DA1145650490060A5C5 /* RestKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E31145650490060A5C5 /* lcl_config_components_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DA5145650490060A5C5 /* lcl_config_components_RK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E32145650490060A5C5 /* lcl_config_extensions_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DA6145650490060A5C5 /* lcl_config_extensions_RK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E33145650490060A5C5 /* lcl_config_logger_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DA7145650490060A5C5 /* lcl_config_logger_RK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E44145650490060A5C5 /* RestKit-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 25160DBB145650490060A5C5 /* RestKit-Prefix.pch */; settings = {ATTRIBUTES = (); }; };
+		25160E47145650490060A5C5 /* RKDotNetDateFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DBE145650490060A5C5 /* RKDotNetDateFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E48145650490060A5C5 /* RKDotNetDateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160DBF145650490060A5C5 /* RKDotNetDateFormatter.m */; };
+		25160E4A145650490060A5C5 /* RKLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DC1145650490060A5C5 /* RKLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E4B145650490060A5C5 /* RKLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160DC2145650490060A5C5 /* RKLog.m */; };
+		25160E4C145650490060A5C5 /* RKMIMETypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DC3145650490060A5C5 /* RKMIMETypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E4D145650490060A5C5 /* RKMIMETypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160DC4145650490060A5C5 /* RKMIMETypes.m */; };
+		25160E4E145650490060A5C5 /* RKSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DC5145650490060A5C5 /* RKSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160E7A145651060060A5C5 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25160E63145651060060A5C5 /* Cocoa.framework */; };
+		25160EE21456532C0060A5C5 /* lcl_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160EA21456532C0060A5C5 /* lcl_RK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160EE31456532C0060A5C5 /* lcl_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160EA21456532C0060A5C5 /* lcl_RK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160EE41456532C0060A5C5 /* lcl_RK.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160EA31456532C0060A5C5 /* lcl_RK.m */; };
+		25160EE51456532C0060A5C5 /* lcl_RK.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160EA31456532C0060A5C5 /* lcl_RK.m */; };
+		25160EF81456532C0060A5C5 /* LCLNSLog_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160EB01456532C0060A5C5 /* LCLNSLog_RK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160EF91456532C0060A5C5 /* LCLNSLog_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160EB01456532C0060A5C5 /* LCLNSLog_RK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160EFA1456532C0060A5C5 /* LCLNSLog_RK.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160EB11456532C0060A5C5 /* LCLNSLog_RK.m */; };
+		25160EFB1456532C0060A5C5 /* LCLNSLog_RK.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160EB11456532C0060A5C5 /* LCLNSLog_RK.m */; };
+		25160F081456532C0060A5C5 /* SOCKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160EBD1456532C0060A5C5 /* SOCKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F091456532C0060A5C5 /* SOCKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160EBD1456532C0060A5C5 /* SOCKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F0A1456532C0060A5C5 /* SOCKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160EBE1456532C0060A5C5 /* SOCKit.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		25160F0B1456532C0060A5C5 /* SOCKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160EBE1456532C0060A5C5 /* SOCKit.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		25160F25145655AF0060A5C5 /* RestKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DA1145650490060A5C5 /* RestKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F44145655C60060A5C5 /* RKDynamicMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D7C145650490060A5C5 /* RKDynamicMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F45145655C60060A5C5 /* RKDynamicMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D7D145650490060A5C5 /* RKDynamicMapping.m */; };
+		25160F46145655C60060A5C5 /* RKErrorMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D7E145650490060A5C5 /* RKErrorMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F47145655C60060A5C5 /* RKErrorMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D7F145650490060A5C5 /* RKErrorMessage.m */; };
+		25160F4A145655C60060A5C5 /* RKAttributeMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D82145650490060A5C5 /* RKAttributeMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F4B145655C60060A5C5 /* RKAttributeMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D83145650490060A5C5 /* RKAttributeMapping.m */; };
+		25160F51145655C60060A5C5 /* RKMapperOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D89145650490060A5C5 /* RKMapperOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F52145655C60060A5C5 /* RKMapperOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D8A145650490060A5C5 /* RKMapperOperation.m */; };
+		25160F53145655C60060A5C5 /* RKMapperOperation_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D8B145650490060A5C5 /* RKMapperOperation_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		25160F55145655C60060A5C5 /* RKObjectMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D8D145650490060A5C5 /* RKObjectMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F56145655C60060A5C5 /* RKObjectMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D8E145650490060A5C5 /* RKObjectMapping.m */; };
+		25160F57145655C60060A5C5 /* RKMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D8F145650490060A5C5 /* RKMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F58145655C60060A5C5 /* RKMappingOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D90145650490060A5C5 /* RKMappingOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F59145655C60060A5C5 /* RKMappingOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D91145650490060A5C5 /* RKMappingOperation.m */; };
+		25160F5C145655C60060A5C5 /* RKMappingResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D94145650490060A5C5 /* RKMappingResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F5D145655C60060A5C5 /* RKMappingResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D95145650490060A5C5 /* RKMappingResult.m */; };
+		25160F5E145655C60060A5C5 /* RKPropertyInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D96145650490060A5C5 /* RKPropertyInspector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F5F145655C60060A5C5 /* RKPropertyInspector.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D97145650490060A5C5 /* RKPropertyInspector.m */; };
+		25160F60145655C60060A5C5 /* RKRelationshipMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D98145650490060A5C5 /* RKRelationshipMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F61145655C60060A5C5 /* RKRelationshipMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D99145650490060A5C5 /* RKRelationshipMapping.m */; };
+		25160F6F145655D10060A5C5 /* RKEntityMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D4C145650490060A5C5 /* RKEntityMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F70145655D10060A5C5 /* RKEntityMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D4D145650490060A5C5 /* RKEntityMapping.m */; };
+		25160F73145655D10060A5C5 /* RKManagedObjectImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D50145650490060A5C5 /* RKManagedObjectImporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F74145655D10060A5C5 /* RKManagedObjectImporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D51145650490060A5C5 /* RKManagedObjectImporter.m */; };
+		25160F75145655D10060A5C5 /* RKManagedObjectStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D52145650490060A5C5 /* RKManagedObjectStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F76145655D10060A5C5 /* RKManagedObjectStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D53145650490060A5C5 /* RKManagedObjectStore.m */; };
+		25160F79145655D10060A5C5 /* RKPropertyInspector+CoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160D56145650490060A5C5 /* RKPropertyInspector+CoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F7A145655D10060A5C5 /* RKPropertyInspector+CoreData.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160D57145650490060A5C5 /* RKPropertyInspector+CoreData.m */; };
+		25160F7C145657220060A5C5 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25160F7B145657220060A5C5 /* SystemConfiguration.framework */; };
+		25160F7E145657300060A5C5 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25160F7D1456572F0060A5C5 /* Cocoa.framework */; };
+		25160F85145657650060A5C5 /* lcl_config_components_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DA5145650490060A5C5 /* lcl_config_components_RK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F86145657650060A5C5 /* lcl_config_extensions_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DA6145650490060A5C5 /* lcl_config_extensions_RK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F87145657650060A5C5 /* lcl_config_logger_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DA7145650490060A5C5 /* lcl_config_logger_RK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F901456576C0060A5C5 /* RKDotNetDateFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DBE145650490060A5C5 /* RKDotNetDateFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F911456576C0060A5C5 /* RKDotNetDateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160DBF145650490060A5C5 /* RKDotNetDateFormatter.m */; };
+		25160F931456576C0060A5C5 /* RKLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DC1145650490060A5C5 /* RKLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F941456576C0060A5C5 /* RKLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160DC2145650490060A5C5 /* RKLog.m */; };
+		25160F951456576C0060A5C5 /* RKMIMETypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DC3145650490060A5C5 /* RKMIMETypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25160F961456576C0060A5C5 /* RKMIMETypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160DC4145650490060A5C5 /* RKMIMETypes.m */; };
+		25160F971456576C0060A5C5 /* RKSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 25160DC5145650490060A5C5 /* RKSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		251610601456F2330060A5C5 /* RKManagedObjectStoreTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FCB1456F2330060A5C5 /* RKManagedObjectStoreTest.m */; };
+		251610611456F2330060A5C5 /* RKManagedObjectStoreTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FCB1456F2330060A5C5 /* RKManagedObjectStoreTest.m */; };
+		251610641456F2330060A5C5 /* blake.png in Resources */ = {isa = PBXBuildFile; fileRef = 25160FCF1456F2330060A5C5 /* blake.png */; };
+		251610651456F2330060A5C5 /* blake.png in Resources */ = {isa = PBXBuildFile; fileRef = 25160FCF1456F2330060A5C5 /* blake.png */; };
+		251610661456F2330060A5C5 /* ArrayOfNestedDictionaries.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD11456F2330060A5C5 /* ArrayOfNestedDictionaries.json */; };
+		251610671456F2330060A5C5 /* ArrayOfNestedDictionaries.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD11456F2330060A5C5 /* ArrayOfNestedDictionaries.json */; };
+		251610681456F2330060A5C5 /* ArrayOfResults.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD21456F2330060A5C5 /* ArrayOfResults.json */; };
+		251610691456F2330060A5C5 /* ArrayOfResults.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD21456F2330060A5C5 /* ArrayOfResults.json */; };
+		2516106A1456F2330060A5C5 /* ComplexNestedUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD31456F2330060A5C5 /* ComplexNestedUser.json */; };
+		2516106B1456F2330060A5C5 /* ComplexNestedUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD31456F2330060A5C5 /* ComplexNestedUser.json */; };
+		2516106C1456F2330060A5C5 /* ConnectingParents.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD41456F2330060A5C5 /* ConnectingParents.json */; };
+		2516106D1456F2330060A5C5 /* ConnectingParents.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD41456F2330060A5C5 /* ConnectingParents.json */; };
+		2516106E1456F2330060A5C5 /* boy.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD61456F2330060A5C5 /* boy.json */; };
+		2516106F1456F2330060A5C5 /* boy.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD61456F2330060A5C5 /* boy.json */; };
+		251610701456F2330060A5C5 /* friends.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD71456F2330060A5C5 /* friends.json */; };
+		251610711456F2330060A5C5 /* friends.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD71456F2330060A5C5 /* friends.json */; };
+		251610721456F2330060A5C5 /* girl.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD81456F2330060A5C5 /* girl.json */; };
+		251610731456F2330060A5C5 /* girl.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD81456F2330060A5C5 /* girl.json */; };
+		251610741456F2330060A5C5 /* mixed.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD91456F2330060A5C5 /* mixed.json */; };
+		251610751456F2330060A5C5 /* mixed.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FD91456F2330060A5C5 /* mixed.json */; };
+		251610761456F2330060A5C5 /* DynamicKeys.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDA1456F2330060A5C5 /* DynamicKeys.json */; };
+		251610771456F2330060A5C5 /* DynamicKeys.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDA1456F2330060A5C5 /* DynamicKeys.json */; };
+		251610781456F2330060A5C5 /* DynamicKeysWithNestedRelationship.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDB1456F2330060A5C5 /* DynamicKeysWithNestedRelationship.json */; };
+		251610791456F2330060A5C5 /* DynamicKeysWithNestedRelationship.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDB1456F2330060A5C5 /* DynamicKeysWithNestedRelationship.json */; };
+		2516107A1456F2330060A5C5 /* DynamicKeysWithRelationship.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDC1456F2330060A5C5 /* DynamicKeysWithRelationship.json */; };
+		2516107B1456F2330060A5C5 /* DynamicKeysWithRelationship.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDC1456F2330060A5C5 /* DynamicKeysWithRelationship.json */; };
+		2516107C1456F2330060A5C5 /* error.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDD1456F2330060A5C5 /* error.json */; };
+		2516107D1456F2330060A5C5 /* error.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDD1456F2330060A5C5 /* error.json */; };
+		2516107E1456F2330060A5C5 /* errors.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDE1456F2330060A5C5 /* errors.json */; };
+		2516107F1456F2330060A5C5 /* errors.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDE1456F2330060A5C5 /* errors.json */; };
+		251610801456F2330060A5C5 /* Foursquare.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDF1456F2330060A5C5 /* Foursquare.json */; };
+		251610811456F2330060A5C5 /* Foursquare.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FDF1456F2330060A5C5 /* Foursquare.json */; };
+		251610821456F2330060A5C5 /* 1.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE11456F2330060A5C5 /* 1.json */; };
+		251610831456F2330060A5C5 /* 1.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE11456F2330060A5C5 /* 1.json */; };
+		251610841456F2330060A5C5 /* all.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE21456F2330060A5C5 /* all.json */; };
+		251610851456F2330060A5C5 /* all.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE21456F2330060A5C5 /* all.json */; };
+		251610861456F2330060A5C5 /* with_to_one_relationship.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE31456F2330060A5C5 /* with_to_one_relationship.json */; };
+		251610871456F2330060A5C5 /* with_to_one_relationship.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE31456F2330060A5C5 /* with_to_one_relationship.json */; };
+		251610881456F2330060A5C5 /* nested_user.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE41456F2330060A5C5 /* nested_user.json */; };
+		251610891456F2330060A5C5 /* nested_user.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE41456F2330060A5C5 /* nested_user.json */; };
+		2516108A1456F2330060A5C5 /* RailsUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE51456F2330060A5C5 /* RailsUser.json */; };
+		2516108B1456F2330060A5C5 /* RailsUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE51456F2330060A5C5 /* RailsUser.json */; };
+		2516108C1456F2330060A5C5 /* SameKeyDifferentTargetClasses.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE61456F2330060A5C5 /* SameKeyDifferentTargetClasses.json */; };
+		2516108D1456F2330060A5C5 /* SameKeyDifferentTargetClasses.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE61456F2330060A5C5 /* SameKeyDifferentTargetClasses.json */; };
+		2516108E1456F2330060A5C5 /* user.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE71456F2330060A5C5 /* user.json */; };
+		2516108F1456F2330060A5C5 /* user.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE71456F2330060A5C5 /* user.json */; };
+		251610901456F2330060A5C5 /* users.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE81456F2330060A5C5 /* users.json */; };
+		251610911456F2330060A5C5 /* users.json in Resources */ = {isa = PBXBuildFile; fileRef = 25160FE81456F2330060A5C5 /* users.json */; };
+		251610931456F2330060A5C5 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 25160FEA1456F2330060A5C5 /* .gitignore */; };
+		251610961456F2330060A5C5 /* attributes_without_text_content.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FED1456F2330060A5C5 /* attributes_without_text_content.xml */; };
+		251610971456F2330060A5C5 /* attributes_without_text_content.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FED1456F2330060A5C5 /* attributes_without_text_content.xml */; };
+		251610981456F2330060A5C5 /* container_attributes.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FEE1456F2330060A5C5 /* container_attributes.xml */; };
+		251610991456F2330060A5C5 /* container_attributes.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FEE1456F2330060A5C5 /* container_attributes.xml */; };
+		2516109A1456F2330060A5C5 /* national_weather_service.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FEF1456F2330060A5C5 /* national_weather_service.xml */; };
+		2516109B1456F2330060A5C5 /* national_weather_service.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FEF1456F2330060A5C5 /* national_weather_service.xml */; };
+		2516109C1456F2330060A5C5 /* orders.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FF01456F2330060A5C5 /* orders.xml */; };
+		2516109D1456F2330060A5C5 /* orders.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FF01456F2330060A5C5 /* orders.xml */; };
+		2516109E1456F2330060A5C5 /* tab_data.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FF11456F2330060A5C5 /* tab_data.xml */; };
+		2516109F1456F2330060A5C5 /* tab_data.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FF11456F2330060A5C5 /* tab_data.xml */; };
+		251610A01456F2330060A5C5 /* zend.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FF21456F2330060A5C5 /* zend.xml */; };
+		251610A11456F2330060A5C5 /* zend.xml in Resources */ = {isa = PBXBuildFile; fileRef = 25160FF21456F2330060A5C5 /* zend.xml */; };
+		251610A21456F2330060A5C5 /* Data Model.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = 25160FF41456F2330060A5C5 /* Data Model.xcdatamodel */; };
+		251610A31456F2330060A5C5 /* Data Model.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = 25160FF41456F2330060A5C5 /* Data Model.xcdatamodel */; };
+		251610A41456F2330060A5C5 /* RKCat.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FF61456F2330060A5C5 /* RKCat.m */; };
+		251610A51456F2330060A5C5 /* RKCat.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FF61456F2330060A5C5 /* RKCat.m */; };
+		251610A61456F2330060A5C5 /* RKChild.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FF81456F2330060A5C5 /* RKChild.m */; };
+		251610A71456F2330060A5C5 /* RKChild.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FF81456F2330060A5C5 /* RKChild.m */; };
+		251610A81456F2330060A5C5 /* RKDynamicMappingModels.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FFA1456F2330060A5C5 /* RKDynamicMappingModels.m */; };
+		251610A91456F2330060A5C5 /* RKDynamicMappingModels.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FFA1456F2330060A5C5 /* RKDynamicMappingModels.m */; };
+		251610AA1456F2330060A5C5 /* RKHouse.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FFC1456F2330060A5C5 /* RKHouse.m */; };
+		251610AB1456F2330060A5C5 /* RKHouse.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FFC1456F2330060A5C5 /* RKHouse.m */; };
+		251610AC1456F2330060A5C5 /* RKHuman.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FFE1456F2330060A5C5 /* RKHuman.m */; };
+		251610AD1456F2330060A5C5 /* RKHuman.m in Sources */ = {isa = PBXBuildFile; fileRef = 25160FFE1456F2330060A5C5 /* RKHuman.m */; };
+		251610AE1456F2330060A5C5 /* RKMappableAssociation.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610001456F2330060A5C5 /* RKMappableAssociation.m */; };
+		251610AF1456F2330060A5C5 /* RKMappableAssociation.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610001456F2330060A5C5 /* RKMappableAssociation.m */; };
+		251610B01456F2330060A5C5 /* RKMappableObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610021456F2330060A5C5 /* RKMappableObject.m */; };
+		251610B11456F2330060A5C5 /* RKMappableObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610021456F2330060A5C5 /* RKMappableObject.m */; };
+		251610B21456F2330060A5C5 /* RKObjectLoaderTestResultModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610041456F2330060A5C5 /* RKObjectLoaderTestResultModel.m */; };
+		251610B31456F2330060A5C5 /* RKObjectLoaderTestResultModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610041456F2330060A5C5 /* RKObjectLoaderTestResultModel.m */; };
+		251610B41456F2330060A5C5 /* RKObjectMapperTestModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610061456F2330060A5C5 /* RKObjectMapperTestModel.m */; };
+		251610B51456F2330060A5C5 /* RKObjectMapperTestModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610061456F2330060A5C5 /* RKObjectMapperTestModel.m */; };
+		251610B61456F2330060A5C5 /* RKParent.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610081456F2330060A5C5 /* RKParent.m */; };
+		251610B71456F2330060A5C5 /* RKParent.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610081456F2330060A5C5 /* RKParent.m */; };
+		251610B81456F2330060A5C5 /* RKResident.m in Sources */ = {isa = PBXBuildFile; fileRef = 2516100A1456F2330060A5C5 /* RKResident.m */; };
+		251610B91456F2330060A5C5 /* RKResident.m in Sources */ = {isa = PBXBuildFile; fileRef = 2516100A1456F2330060A5C5 /* RKResident.m */; };
+		251610D21456F2330060A5C5 /* RKDynamicMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2516101C1456F2330060A5C5 /* RKDynamicMappingTest.m */; };
+		251610D31456F2330060A5C5 /* RKDynamicMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2516101C1456F2330060A5C5 /* RKDynamicMappingTest.m */; };
+		251610DC1456F2330060A5C5 /* RKObjectMappingNextGenTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610211456F2330060A5C5 /* RKObjectMappingNextGenTest.m */; };
+		251610DD1456F2330060A5C5 /* RKObjectMappingNextGenTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610211456F2330060A5C5 /* RKObjectMappingNextGenTest.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		251610DE1456F2330060A5C5 /* RKMappingOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610221456F2330060A5C5 /* RKMappingOperationTest.m */; };
+		251610DF1456F2330060A5C5 /* RKMappingOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610221456F2330060A5C5 /* RKMappingOperationTest.m */; };
+		251610E21456F2330060A5C5 /* RKMappingResultTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610241456F2330060A5C5 /* RKMappingResultTest.m */; };
+		251610E31456F2330060A5C5 /* RKMappingResultTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610241456F2330060A5C5 /* RKMappingResultTest.m */; };
+		251610E71456F2330060A5C5 /* RKObjectParameterizationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610261456F2330060A5C5 /* RKObjectParameterizationTest.m */; };
+		251610E81456F2330060A5C5 /* RKMIMETypeSerializationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610271456F2330060A5C5 /* RKMIMETypeSerializationTest.m */; };
+		251610E91456F2330060A5C5 /* RKMIMETypeSerializationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610271456F2330060A5C5 /* RKMIMETypeSerializationTest.m */; };
+		251610F01456F2340060A5C5 /* RKTestEnvironment.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610361456F2330060A5C5 /* RKTestEnvironment.m */; };
+		251610F11456F2340060A5C5 /* RKTestEnvironment.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610361456F2330060A5C5 /* RKTestEnvironment.m */; };
+		2516110D1456F2340060A5C5 /* server.rb in Resources */ = {isa = PBXBuildFile; fileRef = 251610501456F2330060A5C5 /* server.rb */; };
+		2516110E1456F2340060A5C5 /* RKURLEncodedSerializationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610521456F2330060A5C5 /* RKURLEncodedSerializationTest.m */; };
+		2516110F1456F2340060A5C5 /* RKURLEncodedSerializationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610521456F2330060A5C5 /* RKURLEncodedSerializationTest.m */; };
+		251611101456F2340060A5C5 /* NSStringRestKitTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610531456F2330060A5C5 /* NSStringRestKitTest.m */; };
+		251611111456F2340060A5C5 /* NSStringRestKitTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610531456F2330060A5C5 /* NSStringRestKitTest.m */; };
+		251611121456F2340060A5C5 /* RKDotNetDateFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610541456F2330060A5C5 /* RKDotNetDateFormatterTest.m */; };
+		251611131456F2340060A5C5 /* RKDotNetDateFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610541456F2330060A5C5 /* RKDotNetDateFormatterTest.m */; };
+		251611161456F2340060A5C5 /* RKPathMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610561456F2330060A5C5 /* RKPathMatcherTest.m */; };
+		251611171456F2340060A5C5 /* RKPathMatcherTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610561456F2330060A5C5 /* RKPathMatcherTest.m */; };
+		251611291456F50F0060A5C5 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 251611281456F50F0060A5C5 /* SystemConfiguration.framework */; };
+		2516112B1456F5170060A5C5 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2516112A1456F5170060A5C5 /* CFNetwork.framework */; };
+		2516112C1456F51D0060A5C5 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 25160F161456538B0060A5C5 /* libxml2.dylib */; };
+		2516112E1456F5520060A5C5 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2516112D1456F5520060A5C5 /* CoreData.framework */; };
+		251611301456F5590060A5C5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2516112F1456F5590060A5C5 /* Security.framework */; };
+		251611321456F56C0060A5C5 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 251611311456F56C0060A5C5 /* MobileCoreServices.framework */; };
+		2519764315823BA1004FE9DD /* RKAttributeMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2519764215823BA1004FE9DD /* RKAttributeMappingTest.m */; };
+		2519764415823BA1004FE9DD /* RKAttributeMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2519764215823BA1004FE9DD /* RKAttributeMappingTest.m */; };
+		2519764815824455004FE9DD /* RKRelationshipMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2519764715824455004FE9DD /* RKRelationshipMappingTest.m */; };
+		2519764915824455004FE9DD /* RKRelationshipMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2519764715824455004FE9DD /* RKRelationshipMappingTest.m */; };
+		2519764C158244F8004FE9DD /* RKObjectMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2519764B158244F8004FE9DD /* RKObjectMappingTest.m */; };
+		2519764D158244F8004FE9DD /* RKObjectMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2519764B158244F8004FE9DD /* RKObjectMappingTest.m */; };
+		252028FC1577AE0B00076FB4 /* RKRouteSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 252028FA1577AE0B00076FB4 /* RKRouteSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		252028FD1577AE0B00076FB4 /* RKRouteSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 252028FA1577AE0B00076FB4 /* RKRouteSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		252028FE1577AE0B00076FB4 /* RKRouteSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 252028FB1577AE0B00076FB4 /* RKRouteSet.m */; };
+		252028FF1577AE0B00076FB4 /* RKRouteSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 252028FB1577AE0B00076FB4 /* RKRouteSet.m */; };
+		252029031577AE1800076FB4 /* RKRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = 252029011577AE1800076FB4 /* RKRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		252029041577AE1800076FB4 /* RKRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = 252029011577AE1800076FB4 /* RKRoute.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		252029051577AE1800076FB4 /* RKRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 252029021577AE1800076FB4 /* RKRoute.m */; };
+		252029061577AE1800076FB4 /* RKRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = 252029021577AE1800076FB4 /* RKRoute.m */; };
+		252029091577C78600076FB4 /* RKRouteSetTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 252029081577C78600076FB4 /* RKRouteSetTest.m */; };
+		2520290A1577C78600076FB4 /* RKRouteSetTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 252029081577C78600076FB4 /* RKRouteSetTest.m */; };
+		252205CC162B242400F7B11E /* RKHTTPUtilitiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 252205CB162B242400F7B11E /* RKHTTPUtilitiesTest.m */; };
+		252205CD162B242400F7B11E /* RKHTTPUtilitiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 252205CB162B242400F7B11E /* RKHTTPUtilitiesTest.m */; };
+		252CCE6617E08E2D00B7F0BF /* RKValueTransformers.h in Headers */ = {isa = PBXBuildFile; fileRef = 252CCE6017E08E2D00B7F0BF /* RKValueTransformers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		252CCE6717E08E2D00B7F0BF /* RKValueTransformers.h in Headers */ = {isa = PBXBuildFile; fileRef = 252CCE6017E08E2D00B7F0BF /* RKValueTransformers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		252CCE6817E08E2D00B7F0BF /* RKValueTransformers.m in Sources */ = {isa = PBXBuildFile; fileRef = 252CCE6117E08E2D00B7F0BF /* RKValueTransformers.m */; };
+		252CCE6917E08E2D00B7F0BF /* RKValueTransformers.m in Sources */ = {isa = PBXBuildFile; fileRef = 252CCE6117E08E2D00B7F0BF /* RKValueTransformers.m */; };
+		252CCE7217E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 252CCE6E17E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		252CCE7317E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 252CCE6E17E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		252CCE7417E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 252CCE6F17E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.m */; };
+		252CCE7517E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 252CCE6F17E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.m */; };
+		252CCE7617E0CA2700B7F0BF /* RKISO8601DateFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 252CCE7017E0CA2700B7F0BF /* RKISO8601DateFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		252CCE7717E0CA2700B7F0BF /* RKISO8601DateFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 252CCE7017E0CA2700B7F0BF /* RKISO8601DateFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		252CCE7817E0CA2700B7F0BF /* RKISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 252CCE7117E0CA2700B7F0BF /* RKISO8601DateFormatter.m */; };
+		252CCE7917E0CA2700B7F0BF /* RKISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 252CCE7117E0CA2700B7F0BF /* RKISO8601DateFormatter.m */; };
+		252EFAFA14D8EAEC004863C8 /* RKEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 252EFAF914D8EAEC004863C8 /* RKEvent.m */; };
+		252EFAFB14D8EAEC004863C8 /* RKEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 252EFAF914D8EAEC004863C8 /* RKEvent.m */; };
+		252EFB2814DA0689004863C8 /* NakedEvents.json in Resources */ = {isa = PBXBuildFile; fileRef = 252EFB2714DA0689004863C8 /* NakedEvents.json */; };
+		252EFB2914DA0689004863C8 /* NakedEvents.json in Resources */ = {isa = PBXBuildFile; fileRef = 252EFB2714DA0689004863C8 /* NakedEvents.json */; };
+		253477F115FFBC61002C0E4E /* RKDictionaryUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 253477EF15FFBC60002C0E4E /* RKDictionaryUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		253477F215FFBC61002C0E4E /* RKDictionaryUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 253477EF15FFBC60002C0E4E /* RKDictionaryUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		253477F315FFBC61002C0E4E /* RKDictionaryUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 253477F015FFBC60002C0E4E /* RKDictionaryUtilities.m */; };
+		253477F415FFBC61002C0E4E /* RKDictionaryUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 253477F015FFBC60002C0E4E /* RKDictionaryUtilities.m */; };
+		2534781615FFD4A6002C0E4E /* RKURLEncodedSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 2534781415FFD4A6002C0E4E /* RKURLEncodedSerialization.m */; };
+		2534781715FFD4A6002C0E4E /* RKURLEncodedSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 2534781415FFD4A6002C0E4E /* RKURLEncodedSerialization.m */; };
+		2534781815FFD4A6002C0E4E /* RKURLEncodedSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 2534781515FFD4A6002C0E4E /* RKURLEncodedSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2534781915FFD4A6002C0E4E /* RKURLEncodedSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 2534781515FFD4A6002C0E4E /* RKURLEncodedSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2536D1FD167270F100DF9BB0 /* RKRouterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2536D1FC167270F100DF9BB0 /* RKRouterTest.m */; };
+		2536D1FE167270F100DF9BB0 /* RKRouterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2536D1FC167270F100DF9BB0 /* RKRouterTest.m */; };
+		253B495214E35D1A00B0483F /* RKTestFixture.h in Headers */ = {isa = PBXBuildFile; fileRef = 252EFB2014D9B35D004863C8 /* RKTestFixture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		253B495F14E35EC300B0483F /* RKTestFixture.m in Sources */ = {isa = PBXBuildFile; fileRef = 252EFB2114D9B35D004863C8 /* RKTestFixture.m */; };
+		254372A815F54995006E8424 /* RKObjectParameterization.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372A615F54995006E8424 /* RKObjectParameterization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372A915F54995006E8424 /* RKObjectParameterization.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372A715F54995006E8424 /* RKObjectParameterization.m */; };
+		254372B815F54C3F006E8424 /* RKHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372AA15F54C3F006E8424 /* RKHTTPRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372B915F54C3F006E8424 /* RKHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372AA15F54C3F006E8424 /* RKHTTPRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372BA15F54C3F006E8424 /* RKHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372AB15F54C3F006E8424 /* RKHTTPRequestOperation.m */; };
+		254372BB15F54C3F006E8424 /* RKHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372AB15F54C3F006E8424 /* RKHTTPRequestOperation.m */; };
+		254372BC15F54C3F006E8424 /* RKObjectManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372AC15F54C3F006E8424 /* RKObjectManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372BD15F54C3F006E8424 /* RKObjectManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372AC15F54C3F006E8424 /* RKObjectManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372BE15F54C3F006E8424 /* RKObjectManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372AD15F54C3F006E8424 /* RKObjectManager.m */; };
+		254372BF15F54C3F006E8424 /* RKObjectManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372AD15F54C3F006E8424 /* RKObjectManager.m */; };
+		254372C015F54C3F006E8424 /* RKPaginator.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372AE15F54C3F006E8424 /* RKPaginator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372C115F54C3F006E8424 /* RKPaginator.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372AE15F54C3F006E8424 /* RKPaginator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372C215F54C3F006E8424 /* RKPaginator.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372AF15F54C3F006E8424 /* RKPaginator.m */; };
+		254372C315F54C3F006E8424 /* RKPaginator.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372AF15F54C3F006E8424 /* RKPaginator.m */; };
+		254372C415F54C3F006E8424 /* RKObjectRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372B015F54C3F006E8424 /* RKObjectRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372C515F54C3F006E8424 /* RKObjectRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372B015F54C3F006E8424 /* RKObjectRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372C615F54C3F006E8424 /* RKObjectRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372B115F54C3F006E8424 /* RKObjectRequestOperation.m */; };
+		254372C715F54C3F006E8424 /* RKObjectRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372B115F54C3F006E8424 /* RKObjectRequestOperation.m */; };
+		254372C815F54C3F006E8424 /* RKRequestDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372B215F54C3F006E8424 /* RKRequestDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372C915F54C3F006E8424 /* RKRequestDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372B215F54C3F006E8424 /* RKRequestDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372CA15F54C3F006E8424 /* RKRequestDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372B315F54C3F006E8424 /* RKRequestDescriptor.m */; };
+		254372CB15F54C3F006E8424 /* RKRequestDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372B315F54C3F006E8424 /* RKRequestDescriptor.m */; };
+		254372CC15F54C3F006E8424 /* RKResponseDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372B415F54C3F006E8424 /* RKResponseDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372CD15F54C3F006E8424 /* RKResponseDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372B415F54C3F006E8424 /* RKResponseDescriptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372CE15F54C3F006E8424 /* RKResponseDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372B515F54C3F006E8424 /* RKResponseDescriptor.m */; };
+		254372CF15F54C3F006E8424 /* RKResponseDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372B515F54C3F006E8424 /* RKResponseDescriptor.m */; };
+		254372D015F54C3F006E8424 /* RKResponseMapperOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372B615F54C3F006E8424 /* RKResponseMapperOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372D115F54C3F006E8424 /* RKResponseMapperOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372B615F54C3F006E8424 /* RKResponseMapperOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372D215F54C3F006E8424 /* RKResponseMapperOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372B715F54C3F006E8424 /* RKResponseMapperOperation.m */; };
+		254372D315F54C3F006E8424 /* RKResponseMapperOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372B715F54C3F006E8424 /* RKResponseMapperOperation.m */; };
+		254372D615F54CE3006E8424 /* RKManagedObjectRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372D415F54CE3006E8424 /* RKManagedObjectRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372D715F54CE3006E8424 /* RKManagedObjectRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372D415F54CE3006E8424 /* RKManagedObjectRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		254372D815F54CE3006E8424 /* RKManagedObjectRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372D515F54CE3006E8424 /* RKManagedObjectRequestOperation.m */; };
+		254372D915F54CE3006E8424 /* RKManagedObjectRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372D515F54CE3006E8424 /* RKManagedObjectRequestOperation.m */; };
+		2543A25D1664FD3100821D5B /* RKResponseDescriptorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25CC5C58161DDADD0008BD21 /* RKResponseDescriptorTest.m */; };
+		2543A25E1664FD3200821D5B /* RKResponseDescriptorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25CC5C58161DDADD0008BD21 /* RKResponseDescriptorTest.m */; };
+		2546A95916628EDD0078E044 /* RKConnectionDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2546A95716628EDD0078E044 /* RKConnectionDescriptionTest.m */; };
+		2548AC6E162F5E00009E79BF /* RKManagedObjectRequestOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2548AC6C162F5E00009E79BF /* RKManagedObjectRequestOperationTest.m */; };
+		2549D646162B376F003DD135 /* RKRequestDescriptorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2549D645162B376F003DD135 /* RKRequestDescriptorTest.m */; };
+		2549D647162B376F003DD135 /* RKRequestDescriptorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2549D645162B376F003DD135 /* RKRequestDescriptorTest.m */; };
+		2550DA2316B1FB62005A0CB8 /* RKPost.m in Sources */ = {isa = PBXBuildFile; fileRef = 2550DA2216B1FB62005A0CB8 /* RKPost.m */; };
+		2550DA2416B1FB62005A0CB8 /* RKPost.m in Sources */ = {isa = PBXBuildFile; fileRef = 2550DA2216B1FB62005A0CB8 /* RKPost.m */; };
+		2551338F167838590017E4B6 /* RKHTTPRequestOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2551338E167838590017E4B6 /* RKHTTPRequestOperationTest.m */; };
+		25513390167838590017E4B6 /* RKHTTPRequestOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2551338E167838590017E4B6 /* RKHTTPRequestOperationTest.m */; };
+		255133CF167AC7600017E4B6 /* RKManagedObjectRequestOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2548AC6C162F5E00009E79BF /* RKManagedObjectRequestOperationTest.m */; };
+		25565956161FC3C300F5BB20 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25565955161FC3C300F5BB20 /* CoreServices.framework */; };
+		25565959161FC3CD00F5BB20 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25565958161FC3CD00F5BB20 /* SystemConfiguration.framework */; };
+		25565965161FDD8800F5BB20 /* RKResponseMapperOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25565964161FDD8800F5BB20 /* RKResponseMapperOperationTest.m */; };
+		25565966161FDD8800F5BB20 /* RKResponseMapperOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25565964161FDD8800F5BB20 /* RKResponseMapperOperationTest.m */; };
+		255893E3166BA6A20010C70B /* RKObjectParameterization.h in Headers */ = {isa = PBXBuildFile; fileRef = 254372A615F54995006E8424 /* RKObjectParameterization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		255893E4166BA7400010C70B /* RestKit-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 25160DBB145650490060A5C5 /* RestKit-Prefix.pch */; };
+		255893E5166BA7700010C70B /* RKTestFixture.h in Headers */ = {isa = PBXBuildFile; fileRef = 252EFB2014D9B35D004863C8 /* RKTestFixture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		255F87911656B22D00914D57 /* RKPaginatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 254A62BF14AD591C00939BEE /* RKPaginatorTest.m */; };
+		255F87921656B22F00914D57 /* RKPaginatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 254A62BF14AD591C00939BEE /* RKPaginatorTest.m */; };
+		2564E40B16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2564E40A16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m */; };
+		2564E40C16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2564E40A16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m */; };
+		257ABAB015112DD500CCAA76 /* NSManagedObjectContext+RKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 257ABAAE15112DD400CCAA76 /* NSManagedObjectContext+RKAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		257ABAB115112DD500CCAA76 /* NSManagedObjectContext+RKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 257ABAAE15112DD400CCAA76 /* NSManagedObjectContext+RKAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		257ABAB215112DD500CCAA76 /* NSManagedObjectContext+RKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 257ABAAF15112DD400CCAA76 /* NSManagedObjectContext+RKAdditions.m */; };
+		257ABAB315112DD500CCAA76 /* NSManagedObjectContext+RKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 257ABAAF15112DD400CCAA76 /* NSManagedObjectContext+RKAdditions.m */; };
+		257ABAB61511371E00CCAA76 /* NSManagedObject+RKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 257ABAB41511371C00CCAA76 /* NSManagedObject+RKAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		257ABAB71511371E00CCAA76 /* NSManagedObject+RKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 257ABAB41511371C00CCAA76 /* NSManagedObject+RKAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		257ABAB81511371E00CCAA76 /* NSManagedObject+RKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 257ABAB51511371D00CCAA76 /* NSManagedObject+RKAdditions.m */; };
+		257ABAB91511371E00CCAA76 /* NSManagedObject+RKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 257ABAB51511371D00CCAA76 /* NSManagedObject+RKAdditions.m */; };
+		2582F56D173038760043B8BB /* RKInMemoryManagedObjectCacheTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2582F56C173038750043B8BB /* RKInMemoryManagedObjectCacheTest.m */; };
+		2582F56E173038760043B8BB /* RKInMemoryManagedObjectCacheTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2582F56C173038750043B8BB /* RKInMemoryManagedObjectCacheTest.m */; };
+		258BEA02168D058300C74C8C /* RKObjectMappingMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 258BEA01168D058300C74C8C /* RKObjectMappingMatcher.m */; };
+		258BEA03168D058300C74C8C /* RKObjectMappingMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 258BEA01168D058300C74C8C /* RKObjectMappingMatcher.m */; };
+		258EA4A815A38BC0007E07A6 /* RKObjectMappingOperationDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 258EA4A615A38BBF007E07A6 /* RKObjectMappingOperationDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		258EA4A915A38BC0007E07A6 /* RKObjectMappingOperationDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 258EA4A615A38BBF007E07A6 /* RKObjectMappingOperationDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		258EA4AA15A38BC0007E07A6 /* RKObjectMappingOperationDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 258EA4A715A38BBF007E07A6 /* RKObjectMappingOperationDataSource.m */; };
+		258EA4AB15A38BC0007E07A6 /* RKObjectMappingOperationDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 258EA4A715A38BBF007E07A6 /* RKObjectMappingOperationDataSource.m */; };
+		258EA4AE15A38E7E007E07A6 /* RKMappingOperationDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 258EA4AD15A38E7D007E07A6 /* RKMappingOperationDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		258EA4AF15A38E7E007E07A6 /* RKMappingOperationDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 258EA4AD15A38E7D007E07A6 /* RKMappingOperationDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		258EA4B215A39090007E07A6 /* RKManagedObjectMappingOperationDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 258EA4B015A3908F007E07A6 /* RKManagedObjectMappingOperationDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		258EA4B315A39090007E07A6 /* RKManagedObjectMappingOperationDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 258EA4B015A3908F007E07A6 /* RKManagedObjectMappingOperationDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		258EFF7A15C0CE1400EE4E0D /* RKManagedObjectSeederTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 258EFF7915C0CE1400EE4E0D /* RKManagedObjectSeederTest.m */; };
+		258EFF7B15C0CE1400EE4E0D /* RKManagedObjectSeederTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 258EFF7915C0CE1400EE4E0D /* RKManagedObjectSeederTest.m */; };
+		2595B46F15F670530087A59B /* RKMIMETypeSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 2595B46B15F670530087A59B /* RKMIMETypeSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2595B47015F670530087A59B /* RKMIMETypeSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 2595B46B15F670530087A59B /* RKMIMETypeSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2595B47115F670530087A59B /* RKMIMETypeSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 2595B46C15F670530087A59B /* RKMIMETypeSerialization.m */; };
+		2595B47215F670530087A59B /* RKMIMETypeSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 2595B46C15F670530087A59B /* RKMIMETypeSerialization.m */; };
+		2595B47315F670530087A59B /* RKNSJSONSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 2595B46D15F670530087A59B /* RKNSJSONSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2595B47415F670530087A59B /* RKNSJSONSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 2595B46D15F670530087A59B /* RKNSJSONSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2595B47515F670530087A59B /* RKNSJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 2595B46E15F670530087A59B /* RKNSJSONSerialization.m */; };
+		2595B47615F670530087A59B /* RKNSJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 2595B46E15F670530087A59B /* RKNSJSONSerialization.m */; };
+		2597F99C15AF6DC400E547D7 /* RKRelationshipConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2597F99A15AF6DC400E547D7 /* RKRelationshipConnectionOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2597F99D15AF6DC400E547D7 /* RKRelationshipConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2597F99A15AF6DC400E547D7 /* RKRelationshipConnectionOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2597F99E15AF6DC400E547D7 /* RKRelationshipConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2597F99B15AF6DC400E547D7 /* RKRelationshipConnectionOperation.m */; };
+		2597F99F15AF6DC400E547D7 /* RKRelationshipConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2597F99B15AF6DC400E547D7 /* RKRelationshipConnectionOperation.m */; };
+		2598888D15EC169E006CAE95 /* RKPropertyMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 2598888B15EC169E006CAE95 /* RKPropertyMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2598888E15EC169E006CAE95 /* RKPropertyMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 2598888B15EC169E006CAE95 /* RKPropertyMapping.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2598888F15EC169E006CAE95 /* RKPropertyMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 2598888C15EC169E006CAE95 /* RKPropertyMapping.m */; };
+		2598889015EC169E006CAE95 /* RKPropertyMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 2598888C15EC169E006CAE95 /* RKPropertyMapping.m */; };
+		259AC481162B05C80012D2F9 /* RKObjectRequestOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 259AC480162B05C80012D2F9 /* RKObjectRequestOperationTest.m */; };
+		259AC482162B05C80012D2F9 /* RKObjectRequestOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 259AC480162B05C80012D2F9 /* RKObjectRequestOperationTest.m */; };
+		259B96D51604CCCC0000C250 /* AFHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96C21604CCCC0000C250 /* AFHTTPClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96D61604CCCC0000C250 /* AFHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96C21604CCCC0000C250 /* AFHTTPClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96D71604CCCC0000C250 /* AFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96C31604CCCC0000C250 /* AFHTTPClient.m */; };
+		259B96D81604CCCC0000C250 /* AFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96C31604CCCC0000C250 /* AFHTTPClient.m */; };
+		259B96D91604CCCC0000C250 /* AFHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96C41604CCCC0000C250 /* AFHTTPRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96DA1604CCCC0000C250 /* AFHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96C41604CCCC0000C250 /* AFHTTPRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96DB1604CCCC0000C250 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96C51604CCCC0000C250 /* AFHTTPRequestOperation.m */; };
+		259B96DC1604CCCC0000C250 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96C51604CCCC0000C250 /* AFHTTPRequestOperation.m */; };
+		259B96DD1604CCCC0000C250 /* AFImageRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96C61604CCCC0000C250 /* AFImageRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96DE1604CCCC0000C250 /* AFImageRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96C61604CCCC0000C250 /* AFImageRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96DF1604CCCC0000C250 /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96C71604CCCC0000C250 /* AFImageRequestOperation.m */; };
+		259B96E01604CCCC0000C250 /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96C71604CCCC0000C250 /* AFImageRequestOperation.m */; };
+		259B96E11604CCCC0000C250 /* AFJSONRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96C81604CCCC0000C250 /* AFJSONRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96E21604CCCC0000C250 /* AFJSONRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96C81604CCCC0000C250 /* AFJSONRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96E31604CCCC0000C250 /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96C91604CCCC0000C250 /* AFJSONRequestOperation.m */; };
+		259B96E41604CCCC0000C250 /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96C91604CCCC0000C250 /* AFJSONRequestOperation.m */; };
+		259B96E51604CCCC0000C250 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96CA1604CCCC0000C250 /* AFNetworkActivityIndicatorManager.m */; };
+		259B96E61604CCCC0000C250 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96CA1604CCCC0000C250 /* AFNetworkActivityIndicatorManager.m */; };
+		259B96E71604CCCC0000C250 /* AFPropertyListRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96CB1604CCCC0000C250 /* AFPropertyListRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96E81604CCCC0000C250 /* AFPropertyListRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96CB1604CCCC0000C250 /* AFPropertyListRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96E91604CCCC0000C250 /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96CC1604CCCC0000C250 /* AFPropertyListRequestOperation.m */; };
+		259B96EA1604CCCC0000C250 /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96CC1604CCCC0000C250 /* AFPropertyListRequestOperation.m */; };
+		259B96EB1604CCCC0000C250 /* AFURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96CD1604CCCC0000C250 /* AFURLConnectionOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96EC1604CCCC0000C250 /* AFURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96CD1604CCCC0000C250 /* AFURLConnectionOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96ED1604CCCC0000C250 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96CE1604CCCC0000C250 /* AFURLConnectionOperation.m */; };
+		259B96EE1604CCCC0000C250 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96CE1604CCCC0000C250 /* AFURLConnectionOperation.m */; };
+		259B96EF1604CCCC0000C250 /* AFXMLRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96CF1604CCCC0000C250 /* AFXMLRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96F01604CCCC0000C250 /* AFXMLRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96CF1604CCCC0000C250 /* AFXMLRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96F11604CCCC0000C250 /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96D01604CCCC0000C250 /* AFXMLRequestOperation.m */; };
+		259B96F21604CCCC0000C250 /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96D01604CCCC0000C250 /* AFXMLRequestOperation.m */; };
+		259B96F31604CCCC0000C250 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96D11604CCCC0000C250 /* UIImageView+AFNetworking.m */; };
+		259B96F41604CCCC0000C250 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 259B96D11604CCCC0000C250 /* UIImageView+AFNetworking.m */; };
+		259B96F51604CCCC0000C250 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96D21604CCCC0000C250 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96F61604CCCC0000C250 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96D21604CCCC0000C250 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96F71604CCCC0000C250 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96D31604CCCC0000C250 /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96F81604CCCC0000C250 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96D31604CCCC0000C250 /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96F91604CCCC0000C250 /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96D41604CCCC0000C250 /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259B96FA1604CCCC0000C250 /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 259B96D41604CCCC0000C250 /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259D983C154F6C90008C90F5 /* benchmark_parents_and_children.json in Resources */ = {isa = PBXBuildFile; fileRef = 259D983B154F6C90008C90F5 /* benchmark_parents_and_children.json */; };
+		259D983D154F6C90008C90F5 /* benchmark_parents_and_children.json in Resources */ = {isa = PBXBuildFile; fileRef = 259D983B154F6C90008C90F5 /* benchmark_parents_and_children.json */; };
+		259D98541550C69A008C90F5 /* RKEntityByAttributeCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 259D98521550C69A008C90F5 /* RKEntityByAttributeCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259D98551550C69A008C90F5 /* RKEntityByAttributeCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 259D98521550C69A008C90F5 /* RKEntityByAttributeCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259D98561550C69A008C90F5 /* RKEntityByAttributeCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 259D98531550C69A008C90F5 /* RKEntityByAttributeCache.m */; };
+		259D98571550C69A008C90F5 /* RKEntityByAttributeCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 259D98531550C69A008C90F5 /* RKEntityByAttributeCache.m */; };
+		259D985A1550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 259D98591550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m */; };
+		259D985B1550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 259D98591550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m */; };
+		259D985E155218E5008C90F5 /* RKEntityCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 259D985C155218E4008C90F5 /* RKEntityCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259D985F155218E5008C90F5 /* RKEntityCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 259D985C155218E4008C90F5 /* RKEntityCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		259D9860155218E5008C90F5 /* RKEntityCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 259D985D155218E4008C90F5 /* RKEntityCache.m */; };
+		259D9861155218E5008C90F5 /* RKEntityCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 259D985D155218E4008C90F5 /* RKEntityCache.m */; };
+		259D986415521B20008C90F5 /* RKEntityCacheTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 259D986315521B1F008C90F5 /* RKEntityCacheTest.m */; };
+		259D986515521B20008C90F5 /* RKEntityCacheTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 259D986315521B1F008C90F5 /* RKEntityCacheTest.m */; };
+		25A199D416ED035A00792629 /* RKBenchmark.h in Headers */ = {isa = PBXBuildFile; fileRef = 25A199D216ED035A00792629 /* RKBenchmark.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25A199D516ED035A00792629 /* RKBenchmark.h in Headers */ = {isa = PBXBuildFile; fileRef = 25A199D216ED035A00792629 /* RKBenchmark.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25A199D616ED035A00792629 /* RKBenchmark.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A199D316ED035A00792629 /* RKBenchmark.m */; };
+		25A199D716ED035A00792629 /* RKBenchmark.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A199D316ED035A00792629 /* RKBenchmark.m */; };
+		25A226D61618A57500952D72 /* RKObjectUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 25A226D41618A57500952D72 /* RKObjectUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25A226D71618A57500952D72 /* RKObjectUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 25A226D41618A57500952D72 /* RKObjectUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25A226D81618A57500952D72 /* RKObjectUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A226D51618A57500952D72 /* RKObjectUtilities.m */; };
+		25A226D91618A57500952D72 /* RKObjectUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A226D51618A57500952D72 /* RKObjectUtilities.m */; };
+		25A34245147D8AAA0009758D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25A34244147D8AAA0009758D /* Security.framework */; };
+		25A73362169C8C230090A930 /* VersionedModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 25A73360169C8C230090A930 /* VersionedModel.xcdatamodeld */; };
+		25A73363169C8C230090A930 /* VersionedModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 25A73360169C8C230090A930 /* VersionedModel.xcdatamodeld */; };
+		25A763E515C7424500A9DF31 /* RKSearchIndexerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A763E415C7424500A9DF31 /* RKSearchIndexerTest.m */; };
+		25A763E615C7424500A9DF31 /* RKSearchIndexerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A763E415C7424500A9DF31 /* RKSearchIndexerTest.m */; };
+		25A8C2341673BD480014D9A6 /* RKConnectionTestExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25A8C2321673BD480014D9A6 /* RKConnectionTestExpectation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25A8C2351673BD480014D9A6 /* RKConnectionTestExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = 25A8C2321673BD480014D9A6 /* RKConnectionTestExpectation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25A8C2361673BD480014D9A6 /* RKConnectionTestExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A8C2331673BD480014D9A6 /* RKConnectionTestExpectation.m */; };
+		25A8C2371673BD480014D9A6 /* RKConnectionTestExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 25A8C2331673BD480014D9A6 /* RKConnectionTestExpectation.m */; };
+		25A9827516A5FF4F0088A3CA /* RKConnectionDescriptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2546A95716628EDD0078E044 /* RKConnectionDescriptionTest.m */; };
+		25AA23D015AF2920006EF62D /* RKManagedObjectMappingOperationDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 25AA23CF15AF291F006EF62D /* RKManagedObjectMappingOperationDataSource.m */; };
+		25AA23D115AF2920006EF62D /* RKManagedObjectMappingOperationDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 25AA23CF15AF291F006EF62D /* RKManagedObjectMappingOperationDataSource.m */; };
+		25AA23D815AF5085006EF62D /* RKManagedObjectMappingOperationDataSourceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25AA23D315AF4F25006EF62D /* RKManagedObjectMappingOperationDataSourceTest.m */; };
+		25AA23D915AF5086006EF62D /* RKManagedObjectMappingOperationDataSourceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25AA23D315AF4F25006EF62D /* RKManagedObjectMappingOperationDataSourceTest.m */; };
+		25AABCED17B698940061DC5B /* RKStringTokenizerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25AABCEC17B698940061DC5B /* RKStringTokenizerTest.m */; };
+		25AABCEE17B698940061DC5B /* RKStringTokenizerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25AABCEC17B698940061DC5B /* RKStringTokenizerTest.m */; };
+		25AFF8F115B4CF1F0051877F /* RKMappingErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 25AFF8F015B4CF1F0051877F /* RKMappingErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25AFF8F215B4CF1F0051877F /* RKMappingErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 25AFF8F015B4CF1F0051877F /* RKMappingErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25B408261491CDDC00F21111 /* RKPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B408241491CDDB00F21111 /* RKPathUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25B408271491CDDC00F21111 /* RKPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B408241491CDDB00F21111 /* RKPathUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25B408281491CDDC00F21111 /* RKPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B408251491CDDB00F21111 /* RKPathUtilities.m */; };
+		25B408291491CDDC00F21111 /* RKPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B408251491CDDB00F21111 /* RKPathUtilities.m */; };
+		25B639CC16961EFA0065EB7B /* RKMappingTestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B639CB16961EFA0065EB7B /* RKMappingTestTest.m */; };
+		25B639CD16961EFA0065EB7B /* RKMappingTestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B639CB16961EFA0065EB7B /* RKMappingTestTest.m */; };
+		25B6E95514CF795D00B1E881 /* RKErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B6E95414CF795D00B1E881 /* RKErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25B6E95614CF795D00B1E881 /* RKErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B6E95414CF795D00B1E881 /* RKErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25B6E95814CF7A1C00B1E881 /* RKErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B6E95714CF7A1C00B1E881 /* RKErrors.m */; };
+		25B6E95914CF7A1C00B1E881 /* RKErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B6E95714CF7A1C00B1E881 /* RKErrors.m */; };
+		25B6E95C14CF7E3C00B1E881 /* RKObjectMappingMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B6E95A14CF7E3C00B1E881 /* RKObjectMappingMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25B6E95D14CF7E3C00B1E881 /* RKObjectMappingMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 25B6E95A14CF7E3C00B1E881 /* RKObjectMappingMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25B6E9DB14CF912500B1E881 /* RKSearchable.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B6E9D614CF912500B1E881 /* RKSearchable.m */; };
+		25B6E9DC14CF912500B1E881 /* RKSearchable.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B6E9D614CF912500B1E881 /* RKSearchable.m */; };
+		25B6E9DD14CF912500B1E881 /* RKTestAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B6E9D814CF912500B1E881 /* RKTestAddress.m */; };
+		25B6E9DE14CF912500B1E881 /* RKTestAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B6E9D814CF912500B1E881 /* RKTestAddress.m */; };
+		25B6E9DF14CF912500B1E881 /* RKTestUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B6E9DA14CF912500B1E881 /* RKTestUser.m */; };
+		25B6E9E014CF912500B1E881 /* RKTestUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 25B6E9DA14CF912500B1E881 /* RKTestUser.m */; };
+		25B6EA0614CF946400B1E881 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25B6EA0514CF946300B1E881 /* QuartzCore.framework */; };
+		25B6EA0814CF947E00B1E881 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25B6EA0714CF947D00B1E881 /* CoreGraphics.framework */; };
+		25BB392E161F4FD700E5C72A /* RKPathUtilitiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25BB392D161F4FD700E5C72A /* RKPathUtilitiesTest.m */; };
+		25BB392F161F4FD700E5C72A /* RKPathUtilitiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25BB392D161F4FD700E5C72A /* RKPathUtilitiesTest.m */; };
+		25C20466160ABC4800D418D5 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 251611281456F50F0060A5C5 /* SystemConfiguration.framework */; };
+		25C246A415C83B090032212E /* RKSearchTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C246A315C83B090032212E /* RKSearchTest.m */; };
+		25C246A515C83B090032212E /* RKSearchTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C246A315C83B090032212E /* RKSearchTest.m */; };
+		25C6C0BD1716F6F800C98A73 /* TKEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C6C0A51716F6F800C98A73 /* TKEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25C6C0BE1716F6F800C98A73 /* TKEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C6C0A51716F6F800C98A73 /* TKEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25C6C0BF1716F6F800C98A73 /* TKEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C6C0A61716F6F800C98A73 /* TKEvent.m */; };
+		25C6C0C01716F6F800C98A73 /* TKEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C6C0A61716F6F800C98A73 /* TKEvent.m */; };
+		25C6C0C11716F6F800C98A73 /* TKState.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C6C0A71716F6F800C98A73 /* TKState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25C6C0C21716F6F800C98A73 /* TKState.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C6C0A71716F6F800C98A73 /* TKState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25C6C0C31716F6F800C98A73 /* TKState.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C6C0A81716F6F800C98A73 /* TKState.m */; };
+		25C6C0C41716F6F800C98A73 /* TKState.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C6C0A81716F6F800C98A73 /* TKState.m */; };
+		25C6C0C51716F6F800C98A73 /* TKStateMachine.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C6C0A91716F6F800C98A73 /* TKStateMachine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25C6C0C61716F6F800C98A73 /* TKStateMachine.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C6C0A91716F6F800C98A73 /* TKStateMachine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25C6C0C71716F6F800C98A73 /* TKStateMachine.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C6C0AA1716F6F800C98A73 /* TKStateMachine.m */; };
+		25C6C0C81716F6F800C98A73 /* TKStateMachine.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C6C0AA1716F6F800C98A73 /* TKStateMachine.m */; };
+		25C6C0CB1716F6F800C98A73 /* TransitionKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C6C0AC1716F6F800C98A73 /* TransitionKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25C6C0CC1716F6F800C98A73 /* TransitionKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C6C0AC1716F6F800C98A73 /* TransitionKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25C6C0E81716F79B00C98A73 /* RKOperationStateMachine.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C6C0E61716F79B00C98A73 /* RKOperationStateMachine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25C6C0E91716F79B00C98A73 /* RKOperationStateMachine.h in Headers */ = {isa = PBXBuildFile; fileRef = 25C6C0E61716F79B00C98A73 /* RKOperationStateMachine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25C6C0EA1716F79B00C98A73 /* RKOperationStateMachine.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C6C0E71716F79B00C98A73 /* RKOperationStateMachine.m */; };
+		25C6C0EB1716F79B00C98A73 /* RKOperationStateMachine.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C6C0E71716F79B00C98A73 /* RKOperationStateMachine.m */; };
+		25C954A715542A47005C9E08 /* RKTestConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C954A415542A47005C9E08 /* RKTestConstants.m */; };
+		25C954A815542A47005C9E08 /* RKTestConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 25C954A415542A47005C9E08 /* RKTestConstants.m */; };
+		25CA7A8F14EC570200888FF8 /* RKMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25CA7A8E14EC570100888FF8 /* RKMapping.m */; };
+		25CA7A9014EC570200888FF8 /* RKMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 25CA7A8E14EC570100888FF8 /* RKMapping.m */; };
+		25CA7A9114EC5C2D00888FF8 /* RKTestFixture.m in Sources */ = {isa = PBXBuildFile; fileRef = 252EFB2114D9B35D004863C8 /* RKTestFixture.m */; };
+		25CAAA9415254E7800CAE5D7 /* ArrayOfHumans.json in Resources */ = {isa = PBXBuildFile; fileRef = 25CAAA9315254E7800CAE5D7 /* ArrayOfHumans.json */; };
+		25CAAA9515254E7800CAE5D7 /* ArrayOfHumans.json in Resources */ = {isa = PBXBuildFile; fileRef = 25CAAA9315254E7800CAE5D7 /* ArrayOfHumans.json */; };
+		25CDA0E7161E828D00F583F3 /* RKISODateFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25CDA0E2161E821000F583F3 /* RKISODateFormatterTest.m */; };
+		25CDA0E8161E828E00F583F3 /* RKISODateFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25CDA0E2161E821000F583F3 /* RKISODateFormatterTest.m */; };
+		25DA356F1836741D001A56A0 /* TKTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 25DA356D1836741C001A56A0 /* TKTransition.h */; };
+		25DA35701836741D001A56A0 /* TKTransition.h in Headers */ = {isa = PBXBuildFile; fileRef = 25DA356D1836741C001A56A0 /* TKTransition.h */; };
+		25DA35711836741D001A56A0 /* TKTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 25DA356E1836741C001A56A0 /* TKTransition.m */; };
+		25DA35721836741D001A56A0 /* TKTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 25DA356E1836741C001A56A0 /* TKTransition.m */; };
+		25DB7508151BD551009F01AF /* NSManagedObjectContext+RKAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25DB7507151BD551009F01AF /* NSManagedObjectContext+RKAdditionsTest.m */; };
+		25DB7509151BD551009F01AF /* NSManagedObjectContext+RKAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25DB7507151BD551009F01AF /* NSManagedObjectContext+RKAdditionsTest.m */; };
+		25E36E0215195CED00F9E448 /* RKFetchRequestMappingCacheTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25E36E0115195CED00F9E448 /* RKFetchRequestMappingCacheTest.m */; };
+		25E36E0315195CED00F9E448 /* RKFetchRequestMappingCacheTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 25E36E0115195CED00F9E448 /* RKFetchRequestMappingCacheTest.m */; };
+		25E88C88165C5CC30042ABD0 /* RKConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 25E88C86165C5CC30042ABD0 /* RKConnectionDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25E88C89165C5CC30042ABD0 /* RKConnectionDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 25E88C86165C5CC30042ABD0 /* RKConnectionDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25E88C8A165C5CC30042ABD0 /* RKConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 25E88C87165C5CC30042ABD0 /* RKConnectionDescription.m */; };
+		25E88C8B165C5CC30042ABD0 /* RKConnectionDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 25E88C87165C5CC30042ABD0 /* RKConnectionDescription.m */; };
+		25E9C8F01612523400647F84 /* RKObjectParameterizationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 251610261456F2330060A5C5 /* RKObjectParameterizationTest.m */; };
+		25E9C8F1161290D500647F84 /* RKObjectParameterization.m in Sources */ = {isa = PBXBuildFile; fileRef = 254372A715F54995006E8424 /* RKObjectParameterization.m */; };
+		25EC1A3914F72B0900C3CF3F /* RKFetchRequestManagedObjectCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 7394DF3814CF168C00CE7BCE /* RKFetchRequestManagedObjectCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25EC1A3A14F72B0A00C3CF3F /* RKFetchRequestManagedObjectCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 7394DF3814CF168C00CE7BCE /* RKFetchRequestManagedObjectCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25EC1A3B14F72B1300C3CF3F /* RKFetchRequestManagedObjectCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 7394DF3914CF168C00CE7BCE /* RKFetchRequestManagedObjectCache.m */; };
+		25EC1A3C14F72B1400C3CF3F /* RKFetchRequestManagedObjectCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 7394DF3914CF168C00CE7BCE /* RKFetchRequestManagedObjectCache.m */; };
+		25EC1A3D14F72B2800C3CF3F /* RKInMemoryManagedObjectCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 7394DF3C14CF19F200CE7BCE /* RKInMemoryManagedObjectCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25EC1A3E14F72B2900C3CF3F /* RKInMemoryManagedObjectCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 7394DF3C14CF19F200CE7BCE /* RKInMemoryManagedObjectCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25EC1A3F14F72B3100C3CF3F /* RKInMemoryManagedObjectCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 7394DF3D14CF19F200CE7BCE /* RKInMemoryManagedObjectCache.m */; };
+		25EC1A4014F72B3300C3CF3F /* RKInMemoryManagedObjectCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 7394DF3D14CF19F200CE7BCE /* RKInMemoryManagedObjectCache.m */; };
+		25EC1A6314F7402A00C3CF3F /* RKManagedObjectCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 7394DF3514CF157A00CE7BCE /* RKManagedObjectCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25EC1A6514F7402A00C3CF3F /* RKManagedObjectCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 7394DF3514CF157A00CE7BCE /* RKManagedObjectCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25EDFCE3161538F6008BAA1D /* RKObjectManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2516101F1456F2330060A5C5 /* RKObjectManagerTest.m */; };
+		25EDFCE5161538F8008BAA1D /* RKObjectManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2516101F1456F2330060A5C5 /* RKObjectManagerTest.m */; };
+		25F53AE215E7B612008B54E6 /* RKHTTPUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 25F53AE015E7B611008B54E6 /* RKHTTPUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25F53AE315E7B612008B54E6 /* RKHTTPUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 25F53AE015E7B611008B54E6 /* RKHTTPUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25F53AE415E7B612008B54E6 /* RKHTTPUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 25F53AE115E7B612008B54E6 /* RKHTTPUtilities.m */; };
+		25F53AE515E7B612008B54E6 /* RKHTTPUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 25F53AE115E7B612008B54E6 /* RKHTTPUtilities.m */; };
+		25F53F391606269400A093BE /* RKObjectRequestOperationSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 25F53F381606269400A093BE /* RKObjectRequestOperationSubclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25F53F3A1606269400A093BE /* RKObjectRequestOperationSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 25F53F381606269400A093BE /* RKObjectRequestOperationSubclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25FABED014E3796400E609E7 /* RKTestNotificationObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 252EFAFD14D8EB30004863C8 /* RKTestNotificationObserver.m */; };
+		25FABED114E3796400E609E7 /* RKTestNotificationObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 252EFAFD14D8EB30004863C8 /* RKTestNotificationObserver.m */; };
+		25FABED214E3796B00E609E7 /* RKTestNotificationObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 252EFAFC14D8EB30004863C8 /* RKTestNotificationObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25FABED314E3796C00E609E7 /* RKTestNotificationObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 252EFAFC14D8EB30004863C8 /* RKTestNotificationObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25FBB852159272DD00955D27 /* RKRouter.h in Headers */ = {isa = PBXBuildFile; fileRef = 25FBB850159272DD00955D27 /* RKRouter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25FBB853159272DD00955D27 /* RKRouter.h in Headers */ = {isa = PBXBuildFile; fileRef = 25FBB850159272DD00955D27 /* RKRouter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		25FBB854159272DD00955D27 /* RKRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = 25FBB851159272DD00955D27 /* RKRouter.m */; };
+		25FBB855159272DD00955D27 /* RKRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = 25FBB851159272DD00955D27 /* RKRouter.m */; };
+		54CDB45B17B408B100FAC285 /* RKStringTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 54CDB45917B408B100FAC285 /* RKStringTokenizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		54CDB45C17B408B100FAC285 /* RKStringTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 54CDB45917B408B100FAC285 /* RKStringTokenizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		54CDB45D17B408B100FAC285 /* RKStringTokenizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 54CDB45A17B408B100FAC285 /* RKStringTokenizer.m */; };
+		54CDB45E17B408B100FAC285 /* RKStringTokenizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 54CDB45A17B408B100FAC285 /* RKStringTokenizer.m */; };
+		5C927E141608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C927E131608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m */; };
+		5C927E151608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C927E131608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m */; };
+		5CCC295615B7124A0045F0F5 /* RKMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CCC295515B7124A0045F0F5 /* RKMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5CCC295715B7124A0045F0F5 /* RKMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CCC295515B7124A0045F0F5 /* RKMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		73D3907414CA1AE00093E3D6 /* parent.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907114CA19F90093E3D6 /* parent.json */; };
+		73D3907514CA1AE20093E3D6 /* parent.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907114CA19F90093E3D6 /* parent.json */; };
+		73D3907614CA1AE60093E3D6 /* child.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907314CA1A4A0093E3D6 /* child.json */; };
+		73D3907714CA1AE60093E3D6 /* child.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907314CA1A4A0093E3D6 /* child.json */; };
+		73D3907914CA1DD40093E3D6 /* channels.xml in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907814CA1D710093E3D6 /* channels.xml */; };
+		73D3907A14CA1DD50093E3D6 /* channels.xml in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907814CA1D710093E3D6 /* channels.xml */; };
+		7AF2905218DF249C009AEB94 /* RKObjectiveCppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2501405215366000004E0466 /* RKObjectiveCppTest.mm */; };
+		7F9CBC6174004E31AEC35813 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 86EC453810D648768BF62304 /* libPods-osx.a */; };
+		BE05BDD11782109F00F7C9C9 /* RKRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */; };
+		BE05BDD2178214AA00F7C9C9 /* RKRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */; };
+		C0F11CE3190883380054AEA0 /* RKPathMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C0F11CE1190883380054AEA0 /* RKPathMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C0F11CE4190883380054AEA0 /* RKPathMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F11CE2190883380054AEA0 /* RKPathMatcher.m */; };
+		C0F11CE5190883460054AEA0 /* RKPathMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C0F11CE1190883380054AEA0 /* RKPathMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C0F11CE6190883460054AEA0 /* RKPathMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F11CE2190883380054AEA0 /* RKPathMatcher.m */; };
+		C0F11CE81908C7E60054AEA0 /* RKCoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = C0F11CE71908C7E60054AEA0 /* RKCoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C0F11CE91908C7E60054AEA0 /* RKCoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = C0F11CE71908C7E60054AEA0 /* RKCoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E2F2B89961FC462B981CEB7A /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E457EFC3D502479D8B4FCF2A /* libPods-ios.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		25160D2C14564E820060A5C5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 25160D0D14564E810060A5C5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 25160D1514564E810060A5C5;
+			remoteInfo = RestKit;
+		};
+		25160E7B145651060060A5C5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 25160D0D14564E810060A5C5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 25160E61145651060060A5C5;
+			remoteInfo = RestKitFramework;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		250CA67F147D8EEC0047D347 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		04D69B4B2A54475834B333CF /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
+		061E3E4524CE8EF78257C26C /* Pods-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.release.xcconfig"; sourceTree = "<group>"; };
+		147F950728350A64F103F55D /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
+		2501405215366000004E0466 /* RKObjectiveCppTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RKObjectiveCppTest.mm; sourceTree = "<group>"; };
+		2502C8E715F79CF70060FD75 /* CoreData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreData.h; sourceTree = "<group>"; };
+		2502C8E815F79CF70060FD75 /* Network.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Network.h; sourceTree = "<group>"; };
+		2502C8E915F79CF70060FD75 /* ObjectMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectMapping.h; sourceTree = "<group>"; };
+		2502C8EA15F79CF70060FD75 /* Search.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Search.h; sourceTree = "<group>"; };
+		2502C8EB15F79CF70060FD75 /* Support.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Support.h; sourceTree = "<group>"; };
+		2502C8EC15F79CF70060FD75 /* Testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Testing.h; sourceTree = "<group>"; };
+		25055B8014EEF32A00B9C4DD /* RKMappingTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RKMappingTest.h; path = Testing/RKMappingTest.h; sourceTree = "<group>"; };
+		25055B8114EEF32A00B9C4DD /* RKMappingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKMappingTest.m; path = Testing/RKMappingTest.m; sourceTree = "<group>"; };
+		25055B8214EEF32A00B9C4DD /* RKTestFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RKTestFactory.h; path = Testing/RKTestFactory.h; sourceTree = "<group>"; };
+		25055B8314EEF32A00B9C4DD /* RKTestFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKTestFactory.m; path = Testing/RKTestFactory.m; sourceTree = "<group>"; };
+		25055B8D14EEF40000B9C4DD /* RKPropertyMappingTestExpectation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RKPropertyMappingTestExpectation.h; path = Testing/RKPropertyMappingTestExpectation.h; sourceTree = "<group>"; };
+		25055B8E14EEF40000B9C4DD /* RKPropertyMappingTestExpectation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKPropertyMappingTestExpectation.m; path = Testing/RKPropertyMappingTestExpectation.m; sourceTree = "<group>"; };
+		25079C75151B952200266AE7 /* NSEntityDescription+RKAdditionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSEntityDescription+RKAdditionsTest.m"; sourceTree = "<group>"; };
+		2507C325161BD5C700EA71FF /* RKTestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RKTestHelpers.h; path = Testing/RKTestHelpers.h; sourceTree = "<group>"; };
+		2507C326161BD5C700EA71FF /* RKTestHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKTestHelpers.m; path = Testing/RKTestHelpers.m; sourceTree = "<group>"; };
+		25104F1315C30CD900829135 /* RKSearchWord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKSearchWord.h; sourceTree = "<group>"; };
+		25104F1415C30CD900829135 /* RKSearchWord.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKSearchWord.m; sourceTree = "<group>"; };
+		25104F2715C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RKManagedObjectStore+RKSearchAdditions.h"; sourceTree = "<group>"; };
+		25104F2815C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RKManagedObjectStore+RKSearchAdditions.m"; sourceTree = "<group>"; };
+		25104F2D15C30E7400829135 /* RKSearchIndexer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKSearchIndexer.h; sourceTree = "<group>"; };
+		25104F2E15C30E7400829135 /* RKSearchIndexer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKSearchIndexer.m; sourceTree = "<group>"; };
+		25104F3315C30EF500829135 /* RKSearchPredicate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKSearchPredicate.h; sourceTree = "<group>"; };
+		25104F3415C30EF500829135 /* RKSearchPredicate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKSearchPredicate.m; sourceTree = "<group>"; };
+		25104F3915C30F2000829135 /* RKSearchWordEntity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKSearchWordEntity.h; sourceTree = "<group>"; };
+		25104F3A15C30F2100829135 /* RKSearchWordEntity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKSearchWordEntity.m; sourceTree = "<group>"; };
+		25119FB5154A34B400C6BC58 /* parents_and_children.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = parents_and_children.json; sourceTree = "<group>"; };
+		25160D1614564E810060A5C5 /* libRestKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRestKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		25160D1914564E810060A5C5 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		25160D2614564E820060A5C5 /* RestKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RestKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		25160D2914564E820060A5C5 /* UIKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		25160D4C145650490060A5C5 /* RKEntityMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKEntityMapping.h; sourceTree = "<group>"; };
+		25160D4D145650490060A5C5 /* RKEntityMapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKEntityMapping.m; sourceTree = "<group>"; };
+		25160D50145650490060A5C5 /* RKManagedObjectImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKManagedObjectImporter.h; sourceTree = "<group>"; };
+		25160D51145650490060A5C5 /* RKManagedObjectImporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKManagedObjectImporter.m; sourceTree = "<group>"; };
+		25160D52145650490060A5C5 /* RKManagedObjectStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKManagedObjectStore.h; sourceTree = "<group>"; };
+		25160D53145650490060A5C5 /* RKManagedObjectStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKManagedObjectStore.m; sourceTree = "<group>"; };
+		25160D56145650490060A5C5 /* RKPropertyInspector+CoreData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RKPropertyInspector+CoreData.h"; sourceTree = "<group>"; };
+		25160D57145650490060A5C5 /* RKPropertyInspector+CoreData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RKPropertyInspector+CoreData.m"; sourceTree = "<group>"; };
+		25160D7C145650490060A5C5 /* RKDynamicMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKDynamicMapping.h; sourceTree = "<group>"; };
+		25160D7D145650490060A5C5 /* RKDynamicMapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKDynamicMapping.m; sourceTree = "<group>"; };
+		25160D7E145650490060A5C5 /* RKErrorMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKErrorMessage.h; sourceTree = "<group>"; };
+		25160D7F145650490060A5C5 /* RKErrorMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKErrorMessage.m; sourceTree = "<group>"; };
+		25160D82145650490060A5C5 /* RKAttributeMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKAttributeMapping.h; sourceTree = "<group>"; };
+		25160D83145650490060A5C5 /* RKAttributeMapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKAttributeMapping.m; sourceTree = "<group>"; };
+		25160D89145650490060A5C5 /* RKMapperOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMapperOperation.h; sourceTree = "<group>"; };
+		25160D8A145650490060A5C5 /* RKMapperOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKMapperOperation.m; sourceTree = "<group>"; };
+		25160D8B145650490060A5C5 /* RKMapperOperation_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMapperOperation_Private.h; sourceTree = "<group>"; };
+		25160D8D145650490060A5C5 /* RKObjectMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKObjectMapping.h; sourceTree = "<group>"; };
+		25160D8E145650490060A5C5 /* RKObjectMapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectMapping.m; sourceTree = "<group>"; };
+		25160D8F145650490060A5C5 /* RKMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMapping.h; sourceTree = "<group>"; };
+		25160D90145650490060A5C5 /* RKMappingOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMappingOperation.h; sourceTree = "<group>"; };
+		25160D91145650490060A5C5 /* RKMappingOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = RKMappingOperation.m; sourceTree = "<group>"; };
+		25160D94145650490060A5C5 /* RKMappingResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMappingResult.h; sourceTree = "<group>"; };
+		25160D95145650490060A5C5 /* RKMappingResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKMappingResult.m; sourceTree = "<group>"; };
+		25160D96145650490060A5C5 /* RKPropertyInspector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKPropertyInspector.h; sourceTree = "<group>"; };
+		25160D97145650490060A5C5 /* RKPropertyInspector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKPropertyInspector.m; sourceTree = "<group>"; };
+		25160D98145650490060A5C5 /* RKRelationshipMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKRelationshipMapping.h; sourceTree = "<group>"; };
+		25160D99145650490060A5C5 /* RKRelationshipMapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRelationshipMapping.m; sourceTree = "<group>"; };
+		25160DA1145650490060A5C5 /* RestKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RestKit.h; sourceTree = "<group>"; };
+		25160DA5145650490060A5C5 /* lcl_config_components_RK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lcl_config_components_RK.h; sourceTree = "<group>"; };
+		25160DA6145650490060A5C5 /* lcl_config_extensions_RK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lcl_config_extensions_RK.h; sourceTree = "<group>"; };
+		25160DA7145650490060A5C5 /* lcl_config_logger_RK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lcl_config_logger_RK.h; sourceTree = "<group>"; };
+		25160DBB145650490060A5C5 /* RestKit-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RestKit-Prefix.pch"; sourceTree = "<group>"; };
+		25160DBE145650490060A5C5 /* RKDotNetDateFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKDotNetDateFormatter.h; sourceTree = "<group>"; };
+		25160DBF145650490060A5C5 /* RKDotNetDateFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKDotNetDateFormatter.m; sourceTree = "<group>"; };
+		25160DC1145650490060A5C5 /* RKLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKLog.h; sourceTree = "<group>"; };
+		25160DC2145650490060A5C5 /* RKLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKLog.m; sourceTree = "<group>"; };
+		25160DC3145650490060A5C5 /* RKMIMETypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMIMETypes.h; sourceTree = "<group>"; };
+		25160DC4145650490060A5C5 /* RKMIMETypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKMIMETypes.m; sourceTree = "<group>"; };
+		25160DC5145650490060A5C5 /* RKSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKSerialization.h; sourceTree = "<group>"; };
+		25160E62145651060060A5C5 /* RestKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RestKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		25160E63145651060060A5C5 /* Cocoa.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		25160E66145651060060A5C5 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		25160E67145651060060A5C5 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		25160E68145651060060A5C5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		25160E78145651060060A5C5 /* RestKitFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RestKitFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		25160EA21456532C0060A5C5 /* lcl_RK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lcl_RK.h; sourceTree = "<group>"; };
+		25160EA31456532C0060A5C5 /* lcl_RK.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = lcl_RK.m; sourceTree = "<group>"; };
+		25160EA71456532C0060A5C5 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
+		25160EB01456532C0060A5C5 /* LCLNSLog_RK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LCLNSLog_RK.h; sourceTree = "<group>"; };
+		25160EB11456532C0060A5C5 /* LCLNSLog_RK.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LCLNSLog_RK.m; sourceTree = "<group>"; };
+		25160EBD1456532C0060A5C5 /* SOCKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SOCKit.h; sourceTree = "<group>"; };
+		25160EBE1456532C0060A5C5 /* SOCKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SOCKit.m; sourceTree = "<group>"; };
+		25160F161456538B0060A5C5 /* libxml2.dylib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
+		25160F7B145657220060A5C5 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = SDKs/MacOSX10.7.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		25160F7D1456572F0060A5C5 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		25160FC71456F2330060A5C5 /* RKManagedObjectLoaderTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKManagedObjectLoaderTest.m; sourceTree = "<group>"; };
+		25160FC91456F2330060A5C5 /* RKEntityMappingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKEntityMappingTest.m; sourceTree = "<group>"; };
+		25160FCB1456F2330060A5C5 /* RKManagedObjectStoreTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKManagedObjectStoreTest.m; sourceTree = "<group>"; };
+		25160FCF1456F2330060A5C5 /* blake.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = blake.png; sourceTree = "<group>"; };
+		25160FD11456F2330060A5C5 /* ArrayOfNestedDictionaries.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ArrayOfNestedDictionaries.json; sourceTree = "<group>"; };
+		25160FD21456F2330060A5C5 /* ArrayOfResults.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ArrayOfResults.json; sourceTree = "<group>"; };
+		25160FD31456F2330060A5C5 /* ComplexNestedUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ComplexNestedUser.json; sourceTree = "<group>"; };
+		25160FD41456F2330060A5C5 /* ConnectingParents.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ConnectingParents.json; sourceTree = "<group>"; };
+		25160FD61456F2330060A5C5 /* boy.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = boy.json; sourceTree = "<group>"; };
+		25160FD71456F2330060A5C5 /* friends.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = friends.json; sourceTree = "<group>"; };
+		25160FD81456F2330060A5C5 /* girl.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = girl.json; sourceTree = "<group>"; };
+		25160FD91456F2330060A5C5 /* mixed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = mixed.json; sourceTree = "<group>"; };
+		25160FDA1456F2330060A5C5 /* DynamicKeys.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = DynamicKeys.json; sourceTree = "<group>"; };
+		25160FDB1456F2330060A5C5 /* DynamicKeysWithNestedRelationship.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = DynamicKeysWithNestedRelationship.json; sourceTree = "<group>"; };
+		25160FDC1456F2330060A5C5 /* DynamicKeysWithRelationship.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = DynamicKeysWithRelationship.json; sourceTree = "<group>"; };
+		25160FDD1456F2330060A5C5 /* error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = error.json; sourceTree = "<group>"; };
+		25160FDE1456F2330060A5C5 /* errors.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = errors.json; sourceTree = "<group>"; };
+		25160FDF1456F2330060A5C5 /* Foursquare.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Foursquare.json; sourceTree = "<group>"; };
+		25160FE11456F2330060A5C5 /* 1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 1.json; sourceTree = "<group>"; };
+		25160FE21456F2330060A5C5 /* all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = all.json; sourceTree = "<group>"; };
+		25160FE31456F2330060A5C5 /* with_to_one_relationship.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = with_to_one_relationship.json; sourceTree = "<group>"; };
+		25160FE41456F2330060A5C5 /* nested_user.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = nested_user.json; sourceTree = "<group>"; };
+		25160FE51456F2330060A5C5 /* RailsUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = RailsUser.json; sourceTree = "<group>"; };
+		25160FE61456F2330060A5C5 /* SameKeyDifferentTargetClasses.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SameKeyDifferentTargetClasses.json; sourceTree = "<group>"; };
+		25160FE71456F2330060A5C5 /* user.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = user.json; sourceTree = "<group>"; };
+		25160FE81456F2330060A5C5 /* users.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = users.json; sourceTree = "<group>"; };
+		25160FEA1456F2330060A5C5 /* .gitignore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		25160FED1456F2330060A5C5 /* attributes_without_text_content.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = attributes_without_text_content.xml; sourceTree = "<group>"; };
+		25160FEE1456F2330060A5C5 /* container_attributes.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = container_attributes.xml; sourceTree = "<group>"; };
+		25160FEF1456F2330060A5C5 /* national_weather_service.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = national_weather_service.xml; sourceTree = "<group>"; };
+		25160FF01456F2330060A5C5 /* orders.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = orders.xml; sourceTree = "<group>"; };
+		25160FF11456F2330060A5C5 /* tab_data.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = tab_data.xml; sourceTree = "<group>"; };
+		25160FF21456F2330060A5C5 /* zend.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = zend.xml; sourceTree = "<group>"; };
+		25160FF41456F2330060A5C5 /* Data Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Data Model.xcdatamodel"; sourceTree = "<group>"; };
+		25160FF51456F2330060A5C5 /* RKCat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKCat.h; sourceTree = "<group>"; };
+		25160FF61456F2330060A5C5 /* RKCat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKCat.m; sourceTree = "<group>"; };
+		25160FF71456F2330060A5C5 /* RKChild.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKChild.h; sourceTree = "<group>"; };
+		25160FF81456F2330060A5C5 /* RKChild.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKChild.m; sourceTree = "<group>"; };
+		25160FF91456F2330060A5C5 /* RKDynamicMappingModels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKDynamicMappingModels.h; sourceTree = "<group>"; };
+		25160FFA1456F2330060A5C5 /* RKDynamicMappingModels.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKDynamicMappingModels.m; sourceTree = "<group>"; };
+		25160FFB1456F2330060A5C5 /* RKHouse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKHouse.h; sourceTree = "<group>"; };
+		25160FFC1456F2330060A5C5 /* RKHouse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKHouse.m; sourceTree = "<group>"; };
+		25160FFD1456F2330060A5C5 /* RKHuman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKHuman.h; sourceTree = "<group>"; };
+		25160FFE1456F2330060A5C5 /* RKHuman.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKHuman.m; sourceTree = "<group>"; };
+		25160FFF1456F2330060A5C5 /* RKMappableAssociation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMappableAssociation.h; sourceTree = "<group>"; };
+		251610001456F2330060A5C5 /* RKMappableAssociation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKMappableAssociation.m; sourceTree = "<group>"; };
+		251610011456F2330060A5C5 /* RKMappableObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMappableObject.h; sourceTree = "<group>"; };
+		251610021456F2330060A5C5 /* RKMappableObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKMappableObject.m; sourceTree = "<group>"; };
+		251610031456F2330060A5C5 /* RKObjectLoaderTestResultModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKObjectLoaderTestResultModel.h; sourceTree = "<group>"; };
+		251610041456F2330060A5C5 /* RKObjectLoaderTestResultModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectLoaderTestResultModel.m; sourceTree = "<group>"; };
+		251610051456F2330060A5C5 /* RKObjectMapperTestModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKObjectMapperTestModel.h; sourceTree = "<group>"; };
+		251610061456F2330060A5C5 /* RKObjectMapperTestModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectMapperTestModel.m; sourceTree = "<group>"; };
+		251610071456F2330060A5C5 /* RKParent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKParent.h; sourceTree = "<group>"; };
+		251610081456F2330060A5C5 /* RKParent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKParent.m; sourceTree = "<group>"; };
+		251610091456F2330060A5C5 /* RKResident.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKResident.h; sourceTree = "<group>"; };
+		2516100A1456F2330060A5C5 /* RKResident.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKResident.m; sourceTree = "<group>"; };
+		2516101C1456F2330060A5C5 /* RKDynamicMappingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKDynamicMappingTest.m; sourceTree = "<group>"; };
+		2516101F1456F2330060A5C5 /* RKObjectManagerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectManagerTest.m; sourceTree = "<group>"; };
+		251610211456F2330060A5C5 /* RKObjectMappingNextGenTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = RKObjectMappingNextGenTest.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		251610221456F2330060A5C5 /* RKMappingOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = RKMappingOperationTest.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		251610241456F2330060A5C5 /* RKMappingResultTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKMappingResultTest.m; sourceTree = "<group>"; };
+		251610261456F2330060A5C5 /* RKObjectParameterizationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectParameterizationTest.m; sourceTree = "<group>"; };
+		251610271456F2330060A5C5 /* RKMIMETypeSerializationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKMIMETypeSerializationTest.m; sourceTree = "<group>"; };
+		251610351456F2330060A5C5 /* RKTestEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKTestEnvironment.h; sourceTree = "<group>"; };
+		251610361456F2330060A5C5 /* RKTestEnvironment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKTestEnvironment.m; sourceTree = "<group>"; };
+		251610501456F2330060A5C5 /* server.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = server.rb; sourceTree = "<group>"; };
+		251610521456F2330060A5C5 /* RKURLEncodedSerializationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKURLEncodedSerializationTest.m; sourceTree = "<group>"; };
+		251610531456F2330060A5C5 /* NSStringRestKitTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringRestKitTest.m; sourceTree = "<group>"; };
+		251610541456F2330060A5C5 /* RKDotNetDateFormatterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKDotNetDateFormatterTest.m; sourceTree = "<group>"; };
+		251610561456F2330060A5C5 /* RKPathMatcherTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKPathMatcherTest.m; sourceTree = "<group>"; };
+		251611281456F50F0060A5C5 /* SystemConfiguration.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		2516112A1456F5170060A5C5 /* CFNetwork.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		2516112D1456F5520060A5C5 /* CoreData.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		2516112F1456F5590060A5C5 /* Security.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		251611311456F56C0060A5C5 /* MobileCoreServices.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		2519764215823BA1004FE9DD /* RKAttributeMappingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKAttributeMappingTest.m; sourceTree = "<group>"; };
+		2519764715824455004FE9DD /* RKRelationshipMappingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRelationshipMappingTest.m; sourceTree = "<group>"; };
+		2519764B158244F8004FE9DD /* RKObjectMappingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectMappingTest.m; sourceTree = "<group>"; };
+		252028FA1577AE0B00076FB4 /* RKRouteSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKRouteSet.h; sourceTree = "<group>"; };
+		252028FB1577AE0B00076FB4 /* RKRouteSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRouteSet.m; sourceTree = "<group>"; };
+		252029011577AE1800076FB4 /* RKRoute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKRoute.h; sourceTree = "<group>"; };
+		252029021577AE1800076FB4 /* RKRoute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRoute.m; sourceTree = "<group>"; };
+		252029081577C78600076FB4 /* RKRouteSetTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRouteSetTest.m; sourceTree = "<group>"; };
+		252205CB162B242400F7B11E /* RKHTTPUtilitiesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKHTTPUtilitiesTest.m; sourceTree = "<group>"; };
+		252CCE6017E08E2D00B7F0BF /* RKValueTransformers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKValueTransformers.h; sourceTree = "<group>"; };
+		252CCE6117E08E2D00B7F0BF /* RKValueTransformers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKValueTransformers.m; sourceTree = "<group>"; };
+		252CCE6E17E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ISO8601DateFormatterValueTransformer.h; sourceTree = "<group>"; };
+		252CCE6F17E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ISO8601DateFormatterValueTransformer.m; sourceTree = "<group>"; };
+		252CCE7017E0CA2700B7F0BF /* RKISO8601DateFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKISO8601DateFormatter.h; sourceTree = "<group>"; };
+		252CCE7117E0CA2700B7F0BF /* RKISO8601DateFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKISO8601DateFormatter.m; sourceTree = "<group>"; };
+		252EFAF814D8EAEC004863C8 /* RKEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKEvent.h; sourceTree = "<group>"; };
+		252EFAF914D8EAEC004863C8 /* RKEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKEvent.m; sourceTree = "<group>"; };
+		252EFAFC14D8EB30004863C8 /* RKTestNotificationObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RKTestNotificationObserver.h; path = Testing/RKTestNotificationObserver.h; sourceTree = "<group>"; };
+		252EFAFD14D8EB30004863C8 /* RKTestNotificationObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKTestNotificationObserver.m; path = Testing/RKTestNotificationObserver.m; sourceTree = "<group>"; };
+		252EFB2014D9B35D004863C8 /* RKTestFixture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RKTestFixture.h; path = Testing/RKTestFixture.h; sourceTree = "<group>"; };
+		252EFB2114D9B35D004863C8 /* RKTestFixture.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKTestFixture.m; path = Testing/RKTestFixture.m; sourceTree = "<group>"; };
+		252EFB2714DA0689004863C8 /* NakedEvents.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = NakedEvents.json; sourceTree = "<group>"; };
+		253477EF15FFBC60002C0E4E /* RKDictionaryUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKDictionaryUtilities.h; sourceTree = "<group>"; };
+		253477F015FFBC60002C0E4E /* RKDictionaryUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKDictionaryUtilities.m; sourceTree = "<group>"; };
+		2534781415FFD4A6002C0E4E /* RKURLEncodedSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKURLEncodedSerialization.m; sourceTree = "<group>"; };
+		2534781515FFD4A6002C0E4E /* RKURLEncodedSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKURLEncodedSerialization.h; sourceTree = "<group>"; };
+		2536D1FC167270F100DF9BB0 /* RKRouterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRouterTest.m; sourceTree = "<group>"; };
+		254372A615F54995006E8424 /* RKObjectParameterization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKObjectParameterization.h; sourceTree = "<group>"; };
+		254372A715F54995006E8424 /* RKObjectParameterization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectParameterization.m; sourceTree = "<group>"; };
+		254372AA15F54C3F006E8424 /* RKHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKHTTPRequestOperation.h; sourceTree = "<group>"; };
+		254372AB15F54C3F006E8424 /* RKHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKHTTPRequestOperation.m; sourceTree = "<group>"; };
+		254372AC15F54C3F006E8424 /* RKObjectManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKObjectManager.h; sourceTree = "<group>"; };
+		254372AD15F54C3F006E8424 /* RKObjectManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectManager.m; sourceTree = "<group>"; };
+		254372AE15F54C3F006E8424 /* RKPaginator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKPaginator.h; sourceTree = "<group>"; };
+		254372AF15F54C3F006E8424 /* RKPaginator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKPaginator.m; sourceTree = "<group>"; };
+		254372B015F54C3F006E8424 /* RKObjectRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKObjectRequestOperation.h; sourceTree = "<group>"; };
+		254372B115F54C3F006E8424 /* RKObjectRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectRequestOperation.m; sourceTree = "<group>"; };
+		254372B215F54C3F006E8424 /* RKRequestDescriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKRequestDescriptor.h; sourceTree = "<group>"; };
+		254372B315F54C3F006E8424 /* RKRequestDescriptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRequestDescriptor.m; sourceTree = "<group>"; };
+		254372B415F54C3F006E8424 /* RKResponseDescriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKResponseDescriptor.h; sourceTree = "<group>"; };
+		254372B515F54C3F006E8424 /* RKResponseDescriptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKResponseDescriptor.m; sourceTree = "<group>"; };
+		254372B615F54C3F006E8424 /* RKResponseMapperOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKResponseMapperOperation.h; sourceTree = "<group>"; };
+		254372B715F54C3F006E8424 /* RKResponseMapperOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKResponseMapperOperation.m; sourceTree = "<group>"; };
+		254372D415F54CE3006E8424 /* RKManagedObjectRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKManagedObjectRequestOperation.h; sourceTree = "<group>"; };
+		254372D515F54CE3006E8424 /* RKManagedObjectRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKManagedObjectRequestOperation.m; sourceTree = "<group>"; };
+		2546A95716628EDD0078E044 /* RKConnectionDescriptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKConnectionDescriptionTest.m; sourceTree = "<group>"; };
+		2548AC6C162F5E00009E79BF /* RKManagedObjectRequestOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKManagedObjectRequestOperationTest.m; sourceTree = "<group>"; };
+		2549D645162B376F003DD135 /* RKRequestDescriptorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRequestDescriptorTest.m; sourceTree = "<group>"; };
+		254A62BF14AD591C00939BEE /* RKPaginatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKPaginatorTest.m; sourceTree = "<group>"; };
+		2550DA2116B1FB62005A0CB8 /* RKPost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKPost.h; sourceTree = "<group>"; };
+		2550DA2216B1FB62005A0CB8 /* RKPost.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKPost.m; sourceTree = "<group>"; };
+		2551338E167838590017E4B6 /* RKHTTPRequestOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKHTTPRequestOperationTest.m; sourceTree = "<group>"; };
+		25565955161FC3C300F5BB20 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/System/Library/Frameworks/CoreServices.framework; sourceTree = DEVELOPER_DIR; };
+		25565958161FC3CD00F5BB20 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		25565964161FDD8800F5BB20 /* RKResponseMapperOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKResponseMapperOperationTest.m; sourceTree = "<group>"; };
+		2564E40A16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRelationshipConnectionOperationTest.m; sourceTree = "<group>"; };
+		257ABAAE15112DD400CCAA76 /* NSManagedObjectContext+RKAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSManagedObjectContext+RKAdditions.h"; sourceTree = "<group>"; };
+		257ABAAF15112DD400CCAA76 /* NSManagedObjectContext+RKAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObjectContext+RKAdditions.m"; sourceTree = "<group>"; };
+		257ABAB41511371C00CCAA76 /* NSManagedObject+RKAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+RKAdditions.h"; sourceTree = "<group>"; };
+		257ABAB51511371D00CCAA76 /* NSManagedObject+RKAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+RKAdditions.m"; sourceTree = "<group>"; };
+		2582F56C173038750043B8BB /* RKInMemoryManagedObjectCacheTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKInMemoryManagedObjectCacheTest.m; sourceTree = "<group>"; };
+		258BEA01168D058300C74C8C /* RKObjectMappingMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectMappingMatcher.m; sourceTree = "<group>"; };
+		258EA4A615A38BBF007E07A6 /* RKObjectMappingOperationDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKObjectMappingOperationDataSource.h; sourceTree = "<group>"; };
+		258EA4A715A38BBF007E07A6 /* RKObjectMappingOperationDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectMappingOperationDataSource.m; sourceTree = "<group>"; };
+		258EA4AD15A38E7D007E07A6 /* RKMappingOperationDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMappingOperationDataSource.h; sourceTree = "<group>"; };
+		258EA4B015A3908F007E07A6 /* RKManagedObjectMappingOperationDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKManagedObjectMappingOperationDataSource.h; sourceTree = "<group>"; };
+		258EFF7915C0CE1400EE4E0D /* RKManagedObjectSeederTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKManagedObjectSeederTest.m; sourceTree = "<group>"; };
+		2595B46B15F670530087A59B /* RKMIMETypeSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMIMETypeSerialization.h; sourceTree = "<group>"; };
+		2595B46C15F670530087A59B /* RKMIMETypeSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKMIMETypeSerialization.m; sourceTree = "<group>"; };
+		2595B46D15F670530087A59B /* RKNSJSONSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKNSJSONSerialization.h; sourceTree = "<group>"; };
+		2595B46E15F670530087A59B /* RKNSJSONSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKNSJSONSerialization.m; sourceTree = "<group>"; };
+		2597F99A15AF6DC400E547D7 /* RKRelationshipConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKRelationshipConnectionOperation.h; sourceTree = "<group>"; };
+		2597F99B15AF6DC400E547D7 /* RKRelationshipConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRelationshipConnectionOperation.m; sourceTree = "<group>"; };
+		2598888B15EC169E006CAE95 /* RKPropertyMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKPropertyMapping.h; sourceTree = "<group>"; };
+		2598888C15EC169E006CAE95 /* RKPropertyMapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKPropertyMapping.m; sourceTree = "<group>"; };
+		259AC480162B05C80012D2F9 /* RKObjectRequestOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectRequestOperationTest.m; sourceTree = "<group>"; };
+		259B96C21604CCCC0000C250 /* AFHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPClient.h; sourceTree = "<group>"; };
+		259B96C31604CCCC0000C250 /* AFHTTPClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPClient.m; sourceTree = "<group>"; };
+		259B96C41604CCCC0000C250 /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPRequestOperation.h; sourceTree = "<group>"; };
+		259B96C51604CCCC0000C250 /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPRequestOperation.m; sourceTree = "<group>"; };
+		259B96C61604CCCC0000C250 /* AFImageRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFImageRequestOperation.h; sourceTree = "<group>"; };
+		259B96C71604CCCC0000C250 /* AFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageRequestOperation.m; sourceTree = "<group>"; };
+		259B96C81604CCCC0000C250 /* AFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONRequestOperation.h; sourceTree = "<group>"; };
+		259B96C91604CCCC0000C250 /* AFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONRequestOperation.m; sourceTree = "<group>"; };
+		259B96CA1604CCCC0000C250 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
+		259B96CB1604CCCC0000C250 /* AFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFPropertyListRequestOperation.h; sourceTree = "<group>"; };
+		259B96CC1604CCCC0000C250 /* AFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFPropertyListRequestOperation.m; sourceTree = "<group>"; };
+		259B96CD1604CCCC0000C250 /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLConnectionOperation.h; sourceTree = "<group>"; };
+		259B96CE1604CCCC0000C250 /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLConnectionOperation.m; sourceTree = "<group>"; };
+		259B96CF1604CCCC0000C250 /* AFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFXMLRequestOperation.h; sourceTree = "<group>"; };
+		259B96D01604CCCC0000C250 /* AFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLRequestOperation.m; sourceTree = "<group>"; };
+		259B96D11604CCCC0000C250 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
+		259B96D21604CCCC0000C250 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
+		259B96D31604CCCC0000C250 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
+		259B96D41604CCCC0000C250 /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
+		259D983B154F6C90008C90F5 /* benchmark_parents_and_children.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = benchmark_parents_and_children.json; sourceTree = "<group>"; };
+		259D98521550C69A008C90F5 /* RKEntityByAttributeCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKEntityByAttributeCache.h; sourceTree = "<group>"; };
+		259D98531550C69A008C90F5 /* RKEntityByAttributeCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKEntityByAttributeCache.m; sourceTree = "<group>"; };
+		259D98591550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKEntityByAttributeCacheTest.m; sourceTree = "<group>"; };
+		259D985C155218E4008C90F5 /* RKEntityCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKEntityCache.h; sourceTree = "<group>"; };
+		259D985D155218E4008C90F5 /* RKEntityCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKEntityCache.m; sourceTree = "<group>"; };
+		259D986315521B1F008C90F5 /* RKEntityCacheTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKEntityCacheTest.m; sourceTree = "<group>"; };
+		25A199D216ED035A00792629 /* RKBenchmark.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RKBenchmark.h; path = Testing/RKBenchmark.h; sourceTree = "<group>"; };
+		25A199D316ED035A00792629 /* RKBenchmark.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKBenchmark.m; path = Testing/RKBenchmark.m; sourceTree = "<group>"; };
+		25A226D41618A57500952D72 /* RKObjectUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKObjectUtilities.h; sourceTree = "<group>"; };
+		25A226D51618A57500952D72 /* RKObjectUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKObjectUtilities.m; sourceTree = "<group>"; };
+		25A34244147D8AAA0009758D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		25A73361169C8C230090A930 /* VersionedModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = VersionedModel.xcdatamodel; sourceTree = "<group>"; };
+		25A73365169C8CD80090A930 /* VersionedModel 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "VersionedModel 2.xcdatamodel"; sourceTree = "<group>"; };
+		25A73366169C8CF30090A930 /* VersionedModel 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "VersionedModel 3.xcdatamodel"; sourceTree = "<group>"; };
+		25A73367169C8D500090A930 /* VersionedModel 4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "VersionedModel 4.xcdatamodel"; sourceTree = "<group>"; };
+		25A763E415C7424500A9DF31 /* RKSearchIndexerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKSearchIndexerTest.m; sourceTree = "<group>"; };
+		25A8C2321673BD480014D9A6 /* RKConnectionTestExpectation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RKConnectionTestExpectation.h; path = Testing/RKConnectionTestExpectation.h; sourceTree = "<group>"; };
+		25A8C2331673BD480014D9A6 /* RKConnectionTestExpectation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKConnectionTestExpectation.m; path = Testing/RKConnectionTestExpectation.m; sourceTree = "<group>"; };
+		25AA23CF15AF291F006EF62D /* RKManagedObjectMappingOperationDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKManagedObjectMappingOperationDataSource.m; sourceTree = "<group>"; };
+		25AA23D315AF4F25006EF62D /* RKManagedObjectMappingOperationDataSourceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKManagedObjectMappingOperationDataSourceTest.m; sourceTree = "<group>"; };
+		25AABCEC17B698940061DC5B /* RKStringTokenizerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKStringTokenizerTest.m; sourceTree = "<group>"; };
+		25AFF8F015B4CF1F0051877F /* RKMappingErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = RKMappingErrors.h; sourceTree = "<group>"; };
+		25B408241491CDDB00F21111 /* RKPathUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKPathUtilities.h; sourceTree = "<group>"; };
+		25B408251491CDDB00F21111 /* RKPathUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKPathUtilities.m; sourceTree = "<group>"; };
+		25B639CB16961EFA0065EB7B /* RKMappingTestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKMappingTestTest.m; sourceTree = "<group>"; };
+		25B6E95414CF795D00B1E881 /* RKErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKErrors.h; sourceTree = "<group>"; };
+		25B6E95714CF7A1C00B1E881 /* RKErrors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKErrors.m; sourceTree = "<group>"; };
+		25B6E95A14CF7E3C00B1E881 /* RKObjectMappingMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKObjectMappingMatcher.h; sourceTree = "<group>"; };
+		25B6E9D514CF912500B1E881 /* RKSearchable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKSearchable.h; sourceTree = "<group>"; };
+		25B6E9D614CF912500B1E881 /* RKSearchable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKSearchable.m; sourceTree = "<group>"; };
+		25B6E9D714CF912500B1E881 /* RKTestAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKTestAddress.h; sourceTree = "<group>"; };
+		25B6E9D814CF912500B1E881 /* RKTestAddress.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKTestAddress.m; sourceTree = "<group>"; };
+		25B6E9D914CF912500B1E881 /* RKTestUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKTestUser.h; sourceTree = "<group>"; };
+		25B6E9DA14CF912500B1E881 /* RKTestUser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKTestUser.m; sourceTree = "<group>"; };
+		25B6EA0514CF946300B1E881 /* QuartzCore.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		25B6EA0714CF947D00B1E881 /* CoreGraphics.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		25BB392D161F4FD700E5C72A /* RKPathUtilitiesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKPathUtilitiesTest.m; sourceTree = "<group>"; };
+		25C246A315C83B090032212E /* RKSearchTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKSearchTest.m; sourceTree = "<group>"; };
+		25C6C0A51716F6F800C98A73 /* TKEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TKEvent.h; path = Code/TKEvent.h; sourceTree = "<group>"; };
+		25C6C0A61716F6F800C98A73 /* TKEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TKEvent.m; path = Code/TKEvent.m; sourceTree = "<group>"; };
+		25C6C0A71716F6F800C98A73 /* TKState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TKState.h; path = Code/TKState.h; sourceTree = "<group>"; };
+		25C6C0A81716F6F800C98A73 /* TKState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TKState.m; path = Code/TKState.m; sourceTree = "<group>"; };
+		25C6C0A91716F6F800C98A73 /* TKStateMachine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TKStateMachine.h; path = Code/TKStateMachine.h; sourceTree = "<group>"; };
+		25C6C0AA1716F6F800C98A73 /* TKStateMachine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TKStateMachine.m; path = Code/TKStateMachine.m; sourceTree = "<group>"; };
+		25C6C0AC1716F6F800C98A73 /* TransitionKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TransitionKit.h; path = Code/TransitionKit.h; sourceTree = "<group>"; };
+		25C6C0E61716F79B00C98A73 /* RKOperationStateMachine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKOperationStateMachine.h; sourceTree = "<group>"; };
+		25C6C0E71716F79B00C98A73 /* RKOperationStateMachine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKOperationStateMachine.m; sourceTree = "<group>"; };
+		25C954A415542A47005C9E08 /* RKTestConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKTestConstants.m; path = Testing/RKTestConstants.m; sourceTree = "<group>"; };
+		25CA7A8E14EC570100888FF8 /* RKMapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKMapping.m; sourceTree = "<group>"; };
+		25CAAA9315254E7800CAE5D7 /* ArrayOfHumans.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ArrayOfHumans.json; sourceTree = "<group>"; };
+		25CC5C58161DDADD0008BD21 /* RKResponseDescriptorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKResponseDescriptorTest.m; sourceTree = "<group>"; };
+		25CDA0E2161E821000F583F3 /* RKISODateFormatterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKISODateFormatterTest.m; sourceTree = "<group>"; };
+		25DA356D1836741C001A56A0 /* TKTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TKTransition.h; path = Code/TKTransition.h; sourceTree = "<group>"; };
+		25DA356E1836741C001A56A0 /* TKTransition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TKTransition.m; path = Code/TKTransition.m; sourceTree = "<group>"; };
+		25DB7507151BD551009F01AF /* NSManagedObjectContext+RKAdditionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObjectContext+RKAdditionsTest.m"; sourceTree = "<group>"; };
+		25E36E0115195CED00F9E448 /* RKFetchRequestMappingCacheTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKFetchRequestMappingCacheTest.m; sourceTree = "<group>"; };
+		25E88C86165C5CC30042ABD0 /* RKConnectionDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKConnectionDescription.h; sourceTree = "<group>"; };
+		25E88C87165C5CC30042ABD0 /* RKConnectionDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKConnectionDescription.m; sourceTree = "<group>"; };
+		25EC1AD814F8022600C3CF3F /* RestKitFramework-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RestKitFramework-Info.plist"; sourceTree = "<group>"; };
+		25EC1AD914F8022600C3CF3F /* RestKitFrameworkTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RestKitFrameworkTests-Info.plist"; sourceTree = "<group>"; };
+		25EC1ADA14F8022600C3CF3F /* RestKitTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RestKitTests-Info.plist"; sourceTree = "<group>"; };
+		25EC1B0014F8078100C3CF3F /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
+		25EC1B1E14F821B500C3CF3F /* RestKitResources-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RestKitResources-Prefix.pch"; sourceTree = "<group>"; };
+		25EC1B1F14F8220800C3CF3F /* RestKitResources-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RestKitResources-Info.plist"; sourceTree = "<group>"; };
+		25F53AE015E7B611008B54E6 /* RKHTTPUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RKHTTPUtilities.h; path = ../ObjectMapping/RKHTTPUtilities.h; sourceTree = "<group>"; };
+		25F53AE115E7B612008B54E6 /* RKHTTPUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RKHTTPUtilities.m; path = ../ObjectMapping/RKHTTPUtilities.m; sourceTree = "<group>"; };
+		25F53F381606269400A093BE /* RKObjectRequestOperationSubclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKObjectRequestOperationSubclass.h; sourceTree = "<group>"; };
+		25FBB850159272DD00955D27 /* RKRouter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKRouter.h; sourceTree = "<group>"; };
+		25FBB851159272DD00955D27 /* RKRouter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRouter.m; sourceTree = "<group>"; };
+		3E886DC0169E10A70069C56B /* has_many_with_to_one_relationship.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = has_many_with_to_one_relationship.json; sourceTree = "<group>"; };
+		3EB0D83816ADCEFC00E9CEA2 /* empty_human.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = empty_human.json; sourceTree = "<group>"; };
+		54CDB45917B408B100FAC285 /* RKStringTokenizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKStringTokenizer.h; sourceTree = "<group>"; };
+		54CDB45A17B408B100FAC285 /* RKStringTokenizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKStringTokenizer.m; sourceTree = "<group>"; };
+		5C927E131608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKDictionaryUtilitiesTest.m; sourceTree = "<group>"; };
+		5CCC295515B7124A0045F0F5 /* RKMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMacros.h; sourceTree = "<group>"; };
+		7394DF3514CF157A00CE7BCE /* RKManagedObjectCaching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKManagedObjectCaching.h; sourceTree = "<group>"; };
+		7394DF3814CF168C00CE7BCE /* RKFetchRequestManagedObjectCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKFetchRequestManagedObjectCache.h; sourceTree = "<group>"; };
+		7394DF3914CF168C00CE7BCE /* RKFetchRequestManagedObjectCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKFetchRequestManagedObjectCache.m; sourceTree = "<group>"; };
+		7394DF3C14CF19F200CE7BCE /* RKInMemoryManagedObjectCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKInMemoryManagedObjectCache.h; sourceTree = "<group>"; };
+		7394DF3D14CF19F200CE7BCE /* RKInMemoryManagedObjectCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKInMemoryManagedObjectCache.m; sourceTree = "<group>"; };
+		73D3907114CA19F90093E3D6 /* parent.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = parent.json; sourceTree = "<group>"; };
+		73D3907314CA1A4A0093E3D6 /* child.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = child.json; sourceTree = "<group>"; };
+		73D3907814CA1D710093E3D6 /* channels.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = channels.xml; sourceTree = "<group>"; };
+		86EC453810D648768BF62304 /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRouteTest.m; sourceTree = "<group>"; };
+		C0F11CE1190883380054AEA0 /* RKPathMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKPathMatcher.h; sourceTree = "<group>"; };
+		C0F11CE2190883380054AEA0 /* RKPathMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKPathMatcher.m; sourceTree = "<group>"; };
+		C0F11CE71908C7E60054AEA0 /* RKCoreData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKCoreData.h; sourceTree = "<group>"; };
+		D8EFCBE1978F7946E0081FAD /* Pods-osx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.debug.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.debug.xcconfig"; sourceTree = "<group>"; };
+		E457EFC3D502479D8B4FCF2A /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F66056291744FF9000A87A45 /* and_cats.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = and_cats.json; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		25160D1314564E810060A5C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25C20466160ABC4800D418D5 /* SystemConfiguration.framework in Frameworks */,
+				25160D1A14564E810060A5C5 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25160D2214564E820060A5C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25B6EA0814CF947E00B1E881 /* CoreGraphics.framework in Frameworks */,
+				25B6EA0614CF946400B1E881 /* QuartzCore.framework in Frameworks */,
+				251611321456F56C0060A5C5 /* MobileCoreServices.framework in Frameworks */,
+				251611301456F5590060A5C5 /* Security.framework in Frameworks */,
+				2516112E1456F5520060A5C5 /* CoreData.framework in Frameworks */,
+				2516112C1456F51D0060A5C5 /* libxml2.dylib in Frameworks */,
+				2516112B1456F5170060A5C5 /* CFNetwork.framework in Frameworks */,
+				251611291456F50F0060A5C5 /* SystemConfiguration.framework in Frameworks */,
+				25160D2A14564E820060A5C5 /* UIKit.framework in Frameworks */,
+				25160D2B14564E820060A5C5 /* Foundation.framework in Frameworks */,
+				E2F2B89961FC462B981CEB7A /* libPods-ios.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25160E5E145651060060A5C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25A34245147D8AAA0009758D /* Security.framework in Frameworks */,
+				25160F7E145657300060A5C5 /* Cocoa.framework in Frameworks */,
+				25160F7C145657220060A5C5 /* SystemConfiguration.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25160E74145651060060A5C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25565959161FC3CD00F5BB20 /* SystemConfiguration.framework in Frameworks */,
+				25565956161FC3C300F5BB20 /* CoreServices.framework in Frameworks */,
+				25160E7A145651060060A5C5 /* Cocoa.framework in Frameworks */,
+				7F9CBC6174004E31AEC35813 /* libPods-osx.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		15BB5BBD8E8B9B2C9C8B11BC /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				147F950728350A64F103F55D /* Pods-ios.debug.xcconfig */,
+				061E3E4524CE8EF78257C26C /* Pods-ios.release.xcconfig */,
+				D8EFCBE1978F7946E0081FAD /* Pods-osx.debug.xcconfig */,
+				04D69B4B2A54475834B333CF /* Pods-osx.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		25104F0E15C30C7900829135 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				25104F1315C30CD900829135 /* RKSearchWord.h */,
+				25104F1415C30CD900829135 /* RKSearchWord.m */,
+				25104F2715C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.h */,
+				25104F2815C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.m */,
+				25104F2D15C30E7400829135 /* RKSearchIndexer.h */,
+				25104F2E15C30E7400829135 /* RKSearchIndexer.m */,
+				25104F3315C30EF500829135 /* RKSearchPredicate.h */,
+				25104F3415C30EF500829135 /* RKSearchPredicate.m */,
+				25104F3915C30F2000829135 /* RKSearchWordEntity.h */,
+				25104F3A15C30F2100829135 /* RKSearchWordEntity.m */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		25104F9B15C33E3A00829135 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				25A763E415C7424500A9DF31 /* RKSearchIndexerTest.m */,
+				25C246A315C83B090032212E /* RKSearchTest.m */,
+			);
+			name = Search;
+			path = Logic/Search;
+			sourceTree = "<group>";
+		};
+		25160D0B14564E810060A5C5 = {
+			isa = PBXGroup;
+			children = (
+				25160D44145650490060A5C5 /* Code */,
+				25160FC51456F2330060A5C5 /* Tests */,
+				25EC1AD614F8022600C3CF3F /* Resources */,
+				25160E8D145652E40060A5C5 /* Vendor */,
+				25160D1814564E810060A5C5 /* Frameworks */,
+				25160D1714564E810060A5C5 /* Products */,
+				15BB5BBD8E8B9B2C9C8B11BC /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		25160D1714564E810060A5C5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				25160D1614564E810060A5C5 /* libRestKit.a */,
+				25160D2614564E820060A5C5 /* RestKitTests.xctest */,
+				25160E62145651060060A5C5 /* RestKit.framework */,
+				25160E78145651060060A5C5 /* RestKitFrameworkTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		25160D1814564E810060A5C5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				25565958161FC3CD00F5BB20 /* SystemConfiguration.framework */,
+				25565955161FC3C300F5BB20 /* CoreServices.framework */,
+				25B6EA0714CF947D00B1E881 /* CoreGraphics.framework */,
+				25B6EA0514CF946300B1E881 /* QuartzCore.framework */,
+				25A34244147D8AAA0009758D /* Security.framework */,
+				251611311456F56C0060A5C5 /* MobileCoreServices.framework */,
+				2516112F1456F5590060A5C5 /* Security.framework */,
+				2516112D1456F5520060A5C5 /* CoreData.framework */,
+				2516112A1456F5170060A5C5 /* CFNetwork.framework */,
+				251611281456F50F0060A5C5 /* SystemConfiguration.framework */,
+				25160F7D1456572F0060A5C5 /* Cocoa.framework */,
+				25160F7B145657220060A5C5 /* SystemConfiguration.framework */,
+				25160F161456538B0060A5C5 /* libxml2.dylib */,
+				25160D1914564E810060A5C5 /* Foundation.framework */,
+				25160D2914564E820060A5C5 /* UIKit.framework */,
+				25160E63145651060060A5C5 /* Cocoa.framework */,
+				25EC1B0014F8078100C3CF3F /* CoreFoundation.framework */,
+				25160E65145651060060A5C5 /* Other Frameworks */,
+				E457EFC3D502479D8B4FCF2A /* libPods-ios.a */,
+				86EC453810D648768BF62304 /* libPods-osx.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		25160D44145650490060A5C5 /* Code */ = {
+			isa = PBXGroup;
+			children = (
+				25160DA1145650490060A5C5 /* RestKit.h */,
+				2502C8E915F79CF70060FD75 /* ObjectMapping.h */,
+				25160D7A145650490060A5C5 /* ObjectMapping */,
+				2502C8E815F79CF70060FD75 /* Network.h */,
+				25160D58145650490060A5C5 /* Network */,
+				2502C8E715F79CF70060FD75 /* CoreData.h */,
+				25160D45145650490060A5C5 /* CoreData */,
+				2502C8EB15F79CF70060FD75 /* Support.h */,
+				25160DA2145650490060A5C5 /* Support */,
+				2502C8EC15F79CF70060FD75 /* Testing.h */,
+				252EFB1F14D9A8D4004863C8 /* Testing */,
+				2502C8EA15F79CF70060FD75 /* Search.h */,
+				25104F0E15C30C7900829135 /* Search */,
+			);
+			path = Code;
+			sourceTree = "<group>";
+		};
+		25160D45145650490060A5C5 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				E4081DFC15FB89DF00364948 /* ManagedObjectCaching */,
+				E4081E0715FB8FC400364948 /* Importing */,
+				E4081DFE15FB8A1D00364948 /* Additions */,
+				E4081E0915FB8FD800364948 /* Mapping */,
+				25160D52145650490060A5C5 /* RKManagedObjectStore.h */,
+				25160D53145650490060A5C5 /* RKManagedObjectStore.m */,
+				2597F99A15AF6DC400E547D7 /* RKRelationshipConnectionOperation.h */,
+				2597F99B15AF6DC400E547D7 /* RKRelationshipConnectionOperation.m */,
+				C0F11CE71908C7E60054AEA0 /* RKCoreData.h */,
+			);
+			path = CoreData;
+			sourceTree = "<group>";
+		};
+		25160D58145650490060A5C5 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				E4081E0015FB8B5900364948 /* Routing */,
+				E4081DFF15FB8B4000364948 /* ObjectRequestOperations */,
+				254372AC15F54C3F006E8424 /* RKObjectManager.h */,
+				254372AD15F54C3F006E8424 /* RKObjectManager.m */,
+				254372AE15F54C3F006E8424 /* RKPaginator.h */,
+				254372AF15F54C3F006E8424 /* RKPaginator.m */,
+				254372B215F54C3F006E8424 /* RKRequestDescriptor.h */,
+				254372B315F54C3F006E8424 /* RKRequestDescriptor.m */,
+				254372B415F54C3F006E8424 /* RKResponseDescriptor.h */,
+				254372B515F54C3F006E8424 /* RKResponseDescriptor.m */,
+				254372B615F54C3F006E8424 /* RKResponseMapperOperation.h */,
+				254372B715F54C3F006E8424 /* RKResponseMapperOperation.m */,
+				254372A615F54995006E8424 /* RKObjectParameterization.h */,
+				254372A715F54995006E8424 /* RKObjectParameterization.m */,
+				25F53AE015E7B611008B54E6 /* RKHTTPUtilities.h */,
+				25F53AE115E7B612008B54E6 /* RKHTTPUtilities.m */,
+				C0F11CE1190883380054AEA0 /* RKPathMatcher.h */,
+				C0F11CE2190883380054AEA0 /* RKPathMatcher.m */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		25160D7A145650490060A5C5 /* ObjectMapping */ = {
+			isa = PBXGroup;
+			children = (
+				258BEA01168D058300C74C8C /* RKObjectMappingMatcher.m */,
+				25B6E95A14CF7E3C00B1E881 /* RKObjectMappingMatcher.h */,
+				25160D7C145650490060A5C5 /* RKDynamicMapping.h */,
+				25160D7D145650490060A5C5 /* RKDynamicMapping.m */,
+				25160D7E145650490060A5C5 /* RKErrorMessage.h */,
+				25160D7F145650490060A5C5 /* RKErrorMessage.m */,
+				25160D82145650490060A5C5 /* RKAttributeMapping.h */,
+				25160D83145650490060A5C5 /* RKAttributeMapping.m */,
+				25160D89145650490060A5C5 /* RKMapperOperation.h */,
+				25160D8A145650490060A5C5 /* RKMapperOperation.m */,
+				25160D8B145650490060A5C5 /* RKMapperOperation_Private.h */,
+				25160D8D145650490060A5C5 /* RKObjectMapping.h */,
+				25160D8E145650490060A5C5 /* RKObjectMapping.m */,
+				25160D8F145650490060A5C5 /* RKMapping.h */,
+				25CA7A8E14EC570100888FF8 /* RKMapping.m */,
+				25160D90145650490060A5C5 /* RKMappingOperation.h */,
+				25160D91145650490060A5C5 /* RKMappingOperation.m */,
+				25160D94145650490060A5C5 /* RKMappingResult.h */,
+				25160D95145650490060A5C5 /* RKMappingResult.m */,
+				25160D96145650490060A5C5 /* RKPropertyInspector.h */,
+				25160D97145650490060A5C5 /* RKPropertyInspector.m */,
+				25160D98145650490060A5C5 /* RKRelationshipMapping.h */,
+				25160D99145650490060A5C5 /* RKRelationshipMapping.m */,
+				258EA4A615A38BBF007E07A6 /* RKObjectMappingOperationDataSource.h */,
+				258EA4A715A38BBF007E07A6 /* RKObjectMappingOperationDataSource.m */,
+				258EA4AD15A38E7D007E07A6 /* RKMappingOperationDataSource.h */,
+				25AFF8F015B4CF1F0051877F /* RKMappingErrors.h */,
+				2598888B15EC169E006CAE95 /* RKPropertyMapping.h */,
+				2598888C15EC169E006CAE95 /* RKPropertyMapping.m */,
+				25A226D41618A57500952D72 /* RKObjectUtilities.h */,
+				25A226D51618A57500952D72 /* RKObjectUtilities.m */,
+			);
+			path = ObjectMapping;
+			sourceTree = "<group>";
+		};
+		25160DA2145650490060A5C5 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				54CDB45917B408B100FAC285 /* RKStringTokenizer.h */,
+				54CDB45A17B408B100FAC285 /* RKStringTokenizer.m */,
+				2534781515FFD4A6002C0E4E /* RKURLEncodedSerialization.h */,
+				2534781415FFD4A6002C0E4E /* RKURLEncodedSerialization.m */,
+				2595B46B15F670530087A59B /* RKMIMETypeSerialization.h */,
+				2595B46C15F670530087A59B /* RKMIMETypeSerialization.m */,
+				2595B46D15F670530087A59B /* RKNSJSONSerialization.h */,
+				2595B46E15F670530087A59B /* RKNSJSONSerialization.m */,
+				25160DA5145650490060A5C5 /* lcl_config_components_RK.h */,
+				25160DA6145650490060A5C5 /* lcl_config_extensions_RK.h */,
+				25160DA7145650490060A5C5 /* lcl_config_logger_RK.h */,
+				25160DBB145650490060A5C5 /* RestKit-Prefix.pch */,
+				25160DBE145650490060A5C5 /* RKDotNetDateFormatter.h */,
+				25160DBF145650490060A5C5 /* RKDotNetDateFormatter.m */,
+				25160DC1145650490060A5C5 /* RKLog.h */,
+				25160DC2145650490060A5C5 /* RKLog.m */,
+				25160DC3145650490060A5C5 /* RKMIMETypes.h */,
+				25160DC4145650490060A5C5 /* RKMIMETypes.m */,
+				25160DC5145650490060A5C5 /* RKSerialization.h */,
+				25B408241491CDDB00F21111 /* RKPathUtilities.h */,
+				25B408251491CDDB00F21111 /* RKPathUtilities.m */,
+				25B6E95414CF795D00B1E881 /* RKErrors.h */,
+				25B6E95714CF7A1C00B1E881 /* RKErrors.m */,
+				5CCC295515B7124A0045F0F5 /* RKMacros.h */,
+				253477EF15FFBC60002C0E4E /* RKDictionaryUtilities.h */,
+				253477F015FFBC60002C0E4E /* RKDictionaryUtilities.m */,
+				25C6C0E61716F79B00C98A73 /* RKOperationStateMachine.h */,
+				25C6C0E71716F79B00C98A73 /* RKOperationStateMachine.m */,
+			);
+			path = Support;
+			sourceTree = "<group>";
+		};
+		25160E65145651060060A5C5 /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				25160E66145651060060A5C5 /* AppKit.framework */,
+				25160E67145651060060A5C5 /* CoreData.framework */,
+				25160E68145651060060A5C5 /* Foundation.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
+		25160E8D145652E40060A5C5 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				252CCE6D17E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer */,
+				252CCE5D17E08E2D00B7F0BF /* RKValueTransformers */,
+				25C6C0A21716F6F800C98A73 /* TransitionKit */,
+				25BCB31715ED57D500EE84DD /* AFNetworking */,
+				25160EA01456532C0060A5C5 /* LibComponentLogging */,
+				25160EB71456532C0060A5C5 /* SOCKit */,
+			);
+			path = Vendor;
+			sourceTree = "<group>";
+		};
+		25160EA01456532C0060A5C5 /* LibComponentLogging */ = {
+			isa = PBXGroup;
+			children = (
+				25160EA11456532C0060A5C5 /* Core */,
+				25160EAE1456532C0060A5C5 /* NSLog */,
+			);
+			path = LibComponentLogging;
+			sourceTree = "<group>";
+		};
+		25160EA11456532C0060A5C5 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				25160EA21456532C0060A5C5 /* lcl_RK.h */,
+				25160EA31456532C0060A5C5 /* lcl_RK.m */,
+				25160EA71456532C0060A5C5 /* README.md */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		25160EAE1456532C0060A5C5 /* NSLog */ = {
+			isa = PBXGroup;
+			children = (
+				25160EB01456532C0060A5C5 /* LCLNSLog_RK.h */,
+				25160EB11456532C0060A5C5 /* LCLNSLog_RK.m */,
+			);
+			path = NSLog;
+			sourceTree = "<group>";
+		};
+		25160EB71456532C0060A5C5 /* SOCKit */ = {
+			isa = PBXGroup;
+			children = (
+				25160EBD1456532C0060A5C5 /* SOCKit.h */,
+				25160EBE1456532C0060A5C5 /* SOCKit.m */,
+			);
+			path = SOCKit;
+			sourceTree = "<group>";
+		};
+		25160FC51456F2330060A5C5 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				251610351456F2330060A5C5 /* RKTestEnvironment.h */,
+				251610361456F2330060A5C5 /* RKTestEnvironment.m */,
+				25160FC61456F2330060A5C5 /* CoreData */,
+				25160FCD1456F2330060A5C5 /* Fixtures */,
+				25160FF31456F2330060A5C5 /* Models */,
+				2516100B1456F2330060A5C5 /* Network */,
+				2516101B1456F2330060A5C5 /* ObjectMapping */,
+				251610511456F2330060A5C5 /* Support */,
+				25104F9B15C33E3A00829135 /* Search */,
+				25B639C816961EC70065EB7B /* Testing */,
+				251610471456F2330060A5C5 /* Server */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		25160FC61456F2330060A5C5 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				25160FC71456F2330060A5C5 /* RKManagedObjectLoaderTest.m */,
+				25160FC91456F2330060A5C5 /* RKEntityMappingTest.m */,
+				25160FCB1456F2330060A5C5 /* RKManagedObjectStoreTest.m */,
+				25E36E0115195CED00F9E448 /* RKFetchRequestMappingCacheTest.m */,
+				25079C75151B952200266AE7 /* NSEntityDescription+RKAdditionsTest.m */,
+				25DB7507151BD551009F01AF /* NSManagedObjectContext+RKAdditionsTest.m */,
+				259D98591550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m */,
+				259D986315521B1F008C90F5 /* RKEntityCacheTest.m */,
+				25AA23D315AF4F25006EF62D /* RKManagedObjectMappingOperationDataSourceTest.m */,
+				258EFF7915C0CE1400EE4E0D /* RKManagedObjectSeederTest.m */,
+				2564E40A16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m */,
+				2546A95716628EDD0078E044 /* RKConnectionDescriptionTest.m */,
+				2582F56C173038750043B8BB /* RKInMemoryManagedObjectCacheTest.m */,
+			);
+			name = CoreData;
+			path = Logic/CoreData;
+			sourceTree = "<group>";
+		};
+		25160FCD1456F2330060A5C5 /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				25160FCE1456F2330060A5C5 /* Assets */,
+				25160FD01456F2330060A5C5 /* JSON */,
+				25160FE91456F2330060A5C5 /* Uploads */,
+				25160FEC1456F2330060A5C5 /* XML */,
+			);
+			path = Fixtures;
+			sourceTree = "<group>";
+		};
+		25160FCE1456F2330060A5C5 /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+				25160FCF1456F2330060A5C5 /* blake.png */,
+			);
+			path = Assets;
+			sourceTree = "<group>";
+		};
+		25160FD01456F2330060A5C5 /* JSON */ = {
+			isa = PBXGroup;
+			children = (
+				259D983B154F6C90008C90F5 /* benchmark_parents_and_children.json */,
+				252EFB2714DA0689004863C8 /* NakedEvents.json */,
+				25160FD11456F2330060A5C5 /* ArrayOfNestedDictionaries.json */,
+				25160FD21456F2330060A5C5 /* ArrayOfResults.json */,
+				25160FD31456F2330060A5C5 /* ComplexNestedUser.json */,
+				25160FD41456F2330060A5C5 /* ConnectingParents.json */,
+				25160FD51456F2330060A5C5 /* Dynamic */,
+				25160FDA1456F2330060A5C5 /* DynamicKeys.json */,
+				25160FDB1456F2330060A5C5 /* DynamicKeysWithNestedRelationship.json */,
+				25160FDC1456F2330060A5C5 /* DynamicKeysWithRelationship.json */,
+				25160FDD1456F2330060A5C5 /* error.json */,
+				25160FDE1456F2330060A5C5 /* errors.json */,
+				25160FDF1456F2330060A5C5 /* Foursquare.json */,
+				25160FE01456F2330060A5C5 /* humans */,
+				25160FE41456F2330060A5C5 /* nested_user.json */,
+				25160FE51456F2330060A5C5 /* RailsUser.json */,
+				25160FE61456F2330060A5C5 /* SameKeyDifferentTargetClasses.json */,
+				25160FE71456F2330060A5C5 /* user.json */,
+				25160FE81456F2330060A5C5 /* users.json */,
+				25CAAA9315254E7800CAE5D7 /* ArrayOfHumans.json */,
+				25119FB5154A34B400C6BC58 /* parents_and_children.json */,
+			);
+			path = JSON;
+			sourceTree = "<group>";
+		};
+		25160FD51456F2330060A5C5 /* Dynamic */ = {
+			isa = PBXGroup;
+			children = (
+				25160FD61456F2330060A5C5 /* boy.json */,
+				73D3907314CA1A4A0093E3D6 /* child.json */,
+				25160FD71456F2330060A5C5 /* friends.json */,
+				25160FD81456F2330060A5C5 /* girl.json */,
+				25160FD91456F2330060A5C5 /* mixed.json */,
+				73D3907114CA19F90093E3D6 /* parent.json */,
+			);
+			path = Dynamic;
+			sourceTree = "<group>";
+		};
+		25160FE01456F2330060A5C5 /* humans */ = {
+			isa = PBXGroup;
+			children = (
+				25160FE11456F2330060A5C5 /* 1.json */,
+				25160FE21456F2330060A5C5 /* all.json */,
+				3EB0D83816ADCEFC00E9CEA2 /* empty_human.json */,
+				3E886DC0169E10A70069C56B /* has_many_with_to_one_relationship.json */,
+				25160FE31456F2330060A5C5 /* with_to_one_relationship.json */,
+				F66056291744FF9000A87A45 /* and_cats.json */,
+			);
+			path = humans;
+			sourceTree = "<group>";
+		};
+		25160FE91456F2330060A5C5 /* Uploads */ = {
+			isa = PBXGroup;
+			children = (
+				25160FEA1456F2330060A5C5 /* .gitignore */,
+			);
+			path = Uploads;
+			sourceTree = "<group>";
+		};
+		25160FEC1456F2330060A5C5 /* XML */ = {
+			isa = PBXGroup;
+			children = (
+				25160FED1456F2330060A5C5 /* attributes_without_text_content.xml */,
+				73D3907814CA1D710093E3D6 /* channels.xml */,
+				25160FEE1456F2330060A5C5 /* container_attributes.xml */,
+				25160FEF1456F2330060A5C5 /* national_weather_service.xml */,
+				25160FF01456F2330060A5C5 /* orders.xml */,
+				25160FF11456F2330060A5C5 /* tab_data.xml */,
+				25160FF21456F2330060A5C5 /* zend.xml */,
+			);
+			path = XML;
+			sourceTree = "<group>";
+		};
+		25160FF31456F2330060A5C5 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				252EFAF814D8EAEC004863C8 /* RKEvent.h */,
+				252EFAF914D8EAEC004863C8 /* RKEvent.m */,
+				25B6E9D514CF912500B1E881 /* RKSearchable.h */,
+				25B6E9D614CF912500B1E881 /* RKSearchable.m */,
+				25B6E9D714CF912500B1E881 /* RKTestAddress.h */,
+				25B6E9D814CF912500B1E881 /* RKTestAddress.m */,
+				25B6E9D914CF912500B1E881 /* RKTestUser.h */,
+				25B6E9DA14CF912500B1E881 /* RKTestUser.m */,
+				25160FF41456F2330060A5C5 /* Data Model.xcdatamodel */,
+				25160FF51456F2330060A5C5 /* RKCat.h */,
+				25160FF61456F2330060A5C5 /* RKCat.m */,
+				25160FF71456F2330060A5C5 /* RKChild.h */,
+				25160FF81456F2330060A5C5 /* RKChild.m */,
+				25160FF91456F2330060A5C5 /* RKDynamicMappingModels.h */,
+				25160FFA1456F2330060A5C5 /* RKDynamicMappingModels.m */,
+				25160FFB1456F2330060A5C5 /* RKHouse.h */,
+				25160FFC1456F2330060A5C5 /* RKHouse.m */,
+				25160FFD1456F2330060A5C5 /* RKHuman.h */,
+				25160FFE1456F2330060A5C5 /* RKHuman.m */,
+				25160FFF1456F2330060A5C5 /* RKMappableAssociation.h */,
+				251610001456F2330060A5C5 /* RKMappableAssociation.m */,
+				251610011456F2330060A5C5 /* RKMappableObject.h */,
+				251610021456F2330060A5C5 /* RKMappableObject.m */,
+				251610031456F2330060A5C5 /* RKObjectLoaderTestResultModel.h */,
+				251610041456F2330060A5C5 /* RKObjectLoaderTestResultModel.m */,
+				251610051456F2330060A5C5 /* RKObjectMapperTestModel.h */,
+				251610061456F2330060A5C5 /* RKObjectMapperTestModel.m */,
+				251610071456F2330060A5C5 /* RKParent.h */,
+				251610081456F2330060A5C5 /* RKParent.m */,
+				251610091456F2330060A5C5 /* RKResident.h */,
+				2516100A1456F2330060A5C5 /* RKResident.m */,
+				25A73360169C8C230090A930 /* VersionedModel.xcdatamodeld */,
+				2550DA2116B1FB62005A0CB8 /* RKPost.h */,
+				2550DA2216B1FB62005A0CB8 /* RKPost.m */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		2516100B1456F2330060A5C5 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				25CC5C58161DDADD0008BD21 /* RKResponseDescriptorTest.m */,
+				BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */,
+				252029081577C78600076FB4 /* RKRouteSetTest.m */,
+				25565964161FDD8800F5BB20 /* RKResponseMapperOperationTest.m */,
+				259AC480162B05C80012D2F9 /* RKObjectRequestOperationTest.m */,
+				2549D645162B376F003DD135 /* RKRequestDescriptorTest.m */,
+				2548AC6C162F5E00009E79BF /* RKManagedObjectRequestOperationTest.m */,
+				2536D1FC167270F100DF9BB0 /* RKRouterTest.m */,
+				2551338E167838590017E4B6 /* RKHTTPRequestOperationTest.m */,
+			);
+			name = Network;
+			path = Logic/Network;
+			sourceTree = "<group>";
+		};
+		2516101B1456F2330060A5C5 /* ObjectMapping */ = {
+			isa = PBXGroup;
+			children = (
+				2516101C1456F2330060A5C5 /* RKDynamicMappingTest.m */,
+				2516101F1456F2330060A5C5 /* RKObjectManagerTest.m */,
+				251610211456F2330060A5C5 /* RKObjectMappingNextGenTest.m */,
+				251610221456F2330060A5C5 /* RKMappingOperationTest.m */,
+				251610241456F2330060A5C5 /* RKMappingResultTest.m */,
+				251610261456F2330060A5C5 /* RKObjectParameterizationTest.m */,
+				251610271456F2330060A5C5 /* RKMIMETypeSerializationTest.m */,
+				254A62BF14AD591C00939BEE /* RKPaginatorTest.m */,
+				2519764215823BA1004FE9DD /* RKAttributeMappingTest.m */,
+				2519764715824455004FE9DD /* RKRelationshipMappingTest.m */,
+				2519764B158244F8004FE9DD /* RKObjectMappingTest.m */,
+			);
+			name = ObjectMapping;
+			path = Logic/ObjectMapping;
+			sourceTree = "<group>";
+		};
+		251610471456F2330060A5C5 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				251610481456F2330060A5C5 /* lib */,
+				251610501456F2330060A5C5 /* server.rb */,
+			);
+			path = Server;
+			sourceTree = "<group>";
+		};
+		251610481456F2330060A5C5 /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				251610491456F2330060A5C5 /* restkit */,
+			);
+			path = lib;
+			sourceTree = "<group>";
+		};
+		251610491456F2330060A5C5 /* restkit */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = restkit;
+			sourceTree = "<group>";
+		};
+		251610511456F2330060A5C5 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				25AABCEC17B698940061DC5B /* RKStringTokenizerTest.m */,
+				5C927E131608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m */,
+				251610521456F2330060A5C5 /* RKURLEncodedSerializationTest.m */,
+				251610531456F2330060A5C5 /* NSStringRestKitTest.m */,
+				251610541456F2330060A5C5 /* RKDotNetDateFormatterTest.m */,
+				251610561456F2330060A5C5 /* RKPathMatcherTest.m */,
+				2501405215366000004E0466 /* RKObjectiveCppTest.mm */,
+				25CDA0E2161E821000F583F3 /* RKISODateFormatterTest.m */,
+				25BB392D161F4FD700E5C72A /* RKPathUtilitiesTest.m */,
+				252205CB162B242400F7B11E /* RKHTTPUtilitiesTest.m */,
+			);
+			name = Support;
+			path = Logic/Support;
+			sourceTree = "<group>";
+		};
+		252CCE5D17E08E2D00B7F0BF /* RKValueTransformers */ = {
+			isa = PBXGroup;
+			children = (
+				252CCE6017E08E2D00B7F0BF /* RKValueTransformers.h */,
+				252CCE6117E08E2D00B7F0BF /* RKValueTransformers.m */,
+			);
+			name = RKValueTransformers;
+			path = RKValueTransformers/Code;
+			sourceTree = "<group>";
+		};
+		252CCE6D17E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer */ = {
+			isa = PBXGroup;
+			children = (
+				252CCE6E17E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.h */,
+				252CCE6F17E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.m */,
+				252CCE7017E0CA2700B7F0BF /* RKISO8601DateFormatter.h */,
+				252CCE7117E0CA2700B7F0BF /* RKISO8601DateFormatter.m */,
+			);
+			name = ISO8601DateFormatterValueTransformer;
+			path = ISO8601DateFormatterValueTransformer/Code;
+			sourceTree = "<group>";
+		};
+		252EFB1F14D9A8D4004863C8 /* Testing */ = {
+			isa = PBXGroup;
+			children = (
+				25A199D216ED035A00792629 /* RKBenchmark.h */,
+				25A199D316ED035A00792629 /* RKBenchmark.m */,
+				25055B8214EEF32A00B9C4DD /* RKTestFactory.h */,
+				25055B8314EEF32A00B9C4DD /* RKTestFactory.m */,
+				252EFB2014D9B35D004863C8 /* RKTestFixture.h */,
+				252EFB2114D9B35D004863C8 /* RKTestFixture.m */,
+				252EFAFC14D8EB30004863C8 /* RKTestNotificationObserver.h */,
+				252EFAFD14D8EB30004863C8 /* RKTestNotificationObserver.m */,
+				25055B8014EEF32A00B9C4DD /* RKMappingTest.h */,
+				25055B8114EEF32A00B9C4DD /* RKMappingTest.m */,
+				25055B8D14EEF40000B9C4DD /* RKPropertyMappingTestExpectation.h */,
+				25055B8E14EEF40000B9C4DD /* RKPropertyMappingTestExpectation.m */,
+				25A8C2321673BD480014D9A6 /* RKConnectionTestExpectation.h */,
+				25A8C2331673BD480014D9A6 /* RKConnectionTestExpectation.m */,
+				25C954A415542A47005C9E08 /* RKTestConstants.m */,
+				2507C325161BD5C700EA71FF /* RKTestHelpers.h */,
+				2507C326161BD5C700EA71FF /* RKTestHelpers.m */,
+			);
+			name = Testing;
+			sourceTree = "<group>";
+		};
+		25B639C816961EC70065EB7B /* Testing */ = {
+			isa = PBXGroup;
+			children = (
+				25B639CB16961EFA0065EB7B /* RKMappingTestTest.m */,
+			);
+			name = Testing;
+			path = Logic/Testing;
+			sourceTree = "<group>";
+		};
+		25BCB31715ED57D500EE84DD /* AFNetworking */ = {
+			isa = PBXGroup;
+			children = (
+				259B96C21604CCCC0000C250 /* AFHTTPClient.h */,
+				259B96C31604CCCC0000C250 /* AFHTTPClient.m */,
+				259B96C41604CCCC0000C250 /* AFHTTPRequestOperation.h */,
+				259B96C51604CCCC0000C250 /* AFHTTPRequestOperation.m */,
+				259B96C61604CCCC0000C250 /* AFImageRequestOperation.h */,
+				259B96C71604CCCC0000C250 /* AFImageRequestOperation.m */,
+				259B96C81604CCCC0000C250 /* AFJSONRequestOperation.h */,
+				259B96C91604CCCC0000C250 /* AFJSONRequestOperation.m */,
+				259B96CA1604CCCC0000C250 /* AFNetworkActivityIndicatorManager.m */,
+				259B96CB1604CCCC0000C250 /* AFPropertyListRequestOperation.h */,
+				259B96CC1604CCCC0000C250 /* AFPropertyListRequestOperation.m */,
+				259B96CD1604CCCC0000C250 /* AFURLConnectionOperation.h */,
+				259B96CE1604CCCC0000C250 /* AFURLConnectionOperation.m */,
+				259B96CF1604CCCC0000C250 /* AFXMLRequestOperation.h */,
+				259B96D01604CCCC0000C250 /* AFXMLRequestOperation.m */,
+				259B96D11604CCCC0000C250 /* UIImageView+AFNetworking.m */,
+				259B96D21604CCCC0000C250 /* AFNetworkActivityIndicatorManager.h */,
+				259B96D31604CCCC0000C250 /* UIImageView+AFNetworking.h */,
+				259B96D41604CCCC0000C250 /* AFNetworking.h */,
+			);
+			name = AFNetworking;
+			path = AFNetworking/AFNetworking;
+			sourceTree = "<group>";
+		};
+		25C6C0A21716F6F800C98A73 /* TransitionKit */ = {
+			isa = PBXGroup;
+			children = (
+				25DA356D1836741C001A56A0 /* TKTransition.h */,
+				25DA356E1836741C001A56A0 /* TKTransition.m */,
+				25C6C0A51716F6F800C98A73 /* TKEvent.h */,
+				25C6C0A61716F6F800C98A73 /* TKEvent.m */,
+				25C6C0A71716F6F800C98A73 /* TKState.h */,
+				25C6C0A81716F6F800C98A73 /* TKState.m */,
+				25C6C0A91716F6F800C98A73 /* TKStateMachine.h */,
+				25C6C0AA1716F6F800C98A73 /* TKStateMachine.m */,
+				25C6C0AC1716F6F800C98A73 /* TransitionKit.h */,
+			);
+			path = TransitionKit;
+			sourceTree = "<group>";
+		};
+		25EC1AD614F8022600C3CF3F /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				25EC1B1E14F821B500C3CF3F /* RestKitResources-Prefix.pch */,
+				25EC1AD714F8022600C3CF3F /* PLISTs */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		25EC1AD714F8022600C3CF3F /* PLISTs */ = {
+			isa = PBXGroup;
+			children = (
+				25EC1B1F14F8220800C3CF3F /* RestKitResources-Info.plist */,
+				25EC1AD814F8022600C3CF3F /* RestKitFramework-Info.plist */,
+				25EC1AD914F8022600C3CF3F /* RestKitFrameworkTests-Info.plist */,
+				25EC1ADA14F8022600C3CF3F /* RestKitTests-Info.plist */,
+			);
+			path = PLISTs;
+			sourceTree = "<group>";
+		};
+		E4081DFC15FB89DF00364948 /* ManagedObjectCaching */ = {
+			isa = PBXGroup;
+			children = (
+				7394DF3814CF168C00CE7BCE /* RKFetchRequestManagedObjectCache.h */,
+				7394DF3914CF168C00CE7BCE /* RKFetchRequestManagedObjectCache.m */,
+				7394DF3C14CF19F200CE7BCE /* RKInMemoryManagedObjectCache.h */,
+				7394DF3D14CF19F200CE7BCE /* RKInMemoryManagedObjectCache.m */,
+				7394DF3514CF157A00CE7BCE /* RKManagedObjectCaching.h */,
+				259D98521550C69A008C90F5 /* RKEntityByAttributeCache.h */,
+				259D98531550C69A008C90F5 /* RKEntityByAttributeCache.m */,
+				259D985C155218E4008C90F5 /* RKEntityCache.h */,
+				259D985D155218E4008C90F5 /* RKEntityCache.m */,
+			);
+			name = ManagedObjectCaching;
+			sourceTree = "<group>";
+		};
+		E4081DFE15FB8A1D00364948 /* Additions */ = {
+			isa = PBXGroup;
+			children = (
+				25160D56145650490060A5C5 /* RKPropertyInspector+CoreData.h */,
+				25160D57145650490060A5C5 /* RKPropertyInspector+CoreData.m */,
+				257ABAAE15112DD400CCAA76 /* NSManagedObjectContext+RKAdditions.h */,
+				257ABAAF15112DD400CCAA76 /* NSManagedObjectContext+RKAdditions.m */,
+				257ABAB41511371C00CCAA76 /* NSManagedObject+RKAdditions.h */,
+				257ABAB51511371D00CCAA76 /* NSManagedObject+RKAdditions.m */,
+			);
+			name = Additions;
+			sourceTree = "<group>";
+		};
+		E4081DFF15FB8B4000364948 /* ObjectRequestOperations */ = {
+			isa = PBXGroup;
+			children = (
+				254372D415F54CE3006E8424 /* RKManagedObjectRequestOperation.h */,
+				254372D515F54CE3006E8424 /* RKManagedObjectRequestOperation.m */,
+				254372AA15F54C3F006E8424 /* RKHTTPRequestOperation.h */,
+				254372AB15F54C3F006E8424 /* RKHTTPRequestOperation.m */,
+				254372B015F54C3F006E8424 /* RKObjectRequestOperation.h */,
+				254372B115F54C3F006E8424 /* RKObjectRequestOperation.m */,
+				25F53F381606269400A093BE /* RKObjectRequestOperationSubclass.h */,
+			);
+			name = ObjectRequestOperations;
+			sourceTree = "<group>";
+		};
+		E4081E0015FB8B5900364948 /* Routing */ = {
+			isa = PBXGroup;
+			children = (
+				252028FA1577AE0B00076FB4 /* RKRouteSet.h */,
+				252028FB1577AE0B00076FB4 /* RKRouteSet.m */,
+				252029011577AE1800076FB4 /* RKRoute.h */,
+				252029021577AE1800076FB4 /* RKRoute.m */,
+				25FBB850159272DD00955D27 /* RKRouter.h */,
+				25FBB851159272DD00955D27 /* RKRouter.m */,
+			);
+			name = Routing;
+			sourceTree = "<group>";
+		};
+		E4081E0715FB8FC400364948 /* Importing */ = {
+			isa = PBXGroup;
+			children = (
+				25160D50145650490060A5C5 /* RKManagedObjectImporter.h */,
+				25160D51145650490060A5C5 /* RKManagedObjectImporter.m */,
+			);
+			name = Importing;
+			sourceTree = "<group>";
+		};
+		E4081E0915FB8FD800364948 /* Mapping */ = {
+			isa = PBXGroup;
+			children = (
+				25160D4C145650490060A5C5 /* RKEntityMapping.h */,
+				25160D4D145650490060A5C5 /* RKEntityMapping.m */,
+				258EA4B015A3908F007E07A6 /* RKManagedObjectMappingOperationDataSource.h */,
+				25AA23CF15AF291F006EF62D /* RKManagedObjectMappingOperationDataSource.m */,
+				25E88C86165C5CC30042ABD0 /* RKConnectionDescription.h */,
+				25E88C87165C5CC30042ABD0 /* RKConnectionDescription.m */,
+			);
+			name = Mapping;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		25160D1414564E810060A5C5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25160DDB145650490060A5C5 /* RKEntityMapping.h in Headers */,
+				25160DDF145650490060A5C5 /* RKManagedObjectImporter.h in Headers */,
+				25160DE1145650490060A5C5 /* RKManagedObjectStore.h in Headers */,
+				25160DE5145650490060A5C5 /* RKPropertyInspector+CoreData.h in Headers */,
+				25160E09145650490060A5C5 /* RKDynamicMapping.h in Headers */,
+				25160E0B145650490060A5C5 /* RKErrorMessage.h in Headers */,
+				252CCE7217E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.h in Headers */,
+				25160E0F145650490060A5C5 /* RKAttributeMapping.h in Headers */,
+				25160E16145650490060A5C5 /* RKMapperOperation.h in Headers */,
+				25160E18145650490060A5C5 /* RKMapperOperation_Private.h in Headers */,
+				25160E1A145650490060A5C5 /* RKObjectMapping.h in Headers */,
+				25160E1C145650490060A5C5 /* RKMapping.h in Headers */,
+				25160E1D145650490060A5C5 /* RKMappingOperation.h in Headers */,
+				25160E21145650490060A5C5 /* RKMappingResult.h in Headers */,
+				25160E23145650490060A5C5 /* RKPropertyInspector.h in Headers */,
+				25160E25145650490060A5C5 /* RKRelationshipMapping.h in Headers */,
+				25160E31145650490060A5C5 /* lcl_config_components_RK.h in Headers */,
+				25160E32145650490060A5C5 /* lcl_config_extensions_RK.h in Headers */,
+				25160E33145650490060A5C5 /* lcl_config_logger_RK.h in Headers */,
+				25160E44145650490060A5C5 /* RestKit-Prefix.pch in Headers */,
+				25160E47145650490060A5C5 /* RKDotNetDateFormatter.h in Headers */,
+				25160E4A145650490060A5C5 /* RKLog.h in Headers */,
+				252CCE7617E0CA2700B7F0BF /* RKISO8601DateFormatter.h in Headers */,
+				25160E4C145650490060A5C5 /* RKMIMETypes.h in Headers */,
+				25160E4E145650490060A5C5 /* RKSerialization.h in Headers */,
+				25160EE21456532C0060A5C5 /* lcl_RK.h in Headers */,
+				25160EF81456532C0060A5C5 /* LCLNSLog_RK.h in Headers */,
+				25160F081456532C0060A5C5 /* SOCKit.h in Headers */,
+				25160E2E145650490060A5C5 /* RestKit.h in Headers */,
+				25B408261491CDDC00F21111 /* RKPathUtilities.h in Headers */,
+				25B6E95514CF795D00B1E881 /* RKErrors.h in Headers */,
+				25B6E95C14CF7E3C00B1E881 /* RKObjectMappingMatcher.h in Headers */,
+				253B495214E35D1A00B0483F /* RKTestFixture.h in Headers */,
+				25FABED214E3796B00E609E7 /* RKTestNotificationObserver.h in Headers */,
+				25055B8414EEF32A00B9C4DD /* RKMappingTest.h in Headers */,
+				25055B8814EEF32A00B9C4DD /* RKTestFactory.h in Headers */,
+				25055B8F14EEF40000B9C4DD /* RKPropertyMappingTestExpectation.h in Headers */,
+				25EC1A3914F72B0900C3CF3F /* RKFetchRequestManagedObjectCache.h in Headers */,
+				25EC1A3D14F72B2800C3CF3F /* RKInMemoryManagedObjectCache.h in Headers */,
+				25EC1A6314F7402A00C3CF3F /* RKManagedObjectCaching.h in Headers */,
+				257ABAB015112DD500CCAA76 /* NSManagedObjectContext+RKAdditions.h in Headers */,
+				257ABAB61511371E00CCAA76 /* NSManagedObject+RKAdditions.h in Headers */,
+				259D98541550C69A008C90F5 /* RKEntityByAttributeCache.h in Headers */,
+				259D985E155218E5008C90F5 /* RKEntityCache.h in Headers */,
+				252028FC1577AE0B00076FB4 /* RKRouteSet.h in Headers */,
+				252029031577AE1800076FB4 /* RKRoute.h in Headers */,
+				25FBB852159272DD00955D27 /* RKRouter.h in Headers */,
+				258EA4A815A38BC0007E07A6 /* RKObjectMappingOperationDataSource.h in Headers */,
+				258EA4AE15A38E7E007E07A6 /* RKMappingOperationDataSource.h in Headers */,
+				258EA4B215A39090007E07A6 /* RKManagedObjectMappingOperationDataSource.h in Headers */,
+				2597F99C15AF6DC400E547D7 /* RKRelationshipConnectionOperation.h in Headers */,
+				25AFF8F115B4CF1F0051877F /* RKMappingErrors.h in Headers */,
+				5CCC295615B7124A0045F0F5 /* RKMacros.h in Headers */,
+				25104F1F15C30CD900829135 /* RKSearchWord.h in Headers */,
+				25104F2915C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.h in Headers */,
+				25104F2F15C30E7400829135 /* RKSearchIndexer.h in Headers */,
+				25104F3515C30EF500829135 /* RKSearchPredicate.h in Headers */,
+				25104F3B15C30F2100829135 /* RKSearchWordEntity.h in Headers */,
+				25F53AE215E7B612008B54E6 /* RKHTTPUtilities.h in Headers */,
+				2598888D15EC169E006CAE95 /* RKPropertyMapping.h in Headers */,
+				254372A815F54995006E8424 /* RKObjectParameterization.h in Headers */,
+				254372B815F54C3F006E8424 /* RKHTTPRequestOperation.h in Headers */,
+				254372BC15F54C3F006E8424 /* RKObjectManager.h in Headers */,
+				254372C015F54C3F006E8424 /* RKPaginator.h in Headers */,
+				254372C415F54C3F006E8424 /* RKObjectRequestOperation.h in Headers */,
+				254372C815F54C3F006E8424 /* RKRequestDescriptor.h in Headers */,
+				254372CC15F54C3F006E8424 /* RKResponseDescriptor.h in Headers */,
+				254372D015F54C3F006E8424 /* RKResponseMapperOperation.h in Headers */,
+				254372D615F54CE3006E8424 /* RKManagedObjectRequestOperation.h in Headers */,
+				2595B46F15F670530087A59B /* RKMIMETypeSerialization.h in Headers */,
+				2595B47315F670530087A59B /* RKNSJSONSerialization.h in Headers */,
+				2502C8ED15F79CF70060FD75 /* CoreData.h in Headers */,
+				2502C8EF15F79CF70060FD75 /* Network.h in Headers */,
+				2502C8F115F79CF70060FD75 /* ObjectMapping.h in Headers */,
+				2502C8F315F79CF70060FD75 /* Search.h in Headers */,
+				2502C8F515F79CF70060FD75 /* Support.h in Headers */,
+				2502C8F715F79CF70060FD75 /* Testing.h in Headers */,
+				2534781815FFD4A6002C0E4E /* RKURLEncodedSerialization.h in Headers */,
+				253477F115FFBC61002C0E4E /* RKDictionaryUtilities.h in Headers */,
+				259B96D51604CCCC0000C250 /* AFHTTPClient.h in Headers */,
+				259B96D91604CCCC0000C250 /* AFHTTPRequestOperation.h in Headers */,
+				259B96DD1604CCCC0000C250 /* AFImageRequestOperation.h in Headers */,
+				259B96E11604CCCC0000C250 /* AFJSONRequestOperation.h in Headers */,
+				259B96E71604CCCC0000C250 /* AFPropertyListRequestOperation.h in Headers */,
+				259B96EB1604CCCC0000C250 /* AFURLConnectionOperation.h in Headers */,
+				259B96EF1604CCCC0000C250 /* AFXMLRequestOperation.h in Headers */,
+				259B96F51604CCCC0000C250 /* AFNetworkActivityIndicatorManager.h in Headers */,
+				259B96F71604CCCC0000C250 /* UIImageView+AFNetworking.h in Headers */,
+				259B96F91604CCCC0000C250 /* AFNetworking.h in Headers */,
+				25F53F391606269400A093BE /* RKObjectRequestOperationSubclass.h in Headers */,
+				25A226D61618A57500952D72 /* RKObjectUtilities.h in Headers */,
+				C0F11CE3190883380054AEA0 /* RKPathMatcher.h in Headers */,
+				252CCE6617E08E2D00B7F0BF /* RKValueTransformers.h in Headers */,
+				2507C327161BD5C700EA71FF /* RKTestHelpers.h in Headers */,
+				C0F11CE81908C7E60054AEA0 /* RKCoreData.h in Headers */,
+				25E88C88165C5CC30042ABD0 /* RKConnectionDescription.h in Headers */,
+				25A8C2341673BD480014D9A6 /* RKConnectionTestExpectation.h in Headers */,
+				25A199D416ED035A00792629 /* RKBenchmark.h in Headers */,
+				25C6C0BD1716F6F800C98A73 /* TKEvent.h in Headers */,
+				25C6C0C11716F6F800C98A73 /* TKState.h in Headers */,
+				25C6C0C51716F6F800C98A73 /* TKStateMachine.h in Headers */,
+				25C6C0CB1716F6F800C98A73 /* TransitionKit.h in Headers */,
+				25C6C0E81716F79B00C98A73 /* RKOperationStateMachine.h in Headers */,
+				25DA356F1836741D001A56A0 /* TKTransition.h in Headers */,
+				54CDB45B17B408B100FAC285 /* RKStringTokenizer.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25160E5F145651060060A5C5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25160EE31456532C0060A5C5 /* lcl_RK.h in Headers */,
+				25160EF91456532C0060A5C5 /* LCLNSLog_RK.h in Headers */,
+				25160F091456532C0060A5C5 /* SOCKit.h in Headers */,
+				25160F44145655C60060A5C5 /* RKDynamicMapping.h in Headers */,
+				25160F46145655C60060A5C5 /* RKErrorMessage.h in Headers */,
+				25160F4A145655C60060A5C5 /* RKAttributeMapping.h in Headers */,
+				252CCE7317E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.h in Headers */,
+				25160F51145655C60060A5C5 /* RKMapperOperation.h in Headers */,
+				25160F53145655C60060A5C5 /* RKMapperOperation_Private.h in Headers */,
+				25160F55145655C60060A5C5 /* RKObjectMapping.h in Headers */,
+				25160F57145655C60060A5C5 /* RKMapping.h in Headers */,
+				25160F58145655C60060A5C5 /* RKMappingOperation.h in Headers */,
+				25160F5C145655C60060A5C5 /* RKMappingResult.h in Headers */,
+				25160F5E145655C60060A5C5 /* RKPropertyInspector.h in Headers */,
+				25160F60145655C60060A5C5 /* RKRelationshipMapping.h in Headers */,
+				25160F6F145655D10060A5C5 /* RKEntityMapping.h in Headers */,
+				25160F73145655D10060A5C5 /* RKManagedObjectImporter.h in Headers */,
+				25160F75145655D10060A5C5 /* RKManagedObjectStore.h in Headers */,
+				25160F79145655D10060A5C5 /* RKPropertyInspector+CoreData.h in Headers */,
+				25160F85145657650060A5C5 /* lcl_config_components_RK.h in Headers */,
+				25160F86145657650060A5C5 /* lcl_config_extensions_RK.h in Headers */,
+				25160F87145657650060A5C5 /* lcl_config_logger_RK.h in Headers */,
+				252CCE7717E0CA2700B7F0BF /* RKISO8601DateFormatter.h in Headers */,
+				25160F901456576C0060A5C5 /* RKDotNetDateFormatter.h in Headers */,
+				25160F931456576C0060A5C5 /* RKLog.h in Headers */,
+				25160F951456576C0060A5C5 /* RKMIMETypes.h in Headers */,
+				25160F971456576C0060A5C5 /* RKSerialization.h in Headers */,
+				25160F25145655AF0060A5C5 /* RestKit.h in Headers */,
+				25B408271491CDDC00F21111 /* RKPathUtilities.h in Headers */,
+				25B6E95614CF795D00B1E881 /* RKErrors.h in Headers */,
+				25B6E95D14CF7E3C00B1E881 /* RKObjectMappingMatcher.h in Headers */,
+				25FABED314E3796C00E609E7 /* RKTestNotificationObserver.h in Headers */,
+				25055B8514EEF32A00B9C4DD /* RKMappingTest.h in Headers */,
+				25055B8914EEF32A00B9C4DD /* RKTestFactory.h in Headers */,
+				C0F11CE91908C7E60054AEA0 /* RKCoreData.h in Headers */,
+				25055B9014EEF40000B9C4DD /* RKPropertyMappingTestExpectation.h in Headers */,
+				25EC1A3A14F72B0A00C3CF3F /* RKFetchRequestManagedObjectCache.h in Headers */,
+				25EC1A3E14F72B2900C3CF3F /* RKInMemoryManagedObjectCache.h in Headers */,
+				25EC1A6514F7402A00C3CF3F /* RKManagedObjectCaching.h in Headers */,
+				257ABAB115112DD500CCAA76 /* NSManagedObjectContext+RKAdditions.h in Headers */,
+				257ABAB71511371E00CCAA76 /* NSManagedObject+RKAdditions.h in Headers */,
+				259D98551550C69A008C90F5 /* RKEntityByAttributeCache.h in Headers */,
+				259D985F155218E5008C90F5 /* RKEntityCache.h in Headers */,
+				252028FD1577AE0B00076FB4 /* RKRouteSet.h in Headers */,
+				252029041577AE1800076FB4 /* RKRoute.h in Headers */,
+				25FBB853159272DD00955D27 /* RKRouter.h in Headers */,
+				258EA4A915A38BC0007E07A6 /* RKObjectMappingOperationDataSource.h in Headers */,
+				258EA4AF15A38E7E007E07A6 /* RKMappingOperationDataSource.h in Headers */,
+				258EA4B315A39090007E07A6 /* RKManagedObjectMappingOperationDataSource.h in Headers */,
+				2597F99D15AF6DC400E547D7 /* RKRelationshipConnectionOperation.h in Headers */,
+				25AFF8F215B4CF1F0051877F /* RKMappingErrors.h in Headers */,
+				5CCC295715B7124A0045F0F5 /* RKMacros.h in Headers */,
+				25104F2015C30CD900829135 /* RKSearchWord.h in Headers */,
+				25104F2A15C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.h in Headers */,
+				25104F3015C30E7400829135 /* RKSearchIndexer.h in Headers */,
+				25104F3615C30EF500829135 /* RKSearchPredicate.h in Headers */,
+				25104F3C15C30F2100829135 /* RKSearchWordEntity.h in Headers */,
+				25F53AE315E7B612008B54E6 /* RKHTTPUtilities.h in Headers */,
+				2598888E15EC169E006CAE95 /* RKPropertyMapping.h in Headers */,
+				254372B915F54C3F006E8424 /* RKHTTPRequestOperation.h in Headers */,
+				254372BD15F54C3F006E8424 /* RKObjectManager.h in Headers */,
+				254372C115F54C3F006E8424 /* RKPaginator.h in Headers */,
+				254372C515F54C3F006E8424 /* RKObjectRequestOperation.h in Headers */,
+				254372C915F54C3F006E8424 /* RKRequestDescriptor.h in Headers */,
+				254372CD15F54C3F006E8424 /* RKResponseDescriptor.h in Headers */,
+				254372D115F54C3F006E8424 /* RKResponseMapperOperation.h in Headers */,
+				254372D715F54CE3006E8424 /* RKManagedObjectRequestOperation.h in Headers */,
+				2595B47015F670530087A59B /* RKMIMETypeSerialization.h in Headers */,
+				2595B47415F670530087A59B /* RKNSJSONSerialization.h in Headers */,
+				2502C8EE15F79CF70060FD75 /* CoreData.h in Headers */,
+				2502C8F015F79CF70060FD75 /* Network.h in Headers */,
+				2502C8F215F79CF70060FD75 /* ObjectMapping.h in Headers */,
+				2502C8F415F79CF70060FD75 /* Search.h in Headers */,
+				2502C8F615F79CF70060FD75 /* Support.h in Headers */,
+				2502C8F815F79CF70060FD75 /* Testing.h in Headers */,
+				253477F215FFBC61002C0E4E /* RKDictionaryUtilities.h in Headers */,
+				2534781915FFD4A6002C0E4E /* RKURLEncodedSerialization.h in Headers */,
+				259B96D61604CCCC0000C250 /* AFHTTPClient.h in Headers */,
+				259B96DA1604CCCC0000C250 /* AFHTTPRequestOperation.h in Headers */,
+				259B96DE1604CCCC0000C250 /* AFImageRequestOperation.h in Headers */,
+				259B96E21604CCCC0000C250 /* AFJSONRequestOperation.h in Headers */,
+				259B96E81604CCCC0000C250 /* AFPropertyListRequestOperation.h in Headers */,
+				259B96EC1604CCCC0000C250 /* AFURLConnectionOperation.h in Headers */,
+				259B96F01604CCCC0000C250 /* AFXMLRequestOperation.h in Headers */,
+				259B96F61604CCCC0000C250 /* AFNetworkActivityIndicatorManager.h in Headers */,
+				259B96F81604CCCC0000C250 /* UIImageView+AFNetworking.h in Headers */,
+				259B96FA1604CCCC0000C250 /* AFNetworking.h in Headers */,
+				25F53F3A1606269400A093BE /* RKObjectRequestOperationSubclass.h in Headers */,
+				25A226D71618A57500952D72 /* RKObjectUtilities.h in Headers */,
+				2507C328161BD5C700EA71FF /* RKTestHelpers.h in Headers */,
+				25E88C89165C5CC30042ABD0 /* RKConnectionDescription.h in Headers */,
+				252CCE6717E08E2D00B7F0BF /* RKValueTransformers.h in Headers */,
+				C0F11CE5190883460054AEA0 /* RKPathMatcher.h in Headers */,
+				255893E3166BA6A20010C70B /* RKObjectParameterization.h in Headers */,
+				255893E4166BA7400010C70B /* RestKit-Prefix.pch in Headers */,
+				255893E5166BA7700010C70B /* RKTestFixture.h in Headers */,
+				25A8C2351673BD480014D9A6 /* RKConnectionTestExpectation.h in Headers */,
+				25A199D516ED035A00792629 /* RKBenchmark.h in Headers */,
+				25C6C0BE1716F6F800C98A73 /* TKEvent.h in Headers */,
+				25C6C0C21716F6F800C98A73 /* TKState.h in Headers */,
+				25C6C0C61716F6F800C98A73 /* TKStateMachine.h in Headers */,
+				25C6C0CC1716F6F800C98A73 /* TransitionKit.h in Headers */,
+				25C6C0E91716F79B00C98A73 /* RKOperationStateMachine.h in Headers */,
+				25DA35701836741D001A56A0 /* TKTransition.h in Headers */,
+				54CDB45C17B408B100FAC285 /* RKStringTokenizer.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		25160D1514564E810060A5C5 /* RestKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 25160D3A14564E820060A5C5 /* Build configuration list for PBXNativeTarget "RestKit" */;
+			buildPhases = (
+				25160D1214564E810060A5C5 /* Sources */,
+				25160D1314564E810060A5C5 /* Frameworks */,
+				25160D1414564E810060A5C5 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RestKit;
+			productName = RestKit;
+			productReference = 25160D1614564E810060A5C5 /* libRestKit.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		25160D2514564E820060A5C5 /* RestKitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 25160D3D14564E820060A5C5 /* Build configuration list for PBXNativeTarget "RestKitTests" */;
+			buildPhases = (
+				25160D2114564E820060A5C5 /* Sources */,
+				25160D2214564E820060A5C5 /* Frameworks */,
+				25160D2314564E820060A5C5 /* Resources */,
+				212C92B936E847348494D6F7 /* Copy Pods Resources */,
+				25160D2414564E820060A5C5 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				25160D2D14564E820060A5C5 /* PBXTargetDependency */,
+			);
+			name = RestKitTests;
+			productName = RestKitTests;
+			productReference = 25160D2614564E820060A5C5 /* RestKitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		25160E61145651060060A5C5 /* RestKitFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 25160E87145651060060A5C5 /* Build configuration list for PBXNativeTarget "RestKitFramework" */;
+			buildPhases = (
+				25160E5D145651060060A5C5 /* Sources */,
+				25160E5E145651060060A5C5 /* Frameworks */,
+				25160E5F145651060060A5C5 /* Headers */,
+				25160E60145651060060A5C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RestKitFramework;
+			productName = RestKitFramework;
+			productReference = 25160E62145651060060A5C5 /* RestKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		25160E77145651060060A5C5 /* RestKitFrameworkTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 25160E8A145651060060A5C5 /* Build configuration list for PBXNativeTarget "RestKitFrameworkTests" */;
+			buildPhases = (
+				25160E73145651060060A5C5 /* Sources */,
+				25160E74145651060060A5C5 /* Frameworks */,
+				25160E75145651060060A5C5 /* Resources */,
+				250CA67F147D8EEC0047D347 /* CopyFiles */,
+				0779C6DD2283438BA5EAB1FB /* Copy Pods Resources */,
+				25160E76145651060060A5C5 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				25160E7C145651060060A5C5 /* PBXTargetDependency */,
+			);
+			name = RestKitFrameworkTests;
+			productName = RestKitFrameworkTests;
+			productReference = 25160E78145651060060A5C5 /* RestKitFrameworkTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		25160D0D14564E810060A5C5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastTestingUpgradeCheck = 0510;
+				LastUpgradeCheck = 0600;
+				ORGANIZATIONNAME = RestKit;
+			};
+			buildConfigurationList = 25160D1014564E810060A5C5 /* Build configuration list for PBXProject "RestKit" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 25160D0B14564E810060A5C5;
+			productRefGroup = 25160D1714564E810060A5C5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				25160D1514564E810060A5C5 /* RestKit */,
+				25160D2514564E820060A5C5 /* RestKitTests */,
+				25160E61145651060060A5C5 /* RestKitFramework */,
+				25160E77145651060060A5C5 /* RestKitFrameworkTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		25160D2314564E820060A5C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				251610641456F2330060A5C5 /* blake.png in Resources */,
+				251610661456F2330060A5C5 /* ArrayOfNestedDictionaries.json in Resources */,
+				251610681456F2330060A5C5 /* ArrayOfResults.json in Resources */,
+				2516106A1456F2330060A5C5 /* ComplexNestedUser.json in Resources */,
+				2516106C1456F2330060A5C5 /* ConnectingParents.json in Resources */,
+				2516106E1456F2330060A5C5 /* boy.json in Resources */,
+				251610701456F2330060A5C5 /* friends.json in Resources */,
+				251610721456F2330060A5C5 /* girl.json in Resources */,
+				251610741456F2330060A5C5 /* mixed.json in Resources */,
+				251610761456F2330060A5C5 /* DynamicKeys.json in Resources */,
+				251610781456F2330060A5C5 /* DynamicKeysWithNestedRelationship.json in Resources */,
+				2516107A1456F2330060A5C5 /* DynamicKeysWithRelationship.json in Resources */,
+				2516107C1456F2330060A5C5 /* error.json in Resources */,
+				2516107E1456F2330060A5C5 /* errors.json in Resources */,
+				251610801456F2330060A5C5 /* Foursquare.json in Resources */,
+				251610821456F2330060A5C5 /* 1.json in Resources */,
+				251610841456F2330060A5C5 /* all.json in Resources */,
+				251610861456F2330060A5C5 /* with_to_one_relationship.json in Resources */,
+				251610881456F2330060A5C5 /* nested_user.json in Resources */,
+				2516108A1456F2330060A5C5 /* RailsUser.json in Resources */,
+				2516108C1456F2330060A5C5 /* SameKeyDifferentTargetClasses.json in Resources */,
+				2516108E1456F2330060A5C5 /* user.json in Resources */,
+				251610901456F2330060A5C5 /* users.json in Resources */,
+				251610961456F2330060A5C5 /* attributes_without_text_content.xml in Resources */,
+				251610981456F2330060A5C5 /* container_attributes.xml in Resources */,
+				2516109A1456F2330060A5C5 /* national_weather_service.xml in Resources */,
+				2516109C1456F2330060A5C5 /* orders.xml in Resources */,
+				2516109E1456F2330060A5C5 /* tab_data.xml in Resources */,
+				251610A01456F2330060A5C5 /* zend.xml in Resources */,
+				73D3907414CA1AE00093E3D6 /* parent.json in Resources */,
+				73D3907614CA1AE60093E3D6 /* child.json in Resources */,
+				73D3907914CA1DD40093E3D6 /* channels.xml in Resources */,
+				252EFB2814DA0689004863C8 /* NakedEvents.json in Resources */,
+				25CAAA9415254E7800CAE5D7 /* ArrayOfHumans.json in Resources */,
+				25119FB6154A34B400C6BC58 /* parents_and_children.json in Resources */,
+				259D983C154F6C90008C90F5 /* benchmark_parents_and_children.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25160E60145651060060A5C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25160E75145651060060A5C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				251610651456F2330060A5C5 /* blake.png in Resources */,
+				251610671456F2330060A5C5 /* ArrayOfNestedDictionaries.json in Resources */,
+				251610691456F2330060A5C5 /* ArrayOfResults.json in Resources */,
+				2516106B1456F2330060A5C5 /* ComplexNestedUser.json in Resources */,
+				2516106D1456F2330060A5C5 /* ConnectingParents.json in Resources */,
+				2516106F1456F2330060A5C5 /* boy.json in Resources */,
+				251610711456F2330060A5C5 /* friends.json in Resources */,
+				251610731456F2330060A5C5 /* girl.json in Resources */,
+				251610751456F2330060A5C5 /* mixed.json in Resources */,
+				251610771456F2330060A5C5 /* DynamicKeys.json in Resources */,
+				251610791456F2330060A5C5 /* DynamicKeysWithNestedRelationship.json in Resources */,
+				2516107B1456F2330060A5C5 /* DynamicKeysWithRelationship.json in Resources */,
+				2516107D1456F2330060A5C5 /* error.json in Resources */,
+				2516107F1456F2330060A5C5 /* errors.json in Resources */,
+				251610811456F2330060A5C5 /* Foursquare.json in Resources */,
+				251610831456F2330060A5C5 /* 1.json in Resources */,
+				251610851456F2330060A5C5 /* all.json in Resources */,
+				251610871456F2330060A5C5 /* with_to_one_relationship.json in Resources */,
+				251610891456F2330060A5C5 /* nested_user.json in Resources */,
+				2516108B1456F2330060A5C5 /* RailsUser.json in Resources */,
+				2516108D1456F2330060A5C5 /* SameKeyDifferentTargetClasses.json in Resources */,
+				2516108F1456F2330060A5C5 /* user.json in Resources */,
+				251610911456F2330060A5C5 /* users.json in Resources */,
+				251610931456F2330060A5C5 /* .gitignore in Resources */,
+				251610971456F2330060A5C5 /* attributes_without_text_content.xml in Resources */,
+				251610991456F2330060A5C5 /* container_attributes.xml in Resources */,
+				2516109B1456F2330060A5C5 /* national_weather_service.xml in Resources */,
+				2516109D1456F2330060A5C5 /* orders.xml in Resources */,
+				2516109F1456F2330060A5C5 /* tab_data.xml in Resources */,
+				251610A11456F2330060A5C5 /* zend.xml in Resources */,
+				2516110D1456F2340060A5C5 /* server.rb in Resources */,
+				73D3907514CA1AE20093E3D6 /* parent.json in Resources */,
+				73D3907714CA1AE60093E3D6 /* child.json in Resources */,
+				73D3907A14CA1DD50093E3D6 /* channels.xml in Resources */,
+				252EFB2914DA0689004863C8 /* NakedEvents.json in Resources */,
+				25CAAA9515254E7800CAE5D7 /* ArrayOfHumans.json in Resources */,
+				25119FB7154A34B400C6BC58 /* parents_and_children.json in Resources */,
+				259D983D154F6C90008C90F5 /* benchmark_parents_and_children.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0779C6DD2283438BA5EAB1FB /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-resources.sh\"\n";
+		};
+		212C92B936E847348494D6F7 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-resources.sh\"\n";
+		};
+		25160D2414564E820060A5C5 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"";
+		};
+		25160E76145651060060A5C5 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		25160D1214564E810060A5C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				253B495F14E35EC300B0483F /* RKTestFixture.m in Sources */,
+				25160DDC145650490060A5C5 /* RKEntityMapping.m in Sources */,
+				25160DE0145650490060A5C5 /* RKManagedObjectImporter.m in Sources */,
+				25160DE2145650490060A5C5 /* RKManagedObjectStore.m in Sources */,
+				25160DE6145650490060A5C5 /* RKPropertyInspector+CoreData.m in Sources */,
+				25160E0A145650490060A5C5 /* RKDynamicMapping.m in Sources */,
+				25160E0C145650490060A5C5 /* RKErrorMessage.m in Sources */,
+				25DA35711836741D001A56A0 /* TKTransition.m in Sources */,
+				25160E10145650490060A5C5 /* RKAttributeMapping.m in Sources */,
+				25160E17145650490060A5C5 /* RKMapperOperation.m in Sources */,
+				25160E1B145650490060A5C5 /* RKObjectMapping.m in Sources */,
+				25160E1E145650490060A5C5 /* RKMappingOperation.m in Sources */,
+				25160E22145650490060A5C5 /* RKMappingResult.m in Sources */,
+				252CCE7817E0CA2700B7F0BF /* RKISO8601DateFormatter.m in Sources */,
+				25160E24145650490060A5C5 /* RKPropertyInspector.m in Sources */,
+				25160E26145650490060A5C5 /* RKRelationshipMapping.m in Sources */,
+				252CCE7417E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.m in Sources */,
+				25160E48145650490060A5C5 /* RKDotNetDateFormatter.m in Sources */,
+				25160E4B145650490060A5C5 /* RKLog.m in Sources */,
+				25160E4D145650490060A5C5 /* RKMIMETypes.m in Sources */,
+				25160EE41456532C0060A5C5 /* lcl_RK.m in Sources */,
+				25160EFA1456532C0060A5C5 /* LCLNSLog_RK.m in Sources */,
+				25160F0A1456532C0060A5C5 /* SOCKit.m in Sources */,
+				25B408281491CDDC00F21111 /* RKPathUtilities.m in Sources */,
+				25B6E95814CF7A1C00B1E881 /* RKErrors.m in Sources */,
+				25FABED114E3796400E609E7 /* RKTestNotificationObserver.m in Sources */,
+				25CA7A8F14EC570200888FF8 /* RKMapping.m in Sources */,
+				25055B8614EEF32A00B9C4DD /* RKMappingTest.m in Sources */,
+				25055B8A14EEF32A00B9C4DD /* RKTestFactory.m in Sources */,
+				25055B9114EEF40000B9C4DD /* RKPropertyMappingTestExpectation.m in Sources */,
+				25EC1A3B14F72B1300C3CF3F /* RKFetchRequestManagedObjectCache.m in Sources */,
+				25EC1A3F14F72B3100C3CF3F /* RKInMemoryManagedObjectCache.m in Sources */,
+				257ABAB215112DD500CCAA76 /* NSManagedObjectContext+RKAdditions.m in Sources */,
+				257ABAB81511371E00CCAA76 /* NSManagedObject+RKAdditions.m in Sources */,
+				25C954A715542A47005C9E08 /* RKTestConstants.m in Sources */,
+				259D98561550C69A008C90F5 /* RKEntityByAttributeCache.m in Sources */,
+				259D9860155218E5008C90F5 /* RKEntityCache.m in Sources */,
+				252028FE1577AE0B00076FB4 /* RKRouteSet.m in Sources */,
+				252029051577AE1800076FB4 /* RKRoute.m in Sources */,
+				25FBB854159272DD00955D27 /* RKRouter.m in Sources */,
+				258EA4AA15A38BC0007E07A6 /* RKObjectMappingOperationDataSource.m in Sources */,
+				25AA23D015AF2920006EF62D /* RKManagedObjectMappingOperationDataSource.m in Sources */,
+				2597F99E15AF6DC400E547D7 /* RKRelationshipConnectionOperation.m in Sources */,
+				25104F2115C30CD900829135 /* RKSearchWord.m in Sources */,
+				25104F2B15C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.m in Sources */,
+				25104F3115C30E7400829135 /* RKSearchIndexer.m in Sources */,
+				25104F3715C30EF500829135 /* RKSearchPredicate.m in Sources */,
+				25104F3D15C30F2100829135 /* RKSearchWordEntity.m in Sources */,
+				25F53AE415E7B612008B54E6 /* RKHTTPUtilities.m in Sources */,
+				2598888F15EC169E006CAE95 /* RKPropertyMapping.m in Sources */,
+				254372A915F54995006E8424 /* RKObjectParameterization.m in Sources */,
+				254372BA15F54C3F006E8424 /* RKHTTPRequestOperation.m in Sources */,
+				254372BE15F54C3F006E8424 /* RKObjectManager.m in Sources */,
+				254372C215F54C3F006E8424 /* RKPaginator.m in Sources */,
+				254372C615F54C3F006E8424 /* RKObjectRequestOperation.m in Sources */,
+				254372CA15F54C3F006E8424 /* RKRequestDescriptor.m in Sources */,
+				C0F11CE4190883380054AEA0 /* RKPathMatcher.m in Sources */,
+				254372CE15F54C3F006E8424 /* RKResponseDescriptor.m in Sources */,
+				254372D215F54C3F006E8424 /* RKResponseMapperOperation.m in Sources */,
+				254372D815F54CE3006E8424 /* RKManagedObjectRequestOperation.m in Sources */,
+				2595B47115F670530087A59B /* RKMIMETypeSerialization.m in Sources */,
+				2595B47515F670530087A59B /* RKNSJSONSerialization.m in Sources */,
+				252CCE6817E08E2D00B7F0BF /* RKValueTransformers.m in Sources */,
+				253477F315FFBC61002C0E4E /* RKDictionaryUtilities.m in Sources */,
+				2534781615FFD4A6002C0E4E /* RKURLEncodedSerialization.m in Sources */,
+				259B96D71604CCCC0000C250 /* AFHTTPClient.m in Sources */,
+				259B96DB1604CCCC0000C250 /* AFHTTPRequestOperation.m in Sources */,
+				259B96DF1604CCCC0000C250 /* AFImageRequestOperation.m in Sources */,
+				259B96E31604CCCC0000C250 /* AFJSONRequestOperation.m in Sources */,
+				259B96E51604CCCC0000C250 /* AFNetworkActivityIndicatorManager.m in Sources */,
+				259B96E91604CCCC0000C250 /* AFPropertyListRequestOperation.m in Sources */,
+				259B96ED1604CCCC0000C250 /* AFURLConnectionOperation.m in Sources */,
+				259B96F11604CCCC0000C250 /* AFXMLRequestOperation.m in Sources */,
+				259B96F31604CCCC0000C250 /* UIImageView+AFNetworking.m in Sources */,
+				25A226D81618A57500952D72 /* RKObjectUtilities.m in Sources */,
+				2507C329161BD5C700EA71FF /* RKTestHelpers.m in Sources */,
+				25E88C8A165C5CC30042ABD0 /* RKConnectionDescription.m in Sources */,
+				25A8C2361673BD480014D9A6 /* RKConnectionTestExpectation.m in Sources */,
+				258BEA02168D058300C74C8C /* RKObjectMappingMatcher.m in Sources */,
+				25A199D616ED035A00792629 /* RKBenchmark.m in Sources */,
+				25C6C0BF1716F6F800C98A73 /* TKEvent.m in Sources */,
+				25C6C0C31716F6F800C98A73 /* TKState.m in Sources */,
+				25C6C0C71716F6F800C98A73 /* TKStateMachine.m in Sources */,
+				25C6C0EA1716F79B00C98A73 /* RKOperationStateMachine.m in Sources */,
+				54CDB45D17B408B100FAC285 /* RKStringTokenizer.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25160D2114564E820060A5C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				251610601456F2330060A5C5 /* RKManagedObjectStoreTest.m in Sources */,
+				251610A21456F2330060A5C5 /* Data Model.xcdatamodel in Sources */,
+				251610A41456F2330060A5C5 /* RKCat.m in Sources */,
+				251610A61456F2330060A5C5 /* RKChild.m in Sources */,
+				251610A81456F2330060A5C5 /* RKDynamicMappingModels.m in Sources */,
+				251610AA1456F2330060A5C5 /* RKHouse.m in Sources */,
+				251610AC1456F2330060A5C5 /* RKHuman.m in Sources */,
+				251610AE1456F2330060A5C5 /* RKMappableAssociation.m in Sources */,
+				251610B01456F2330060A5C5 /* RKMappableObject.m in Sources */,
+				251610B21456F2330060A5C5 /* RKObjectLoaderTestResultModel.m in Sources */,
+				251610B41456F2330060A5C5 /* RKObjectMapperTestModel.m in Sources */,
+				251610B61456F2330060A5C5 /* RKParent.m in Sources */,
+				251610B81456F2330060A5C5 /* RKResident.m in Sources */,
+				251610D21456F2330060A5C5 /* RKDynamicMappingTest.m in Sources */,
+				251610DC1456F2330060A5C5 /* RKObjectMappingNextGenTest.m in Sources */,
+				251610DE1456F2330060A5C5 /* RKMappingOperationTest.m in Sources */,
+				251610E21456F2330060A5C5 /* RKMappingResultTest.m in Sources */,
+				251610E81456F2330060A5C5 /* RKMIMETypeSerializationTest.m in Sources */,
+				251610F01456F2340060A5C5 /* RKTestEnvironment.m in Sources */,
+				2516110E1456F2340060A5C5 /* RKURLEncodedSerializationTest.m in Sources */,
+				251611101456F2340060A5C5 /* NSStringRestKitTest.m in Sources */,
+				251611121456F2340060A5C5 /* RKDotNetDateFormatterTest.m in Sources */,
+				251611161456F2340060A5C5 /* RKPathMatcherTest.m in Sources */,
+				25B6E9DB14CF912500B1E881 /* RKSearchable.m in Sources */,
+				25B6E9DD14CF912500B1E881 /* RKTestAddress.m in Sources */,
+				25B6E9DF14CF912500B1E881 /* RKTestUser.m in Sources */,
+				252EFAFA14D8EAEC004863C8 /* RKEvent.m in Sources */,
+				25E36E0215195CED00F9E448 /* RKFetchRequestMappingCacheTest.m in Sources */,
+				25DB7508151BD551009F01AF /* NSManagedObjectContext+RKAdditionsTest.m in Sources */,
+				259D985A1550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m in Sources */,
+				259D986415521B20008C90F5 /* RKEntityCacheTest.m in Sources */,
+				252029091577C78600076FB4 /* RKRouteSetTest.m in Sources */,
+				2519764315823BA1004FE9DD /* RKAttributeMappingTest.m in Sources */,
+				2519764815824455004FE9DD /* RKRelationshipMappingTest.m in Sources */,
+				2519764C158244F8004FE9DD /* RKObjectMappingTest.m in Sources */,
+				25AA23D815AF5085006EF62D /* RKManagedObjectMappingOperationDataSourceTest.m in Sources */,
+				258EFF7A15C0CE1400EE4E0D /* RKManagedObjectSeederTest.m in Sources */,
+				25A763E515C7424500A9DF31 /* RKSearchIndexerTest.m in Sources */,
+				25C246A415C83B090032212E /* RKSearchTest.m in Sources */,
+				5C927E141608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m in Sources */,
+				25E9C8F01612523400647F84 /* RKObjectParameterizationTest.m in Sources */,
+				25EDFCE3161538F6008BAA1D /* RKObjectManagerTest.m in Sources */,
+				2564E40B16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m in Sources */,
+				25CDA0E7161E828D00F583F3 /* RKISODateFormatterTest.m in Sources */,
+				25BB392E161F4FD700E5C72A /* RKPathUtilitiesTest.m in Sources */,
+				25565965161FDD8800F5BB20 /* RKResponseMapperOperationTest.m in Sources */,
+				259AC481162B05C80012D2F9 /* RKObjectRequestOperationTest.m in Sources */,
+				252205CC162B242400F7B11E /* RKHTTPUtilitiesTest.m in Sources */,
+				2549D646162B376F003DD135 /* RKRequestDescriptorTest.m in Sources */,
+				2506759F162DEA25003210B0 /* RKEntityMappingTest.m in Sources */,
+				255F87911656B22D00914D57 /* RKPaginatorTest.m in Sources */,
+				2543A25D1664FD3100821D5B /* RKResponseDescriptorTest.m in Sources */,
+				2536D1FD167270F100DF9BB0 /* RKRouterTest.m in Sources */,
+				2551338F167838590017E4B6 /* RKHTTPRequestOperationTest.m in Sources */,
+				255133CF167AC7600017E4B6 /* RKManagedObjectRequestOperationTest.m in Sources */,
+				25B639CC16961EFA0065EB7B /* RKMappingTestTest.m in Sources */,
+				25A73362169C8C230090A930 /* VersionedModel.xcdatamodeld in Sources */,
+				25A9827516A5FF4F0088A3CA /* RKConnectionDescriptionTest.m in Sources */,
+				2550DA2316B1FB62005A0CB8 /* RKPost.m in Sources */,
+				2582F56D173038760043B8BB /* RKInMemoryManagedObjectCacheTest.m in Sources */,
+				BE05BDD11782109F00F7C9C9 /* RKRouteTest.m in Sources */,
+				25AABCED17B698940061DC5B /* RKStringTokenizerTest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25160E5D145651060060A5C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25160EE51456532C0060A5C5 /* lcl_RK.m in Sources */,
+				25160EFB1456532C0060A5C5 /* LCLNSLog_RK.m in Sources */,
+				25160F0B1456532C0060A5C5 /* SOCKit.m in Sources */,
+				25160F45145655C60060A5C5 /* RKDynamicMapping.m in Sources */,
+				25160F47145655C60060A5C5 /* RKErrorMessage.m in Sources */,
+				25160F4B145655C60060A5C5 /* RKAttributeMapping.m in Sources */,
+				25160F52145655C60060A5C5 /* RKMapperOperation.m in Sources */,
+				25DA35721836741D001A56A0 /* TKTransition.m in Sources */,
+				25160F56145655C60060A5C5 /* RKObjectMapping.m in Sources */,
+				25160F59145655C60060A5C5 /* RKMappingOperation.m in Sources */,
+				25160F5D145655C60060A5C5 /* RKMappingResult.m in Sources */,
+				25160F5F145655C60060A5C5 /* RKPropertyInspector.m in Sources */,
+				25160F61145655C60060A5C5 /* RKRelationshipMapping.m in Sources */,
+				252CCE7917E0CA2700B7F0BF /* RKISO8601DateFormatter.m in Sources */,
+				25160F70145655D10060A5C5 /* RKEntityMapping.m in Sources */,
+				25160F74145655D10060A5C5 /* RKManagedObjectImporter.m in Sources */,
+				252CCE7517E0CA2700B7F0BF /* ISO8601DateFormatterValueTransformer.m in Sources */,
+				25160F76145655D10060A5C5 /* RKManagedObjectStore.m in Sources */,
+				25160F7A145655D10060A5C5 /* RKPropertyInspector+CoreData.m in Sources */,
+				25160F911456576C0060A5C5 /* RKDotNetDateFormatter.m in Sources */,
+				25160F941456576C0060A5C5 /* RKLog.m in Sources */,
+				25160F961456576C0060A5C5 /* RKMIMETypes.m in Sources */,
+				25B408291491CDDC00F21111 /* RKPathUtilities.m in Sources */,
+				25B6E95914CF7A1C00B1E881 /* RKErrors.m in Sources */,
+				25FABED014E3796400E609E7 /* RKTestNotificationObserver.m in Sources */,
+				25CA7A9014EC570200888FF8 /* RKMapping.m in Sources */,
+				25CA7A9114EC5C2D00888FF8 /* RKTestFixture.m in Sources */,
+				25055B8714EEF32A00B9C4DD /* RKMappingTest.m in Sources */,
+				25055B8B14EEF32A00B9C4DD /* RKTestFactory.m in Sources */,
+				25055B9214EEF40000B9C4DD /* RKPropertyMappingTestExpectation.m in Sources */,
+				25EC1A3C14F72B1400C3CF3F /* RKFetchRequestManagedObjectCache.m in Sources */,
+				25EC1A4014F72B3300C3CF3F /* RKInMemoryManagedObjectCache.m in Sources */,
+				257ABAB315112DD500CCAA76 /* NSManagedObjectContext+RKAdditions.m in Sources */,
+				257ABAB91511371E00CCAA76 /* NSManagedObject+RKAdditions.m in Sources */,
+				25C954A815542A47005C9E08 /* RKTestConstants.m in Sources */,
+				259D98571550C69A008C90F5 /* RKEntityByAttributeCache.m in Sources */,
+				259D9861155218E5008C90F5 /* RKEntityCache.m in Sources */,
+				252028FF1577AE0B00076FB4 /* RKRouteSet.m in Sources */,
+				252029061577AE1800076FB4 /* RKRoute.m in Sources */,
+				25FBB855159272DD00955D27 /* RKRouter.m in Sources */,
+				258EA4AB15A38BC0007E07A6 /* RKObjectMappingOperationDataSource.m in Sources */,
+				25AA23D115AF2920006EF62D /* RKManagedObjectMappingOperationDataSource.m in Sources */,
+				2597F99F15AF6DC400E547D7 /* RKRelationshipConnectionOperation.m in Sources */,
+				25104F2215C30CD900829135 /* RKSearchWord.m in Sources */,
+				25104F2C15C30D1700829135 /* RKManagedObjectStore+RKSearchAdditions.m in Sources */,
+				25104F3215C30E7400829135 /* RKSearchIndexer.m in Sources */,
+				25104F3815C30EF500829135 /* RKSearchPredicate.m in Sources */,
+				25104F3E15C30F2100829135 /* RKSearchWordEntity.m in Sources */,
+				25F53AE515E7B612008B54E6 /* RKHTTPUtilities.m in Sources */,
+				2598889015EC169E006CAE95 /* RKPropertyMapping.m in Sources */,
+				254372BB15F54C3F006E8424 /* RKHTTPRequestOperation.m in Sources */,
+				254372BF15F54C3F006E8424 /* RKObjectManager.m in Sources */,
+				254372C315F54C3F006E8424 /* RKPaginator.m in Sources */,
+				254372C715F54C3F006E8424 /* RKObjectRequestOperation.m in Sources */,
+				254372CB15F54C3F006E8424 /* RKRequestDescriptor.m in Sources */,
+				254372CF15F54C3F006E8424 /* RKResponseDescriptor.m in Sources */,
+				C0F11CE6190883460054AEA0 /* RKPathMatcher.m in Sources */,
+				254372D315F54C3F006E8424 /* RKResponseMapperOperation.m in Sources */,
+				254372D915F54CE3006E8424 /* RKManagedObjectRequestOperation.m in Sources */,
+				2595B47215F670530087A59B /* RKMIMETypeSerialization.m in Sources */,
+				2595B47615F670530087A59B /* RKNSJSONSerialization.m in Sources */,
+				253477F415FFBC61002C0E4E /* RKDictionaryUtilities.m in Sources */,
+				252CCE6917E08E2D00B7F0BF /* RKValueTransformers.m in Sources */,
+				2534781715FFD4A6002C0E4E /* RKURLEncodedSerialization.m in Sources */,
+				259B96D81604CCCC0000C250 /* AFHTTPClient.m in Sources */,
+				259B96DC1604CCCC0000C250 /* AFHTTPRequestOperation.m in Sources */,
+				259B96E01604CCCC0000C250 /* AFImageRequestOperation.m in Sources */,
+				259B96E41604CCCC0000C250 /* AFJSONRequestOperation.m in Sources */,
+				259B96E61604CCCC0000C250 /* AFNetworkActivityIndicatorManager.m in Sources */,
+				259B96EA1604CCCC0000C250 /* AFPropertyListRequestOperation.m in Sources */,
+				259B96EE1604CCCC0000C250 /* AFURLConnectionOperation.m in Sources */,
+				259B96F21604CCCC0000C250 /* AFXMLRequestOperation.m in Sources */,
+				259B96F41604CCCC0000C250 /* UIImageView+AFNetworking.m in Sources */,
+				25E9C8F1161290D500647F84 /* RKObjectParameterization.m in Sources */,
+				25A226D91618A57500952D72 /* RKObjectUtilities.m in Sources */,
+				2507C32A161BD5C700EA71FF /* RKTestHelpers.m in Sources */,
+				25E88C8B165C5CC30042ABD0 /* RKConnectionDescription.m in Sources */,
+				25A8C2371673BD480014D9A6 /* RKConnectionTestExpectation.m in Sources */,
+				258BEA03168D058300C74C8C /* RKObjectMappingMatcher.m in Sources */,
+				25A199D716ED035A00792629 /* RKBenchmark.m in Sources */,
+				25C6C0C01716F6F800C98A73 /* TKEvent.m in Sources */,
+				25C6C0C41716F6F800C98A73 /* TKState.m in Sources */,
+				25C6C0C81716F6F800C98A73 /* TKStateMachine.m in Sources */,
+				25C6C0EB1716F79B00C98A73 /* RKOperationStateMachine.m in Sources */,
+				54CDB45E17B408B100FAC285 /* RKStringTokenizer.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25160E73145651060060A5C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7AF2905218DF249C009AEB94 /* RKObjectiveCppTest.mm in Sources */,
+				251610611456F2330060A5C5 /* RKManagedObjectStoreTest.m in Sources */,
+				251610A31456F2330060A5C5 /* Data Model.xcdatamodel in Sources */,
+				251610A51456F2330060A5C5 /* RKCat.m in Sources */,
+				251610A71456F2330060A5C5 /* RKChild.m in Sources */,
+				251610A91456F2330060A5C5 /* RKDynamicMappingModels.m in Sources */,
+				251610AB1456F2330060A5C5 /* RKHouse.m in Sources */,
+				251610AD1456F2330060A5C5 /* RKHuman.m in Sources */,
+				251610AF1456F2330060A5C5 /* RKMappableAssociation.m in Sources */,
+				251610B11456F2330060A5C5 /* RKMappableObject.m in Sources */,
+				251610B31456F2330060A5C5 /* RKObjectLoaderTestResultModel.m in Sources */,
+				251610B51456F2330060A5C5 /* RKObjectMapperTestModel.m in Sources */,
+				251610B71456F2330060A5C5 /* RKParent.m in Sources */,
+				251610B91456F2330060A5C5 /* RKResident.m in Sources */,
+				251610D31456F2330060A5C5 /* RKDynamicMappingTest.m in Sources */,
+				251610DD1456F2330060A5C5 /* RKObjectMappingNextGenTest.m in Sources */,
+				251610DF1456F2330060A5C5 /* RKMappingOperationTest.m in Sources */,
+				251610E31456F2330060A5C5 /* RKMappingResultTest.m in Sources */,
+				251610E71456F2330060A5C5 /* RKObjectParameterizationTest.m in Sources */,
+				251610E91456F2330060A5C5 /* RKMIMETypeSerializationTest.m in Sources */,
+				251610F11456F2340060A5C5 /* RKTestEnvironment.m in Sources */,
+				2516110F1456F2340060A5C5 /* RKURLEncodedSerializationTest.m in Sources */,
+				251611111456F2340060A5C5 /* NSStringRestKitTest.m in Sources */,
+				251611131456F2340060A5C5 /* RKDotNetDateFormatterTest.m in Sources */,
+				251611171456F2340060A5C5 /* RKPathMatcherTest.m in Sources */,
+				25B6E9DC14CF912500B1E881 /* RKSearchable.m in Sources */,
+				25B6E9DE14CF912500B1E881 /* RKTestAddress.m in Sources */,
+				25B6E9E014CF912500B1E881 /* RKTestUser.m in Sources */,
+				252EFAFB14D8EAEC004863C8 /* RKEvent.m in Sources */,
+				25E36E0315195CED00F9E448 /* RKFetchRequestMappingCacheTest.m in Sources */,
+				25DB7509151BD551009F01AF /* NSManagedObjectContext+RKAdditionsTest.m in Sources */,
+				259D985B1550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m in Sources */,
+				259D986515521B20008C90F5 /* RKEntityCacheTest.m in Sources */,
+				2520290A1577C78600076FB4 /* RKRouteSetTest.m in Sources */,
+				2519764415823BA1004FE9DD /* RKAttributeMappingTest.m in Sources */,
+				2519764915824455004FE9DD /* RKRelationshipMappingTest.m in Sources */,
+				2519764D158244F8004FE9DD /* RKObjectMappingTest.m in Sources */,
+				25AA23D915AF5086006EF62D /* RKManagedObjectMappingOperationDataSourceTest.m in Sources */,
+				258EFF7B15C0CE1400EE4E0D /* RKManagedObjectSeederTest.m in Sources */,
+				25A763E615C7424500A9DF31 /* RKSearchIndexerTest.m in Sources */,
+				25C246A515C83B090032212E /* RKSearchTest.m in Sources */,
+				5C927E151608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m in Sources */,
+				25EDFCE5161538F8008BAA1D /* RKObjectManagerTest.m in Sources */,
+				2564E40C16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m in Sources */,
+				25CDA0E8161E828E00F583F3 /* RKISODateFormatterTest.m in Sources */,
+				25BB392F161F4FD700E5C72A /* RKPathUtilitiesTest.m in Sources */,
+				25565966161FDD8800F5BB20 /* RKResponseMapperOperationTest.m in Sources */,
+				259AC482162B05C80012D2F9 /* RKObjectRequestOperationTest.m in Sources */,
+				252205CD162B242400F7B11E /* RKHTTPUtilitiesTest.m in Sources */,
+				2549D647162B376F003DD135 /* RKRequestDescriptorTest.m in Sources */,
+				250675A1162DEA27003210B0 /* RKEntityMappingTest.m in Sources */,
+				2548AC6E162F5E00009E79BF /* RKManagedObjectRequestOperationTest.m in Sources */,
+				255F87921656B22F00914D57 /* RKPaginatorTest.m in Sources */,
+				2546A95916628EDD0078E044 /* RKConnectionDescriptionTest.m in Sources */,
+				2543A25E1664FD3200821D5B /* RKResponseDescriptorTest.m in Sources */,
+				2536D1FE167270F100DF9BB0 /* RKRouterTest.m in Sources */,
+				25513390167838590017E4B6 /* RKHTTPRequestOperationTest.m in Sources */,
+				25B639CD16961EFA0065EB7B /* RKMappingTestTest.m in Sources */,
+				25A73363169C8C230090A930 /* VersionedModel.xcdatamodeld in Sources */,
+				2550DA2416B1FB62005A0CB8 /* RKPost.m in Sources */,
+				2582F56E173038760043B8BB /* RKInMemoryManagedObjectCacheTest.m in Sources */,
+				BE05BDD2178214AA00F7C9C9 /* RKRouteTest.m in Sources */,
+				25AABCEE17B698940061DC5B /* RKStringTokenizerTest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		25160D2D14564E820060A5C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 25160D1514564E810060A5C5 /* RestKit */;
+			targetProxy = 25160D2C14564E820060A5C5 /* PBXContainerItemProxy */;
+		};
+		25160E7C145651060060A5C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 25160E61145651060060A5C5 /* RestKitFramework */;
+			targetProxy = 25160E7B145651060060A5C5 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		25160D3814564E820060A5C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Debug;
+		};
+		25160D3914564E820060A5C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
+				SDKROOT = iphoneos;
+				STRIP_INSTALLED_PRODUCT = NO;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		25160D3B14564E820060A5C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Code/Support/RestKit-Prefix.pch";
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				INSTALL_PATH = "@rpath";
+				OBJROOT = "$(SRCROOT)/Build";
+				OTHER_LDFLAGS = "-ObjC";
+				PRIVATE_HEADERS_FOLDER_PATH = "$(PUBLIC_HEADERS_FOLDER_PATH)/Private";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = ../../Headers/RestKit;
+				SKIP_INSTALL = YES;
+				SYMROOT = "$(SRCROOT)/Build/Products";
+			};
+			name = Debug;
+		};
+		25160D3C14564E820060A5C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Code/Support/RestKit-Prefix.pch";
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				INSTALL_PATH = "@rpath";
+				OBJROOT = "$(SRCROOT)/Build";
+				OTHER_LDFLAGS = "-ObjC";
+				PRIVATE_HEADERS_FOLDER_PATH = "$(PUBLIC_HEADERS_FOLDER_PATH)/Private";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = ../../Headers/RestKit;
+				SKIP_INSTALL = YES;
+				SYMROOT = "$(SRCROOT)/Build/Products";
+			};
+			name = Release;
+		};
+		25160D3E14564E820060A5C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 147F950728350A64F103F55D /* Pods-ios.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Code/Support/RestKit-Prefix.pch";
+				INFOPLIST_FILE = "Resources/PLISTs/RestKitTests-Info.plist";
+				OBJROOT = "$(SRCROOT)/Build";
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYMROOT = "$(SRCROOT)/Build/Products";
+			};
+			name = Debug;
+		};
+		25160D3F14564E820060A5C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 061E3E4524CE8EF78257C26C /* Pods-ios.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Code/Support/RestKit-Prefix.pch";
+				INFOPLIST_FILE = "Resources/PLISTs/RestKitTests-Info.plist";
+				OBJROOT = "$(SRCROOT)/Build";
+				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYMROOT = "$(SRCROOT)/Build/Products";
+			};
+			name = Release;
+		};
+		25160E88145651060060A5C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(DEVELOPER_FRAMEWORKS_DIR)\"",
+				);
+				FRAMEWORK_VERSION = A;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Code/Support/RestKit-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				INFOPLIST_FILE = "Resources/PLISTs/RestKitFramework-Info.plist";
+				INSTALL_PATH = "@rpath";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = RestKit;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Debug;
+		};
+		25160E89145651060060A5C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(DEVELOPER_FRAMEWORKS_DIR)\"",
+				);
+				FRAMEWORK_VERSION = A;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Code/Support/RestKit-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				INFOPLIST_FILE = "Resources/PLISTs/RestKitFramework-Info.plist";
+				INSTALL_PATH = "@rpath";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				PRODUCT_NAME = RestKit;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Release;
+		};
+		25160E8B145651060060A5C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D8EFCBE1978F7946E0081FAD /* Pods-osx.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Code/Support/RestKit-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				INFOPLIST_FILE = "Resources/PLISTs/RestKitFrameworkTests-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		25160E8C145651060060A5C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 04D69B4B2A54475834B333CF /* Pods-osx.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Code/Support/RestKit-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				INFOPLIST_FILE = "Resources/PLISTs/RestKitFrameworkTests-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		25160D1014564E810060A5C5 /* Build configuration list for PBXProject "RestKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25160D3814564E820060A5C5 /* Debug */,
+				25160D3914564E820060A5C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		25160D3A14564E820060A5C5 /* Build configuration list for PBXNativeTarget "RestKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25160D3B14564E820060A5C5 /* Debug */,
+				25160D3C14564E820060A5C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		25160D3D14564E820060A5C5 /* Build configuration list for PBXNativeTarget "RestKitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25160D3E14564E820060A5C5 /* Debug */,
+				25160D3F14564E820060A5C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		25160E87145651060060A5C5 /* Build configuration list for PBXNativeTarget "RestKitFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25160E88145651060060A5C5 /* Debug */,
+				25160E89145651060060A5C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		25160E8A145651060060A5C5 /* Build configuration list for PBXNativeTarget "RestKitFrameworkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25160E8B145651060060A5C5 /* Debug */,
+				25160E8C145651060060A5C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		25A73360169C8C230090A930 /* VersionedModel.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				25A73365169C8CD80090A930 /* VersionedModel 2.xcdatamodel */,
+				25A73366169C8CF30090A930 /* VersionedModel 3.xcdatamodel */,
+				25A73367169C8D500090A930 /* VersionedModel 4.xcdatamodel */,
+				25A73361169C8C230090A930 /* VersionedModel.xcdatamodel */,
+			);
+			currentVersion = 25A73367169C8D500090A930 /* VersionedModel 4.xcdatamodel */;
+			path = VersionedModel.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
+	};
+	rootObject = 25160D0D14564E810060A5C5 /* Project object */;
+}


### PR DESCRIPTION
Xcode 6.x will modify the format of the project files, so unless we update its format all new pull request will have conflicts.
