### PR TITLE
Speed up RKMappingSourceObject KeyValue

### DIFF
--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -152,6 +152,7 @@ static NSString *const RKSelfKeyPathPrefix = @"self.";
 
 - (id)valueForKey:(NSString *)key
 {
+    /* Using firstChar as a small performance enhancement -- one check can avoid several isEqual: calls */
     unichar firstChar = [key length] > 0 ? [key characterAtIndex:0] : 0;
 
     if (firstChar == 's' && [key isEqualToString:RKSelfKey]) {
@@ -174,6 +175,7 @@ static NSString *const RKSelfKeyPathPrefix = @"self.";
  */
 - (id)valueForKeyPath:(NSString *)keyPath
 {
+    /* Using firstChar as a small performance enhancement -- one check can avoid several hasPrefix calls */
     unichar firstChar = [keyPath length] > 0 ? [keyPath characterAtIndex:0] : 0;
 
     if (firstChar == 's' && [keyPath hasPrefix:RKSelfKeyPathPrefix]) {


### PR DESCRIPTION
The CFStringHasPrefix function did show up as a minor hotspot when profiling for issues mentioned on RestKit/RestKit/issues/2065, and I tracked it back to RKMappingSourceObject.  While hasPrefix is pretty fast, most calls it will not be one of the special keys, so a quick character check at the start can avoid all of the extra work.

I don't think it's possible to have an empty key used with valueForKey[Path], but if you want to be safe, I could add a check for [key length] == 0 as well.

It's not a huge improvement, but here are the numbers before:

(Device) Mapping 5000 students with relationship mapping: 39.762720
(Simulator) Mapping 5000 students with relationship mapping: 5.673784

After:

(Device) Mapping 5000 students with relationship mapping: 39.540743
(Simulator) Mapping 5000 students with relationship mapping: 5.572813
