### PR TITLE
Fix a unit test which fails when run with Xcode6 / iOS8

### DIFF
--- a/Tests/Logic/Network/RKObjectRequestOperationTest.m
+++ b/Tests/Logic/Network/RKObjectRequestOperationTest.m
@@ -122,7 +122,7 @@
     
     // iOS8 (and presumably 10.10) returns NSURLErrorUnsupportedURL which means the HTTP NSURLProtocol does not accept it
     NSArray *validErrorCodes = @[ @(NSURLErrorBadURL), @(NSURLErrorUnsupportedURL) ];
-    assertThat(validErrorCodes, hasItem(@([requestOperation.error code])));
+    expect(validErrorCodes).to.contain(requestOperation.error.code);
 }
 
 #pragma mark - Complex JSON


### PR DESCRIPTION
Fix a unit test which fails when run with Xcode6 (at least on an iOS8 simulator).  It looks like the internal HTTP NSURLProtocol returns NO from canInitWithRequest: if the URL has invalid characters like this, meaning no NSURLProtocols match it, and we get an NSURLErrorUnsupportedURL instead of NSURLErrorBadURL.  So, accept either error code.   Also changed some local variable types to avoid compiler warning.
