### PR TITLE
The RKObjectMapping -classForKeyPath: gets called a lot; avoiding the cr...

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -398,6 +398,8 @@ static RKSourceToDesinationKeyTransformationBlock defaultSourceToDestinationKeyT
 
 - (Class)classForKeyPath:(NSString *)keyPath
 {
+    if (keyPath == nil) return self.objectClass;
+
     RKPropertyInspector *inspector = [RKPropertyInspector sharedInspector];
 
     if ([keyPath rangeOfString:@"." options:NSLiteralSearch].length == 0) {


### PR DESCRIPTION
The RKObjectMapping -classForKeyPath: gets called a lot; avoiding the creation of a temporary NSArray for simple keys (the usual case) makes a measurable speed difference.  This does show up in profiling for RestKit/RestKit/issues/2065

Using NSLiteralSearch is faster than option 0 (since the default is to normalize the strings first), so I just added that.  Using rangeOfCharacterFromSet: is faster still, but that would require creating a global variable with the NSCharacterSet instance (even calling a method to get it would negate any advantage), so I didn't bother.  It might be something to consider if it can be used in a number of places, but the speedups are still pretty minor.  The big thing is to avoid the object creation.

Speed before:
(Device) Mapping 5000 students with relationship mapping: 39.823580
(Simulator) Mapping 5000 students with relationship mapping: 5.768704

After:
(Device) Mapping 5000 students with relationship mapping: 38.642747
(Simulator) Mapping 5000 students with relationship mapping: 5.517917
