### PR TITLE
Small speedups in RKPropertyInspector

### DIFF
--- a/Code/ObjectMapping/RKPropertyInspector.h
+++ b/Code/ObjectMapping/RKPropertyInspector.h
@@ -51,26 +51,6 @@
 
 @end
 
-///--------------------------------------------------
-/// @name Keys for the Property Inspection Dictionary
-///--------------------------------------------------
-
-/**
- The name of the property
- */
-extern NSString * const RKPropertyInspectionNameKey DEPRECATED_MSG_ATTRIBUTE("Use the RKPropertyInspectorPropertyInfo name property");
-
-/**
- The class used for key-value coding access to the property.
- 
- If the property is an object object type, then the class set for this key will be the type of the property. If the property is a primitive, then the class set for the key will be the boxed type used for KVC access to the property. For example, an `NSInteger` property is boxed to an `NSNumber` for KVC purposes.
- */
-extern NSString * const RKPropertyInspectionKeyValueCodingClassKey DEPRECATED_MSG_ATTRIBUTE("Use the RKPropertyInspectorPropertyInfo keyValueCodingClass property");
-
-/**
- A Boolean value that indicates if the property is a primitive (non-object) value.
- */
-extern NSString * const RKPropertyInspectionIsPrimitiveKey DEPRECATED_MSG_ATTRIBUTE("Use the RKPropertyInspectorPropertyInfo isPrimitive property");
 
 /**
  The `RKPropertyInspector` class provides an interface for introspecting the properties and attributes of classes using the reflection capabilities of the Objective-C runtime. Once inspected, the properties inspection details are cached.

--- a/Code/ObjectMapping/RKPropertyInspector.m
+++ b/Code/ObjectMapping/RKPropertyInspector.m
@@ -49,22 +49,6 @@ NSString * const RKPropertyInspectionIsPrimitiveKey = @"isPrimitive";
     return self;
 }
 
-/* In case external code calls us as a dictionary */
-- (id)objectForKey:(id)key
-{
-    return [self valueForKey:key];
-}
-
-- (id)objectForKeyedSubscript:(id)key
-{
-    return [self valueForKey:key];
-}
-
-- (id)valueForUndefinedKey:(NSString *)key
-{
-    return nil;
-}
-
 @end
 
 
@@ -175,8 +159,8 @@ NSString * const RKPropertyInspectionIsPrimitiveKey = @"isPrimitive";
 {
     NSDictionary *classInspection = [self propertyInspectionForClass:objectClass];
     RKPropertyInspectorPropertyInfo *propertyInspection = [classInspection objectForKey:propertyName];
-    if (isPrimitive) *isPrimitive = [propertyInspection isPrimitive];
-    return [propertyInspection keyValueCodingClass];
+    if (isPrimitive) *isPrimitive = propertyInspection.isPrimitive;
+    return propertyInspection.keyValueCodingClass;
 }
 
 @end
@@ -200,7 +184,7 @@ NSString * const RKPropertyInspectionIsPrimitiveKey = @"isPrimitive";
 
     NSArray *components = [keyPath componentsSeparatedByString:@"."];
     for (NSString *property in components) {
-        propertyClass = [[RKPropertyInspector sharedInspector] classForPropertyNamed:property ofClass:propertyClass isPrimitive:isPrimitive];
+        propertyClass = [inspector classForPropertyNamed:property ofClass:propertyClass isPrimitive:isPrimitive];
         if (! propertyClass) break;
     }
     

--- a/Tests/Logic/CoreData/RKEntityMappingTest.m
+++ b/Tests/Logic/CoreData/RKEntityMappingTest.m
@@ -122,11 +122,6 @@
 
     NSDictionary *propertyNamesAndTypes = [[RKPropertyInspector sharedInspector] propertyInspectionForEntity:entity];
     assertThat([(RKPropertyInspectorPropertyInfo *)[propertyNamesAndTypes objectForKey:@"favoriteColors"] keyValueCodingClass], is(notNilValue()));
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    assertThat([propertyNamesAndTypes objectForKey:@"favoriteColors"][RKPropertyInspectionKeyValueCodingClassKey], is(notNilValue()));
-#pragma GCC diagnostic pop
 }
 
 - (void)testMappingAnArrayToATransformableWithoutABackingManagedObjectSubclass


### PR DESCRIPTION
When doing investigations on #2065, the RKPropertyInspector method classForPropertyNamed:ofClass:isPrimitive: is (unsurprisingly) one of the larger hotspots left, since it gets called extremely often.  It has been optimized pretty well already, so not much can be done that I can see, with one exception.  A simple accessor method call is faster than an NSDictionary -objectForKey:, and the property information is stored with immutable NSDictionaries with known keys, so we can easily convert that to a real object, and eliminate one -objectForKey: call.  That has a small but measurable effect.

I deprecated the previous key constants, though implemented methods such that if the new object is used as a dictionary it should continue to work in most cases.  Not sure if you would prefer that approach or to just remove the existing constants.

I also sped up the rk_classForPropertyAtKeyPath: method similar to a change in another pull request, though that does not get called during my test case.

Timings before:
(Device) Mapping 5000 students with relationship mapping: 16.064542
(Simulator) Mapping 5000 students with relationship mapping: 2.274153

and after:
(Device) Mapping 5000 students with relationship mapping: 15.740304
(Simulator) Mapping 5000 students with relationship mapping: 2.230252
