### PR TITLE
Fix missing completion blocks when RKObjectRequestOperation is copied.

### DIFF
--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -295,6 +295,8 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
 @property (nonatomic, copy) id (^willMapDeserializedResponseBlock)(id deserializedResponseBody);
 @property (nonatomic, strong) NSDate *mappingDidStartDate;
 @property (nonatomic, strong) NSDate *mappingDidFinishDate;
+@property (nonatomic, copy) void (^successBlock)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult);
+@property (nonatomic, copy) void (^failureBlock)(RKObjectRequestOperation *operation, NSError *error);
 @end
 
 @implementation RKObjectRequestOperation
@@ -457,6 +459,11 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
 // See above setCompletionBlock:
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
+
+    //Keep blocks for copyWithZone
+    self.successBlock = success;
+    self.failureBlock = failure;
+
     self.completionBlock = ^ {
         if ([self isCancelled] && !self.error) {
             self.error = [NSError errorWithDomain:RKErrorDomain code:RKOperationCancelledError userInfo:nil];
@@ -570,8 +577,8 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
     operation.successCallbackQueue = self.successCallbackQueue;
     operation.failureCallbackQueue = self.failureCallbackQueue;
     operation.willMapDeserializedResponseBlock = self.willMapDeserializedResponseBlock;
-    operation.completionBlock = self.completionBlock;
-    
+    [operation setCompletionBlockWithSuccess:self.successBlock failure:self.failureBlock];
+
     return operation;
 }
 

--- a/Tests/Logic/Network/RKObjectRequestOperationTest.m
+++ b/Tests/Logic/Network/RKObjectRequestOperationTest.m
@@ -730,6 +730,66 @@
     expect(user.phone).to.equal(@"867-5309");
 }
 
+
+- (void)testCopyingOperationWithSuccessBlock
+{
+	RKObjectMapping *userMapping = [RKObjectMapping mappingForClass:[RKTestComplexUser class]];
+	[userMapping addAttributeMappingsFromDictionary:@{ @"@metadata.phoneNumber": @"phone" }];
+	RKResponseDescriptor *responseDescriptor = [RKResponseDescriptor responseDescriptorWithMapping:userMapping method:RKRequestMethodAny pathPattern:nil keyPath:nil statusCodes:RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful)];
+	
+	RKTestComplexUser *user = [RKTestComplexUser new];
+	user.firstname = @"Blake";
+	user.lastname = @"Watters";
+	user.email = @"blake@restkit.org";
+	
+	NSMutableURLRequest *request = [NSMutableURLRequest  requestWithURL:[NSURL URLWithString:@"/humans" relativeToURL:[RKTestFactory baseURL]]];
+	request.HTTPMethod = @"POST";
+	RKObjectRequestOperation *requestOperation = [[RKObjectRequestOperation alloc] initWithRequest:request responseDescriptors:@[ responseDescriptor ]];
+	
+	__block BOOL invoked = NO;
+	[requestOperation setCompletionBlockWithSuccess:^(RKObjectRequestOperation *operation, RKMappingResult *mappingResult) {
+		invoked = YES;
+	} failure:nil];
+	[requestOperation start];
+	expect([requestOperation isFinished]).will.beTruthy();
+	expect(invoked).will.beTruthy();
+	
+	RKObjectRequestOperation *copiedOperation = [requestOperation copy];
+	copiedOperation.mappingMetadata = @{ @"phoneNumber": @"867-5309" };
+	copiedOperation.targetObject = user;
+	invoked = NO;
+	[copiedOperation start];
+	[copiedOperation waitUntilFinished];
+	expect(requestOperation.error).to.beNil();
+	expect(requestOperation.mappingResult).notTo.beNil();
+	expect(user.phone).to.equal(@"867-5309");
+	expect(invoked).will.beTruthy();
+}
+
+
+- (void)testCopyingOperationWithFaiureBlock
+{
+	NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"/errors.json" relativeToURL:[RKTestFactory baseURL]]];
+	RKObjectRequestOperation *requestOperation = [[RKObjectRequestOperation alloc] initWithRequest:request responseDescriptors:@[ ]];
+	
+	__block NSError *blockError = nil;
+	[requestOperation setCompletionBlockWithSuccess:nil failure:^(RKObjectRequestOperation *operation, NSError *error) {
+		blockError = error;
+	}];
+	
+	[requestOperation start];
+	expect([requestOperation isFinished]).will.beTruthy();
+	expect(blockError).willNot.beNil();
+	
+	RKObjectRequestOperation *copiedOperation = [requestOperation copy];
+	blockError = nil;
+	[copiedOperation start];
+	[copiedOperation waitUntilFinished];
+	expect([requestOperation isFinished]).will.beTruthy();
+	expect(blockError).willNot.beNil();
+}
+
+
 #pragma mark -
 
 - (void)testThatCacheEntryIsFlaggedWhenMappingCompletes


### PR DESCRIPTION
RKObjectRequestOperation.copyWithZone tried to copy the completionBlock to the destination object. But the completionBlock have been set as nil after the operation is finished.
And because the completionBlock captures the source object as self, the completionBlock shouldn't be passed to the destination object. So it is necessary to keep success and failure blocks so that these blocks could be passed to the destination via setCompletionBlockWithSuccess: failure:. 