### PR TITLE
Upgrade to OCMock 2.2.4.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ def import_pods
   pod 'RestKit/Search', :path => '.'
   
   pod 'Specta', '0.2.1'
-  pod 'OCMock', '2.2.1'
+  pod 'OCMock', '2.2.4'
   pod 'OCHamcrest', '3.0.1'
   pod 'Expecta', '0.3.1'
   

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - ISO8601DateFormatterValueTransformer (0.6.0):
     - RKValueTransformers (~> 1.1.0)
   - OCHamcrest (3.0.1)
-  - OCMock (2.2.1)
+  - OCMock (2.2.4)
   - RestKit (0.23.3):
     - RestKit/Core
   - RestKit/Core (0.23.3):
@@ -38,7 +38,7 @@ PODS:
 DEPENDENCIES:
   - Expecta (= 0.3.1)
   - OCHamcrest (= 3.0.1)
-  - OCMock (= 2.2.1)
+  - OCMock (= 2.2.4)
   - RestKit (from `.`)
   - RestKit/Search (from `.`)
   - RestKit/Testing (from `.`)
@@ -54,7 +54,7 @@ SPEC CHECKSUMS:
   Expecta: 03aabd0a89d8dea843baecb19a7fd7466a69a31d
   ISO8601DateFormatterValueTransformer: a705384ea6531255258e25b6480ba1180db703a0
   OCHamcrest: 207233b7d7a44dadd66aca398947cc7e029c9be5
-  OCMock: 0647d3c53ce945e6f1dbaf072a66848aeb376a40
+  OCMock: 6db79185520e24f9f299548f2b8b07e41d881bd5
   RestKit: ed18af01bf1fef0444cd6c4d11a6d0fb085979a8
   RKCLLocationValueTransformer: 4803de0b5bdd81a1ebedb93a8a1d715f92ceb3f4
   RKValueTransformers: b705e7b4651b9206b94600408462b74554bba969

--- a/Tests/Logic/CoreData/RKManagedObjectLoaderTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectLoaderTest.m
@@ -244,8 +244,7 @@
     RKObjectManager *objectManager = [RKTestFactory objectManager];
     objectManager.managedObjectStore = managedObjectStore;
     id mockStore = [OCMockObject partialMockForObject:managedObjectStore];
-    BOOL success = NO;
-    [[[mockStore stub] andReturnValue:OCMOCK_VALUE(success)] save:[OCMArg anyPointer]];
+    [[[mockStore stub] andReturnValue:@NO] save:[OCMArg anyPointer]];
 
     RKObjectMapping *mapping = [RKEntityMapping mappingForEntityForName:@"Human" inManagedObjectStore:managedObjectStore];
     RKManagedObjectLoader *objectLoader = [objectManager loaderWithResourcePath:@"/humans/1"];

--- a/Tests/Logic/ObjectMapping/RKObjectMappingNextGenTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectMappingNextGenTest.m
@@ -739,8 +739,7 @@
     RKTestUser *user = [RKTestUser new];
     RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
     OCMockObject *mockDataSource = [OCMockObject partialMockForObject:dataSource];
-    BOOL yesVal = YES;
-    [[[mockDataSource stub] andReturnValue:OCMOCK_VALUE(yesVal)] mappingOperationShouldCollectMappingInfo:OCMOCK_ANY];
+    [[[mockDataSource stub] andReturnValue:@YES] mappingOperationShouldCollectMappingInfo:OCMOCK_ANY];
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:user mapping:mapping];
     mappingOperation.dataSource = dataSource;
     [mappingOperation start];
@@ -764,8 +763,7 @@
     RKTestUser *user = [RKTestUser new];
     RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
     OCMockObject *mockDataSource = [OCMockObject partialMockForObject:dataSource];
-    BOOL yesVal = YES;
-    [[[mockDataSource stub] andReturnValue:OCMOCK_VALUE(yesVal)] mappingOperationShouldCollectMappingInfo:OCMOCK_ANY];
+    [[[mockDataSource stub] andReturnValue:@YES] mappingOperationShouldCollectMappingInfo:OCMOCK_ANY];
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:user mapping:mapping];
     mappingOperation.dataSource = dataSource;
     [mappingOperation start];
@@ -788,8 +786,7 @@
     RKTestUser *user = [RKTestUser new];
     RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
     OCMockObject *mockDataSource = [OCMockObject partialMockForObject:dataSource];
-    BOOL yesVal = YES;
-    [[[mockDataSource stub] andReturnValue:OCMOCK_VALUE(yesVal)] mappingOperationShouldCollectMappingInfo:OCMOCK_ANY];
+    [[[mockDataSource stub] andReturnValue:@YES] mappingOperationShouldCollectMappingInfo:OCMOCK_ANY];
     RKMapperOperation *mapperOperation = [[RKMapperOperation alloc] initWithRepresentation:representation mappingsDictionary:@{ [NSNull null]: mapping }];
     mapperOperation.targetObject = user;
     mapperOperation.mappingOperationDataSource = dataSource;
@@ -808,7 +805,7 @@
 - (void)testShouldNotifyTheDelegateWhenItFailedToMapAnObject
 {
     id mockDelegate = [OCMockObject niceMockForProtocol:@protocol(RKMapperOperationDelegate)];
-    RKObjectMapping *mapping = [RKObjectMapping mappingForClass:NSClassFromString(@"OCPartialMockObject")];
+    RKObjectMapping *mapping = [RKObjectMapping mappingForClass:[RKTestUser class]];
     [mapping addAttributeMappingsFromArray:@[@"name"]];
 
     id userInfo = [RKTestFixture parsedObjectWithContentsOfFixture:@"user.json"];
@@ -822,9 +819,9 @@
     [[mockDelegate expect] mapper:mapper didFailMappingOperation:OCMOCK_ANY forKeyPath:nil withError:OCMOCK_ANY];
     mapper.delegate = mockDelegate;
     [mapper start];
+    [mockInspector stopMocking];
     [mockObject verify];
     [mockDelegate verify];
-    [mockInspector stopMocking];
 }
 
 #pragma mark - RKObjectMappingOperationTests
@@ -1348,7 +1345,7 @@
     operation.delegate = mockDelegate;
     NSError *error = nil;
     [[mockDelegate expect] mappingOperation:operation didFindValue:[NSNull null] forKeyPath:@"name" mapping:nameMapping];
-    [[[mockDelegate stub] andReturnValue:OCMOCK_VALUE((BOOL){YES})] mappingOperation:operation shouldSetValue:nil forKeyPath:@"name" usingMapping:nameMapping];
+    [[[mockDelegate stub] andReturnValue:OCMOCK_VALUE(YES)] mappingOperation:operation shouldSetValue:nil forKeyPath:@"name" usingMapping:nameMapping];
     [[mockDelegate expect] mappingOperation:operation didSetValue:nil forKeyPath:@"name" usingMapping:nameMapping];
     operation.dataSource = dataSource;
     [operation performMapping:&error];
@@ -1394,8 +1391,7 @@
     RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
     operation.dataSource = dataSource;
     id mockMapping = [OCMockObject partialMockForObject:mapping];
-    BOOL returnValue = YES;
-    [[[mockMapping expect] andReturnValue:OCMOCK_VALUE(returnValue)] assignsDefaultValueForMissingAttributes];
+    [[[mockMapping expect] andReturnValue:@YES] assignsDefaultValueForMissingAttributes];
     NSError *error = nil;
     [operation performMapping:&error];
     [mockUser verify];
@@ -1417,8 +1413,7 @@
     RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
     operation.dataSource = dataSource;
     id mockMapping = [OCMockObject partialMockForObject:mapping];
-    BOOL returnValue = NO;
-    [[[mockMapping expect] andReturnValue:OCMOCK_VALUE(returnValue)] shouldSetDefaultValueForMissingAttributes];
+    [[[mockMapping expect] andReturnValue:@NO] shouldSetDefaultValueForMissingAttributes];
     NSError *error = nil;
     [operation performMapping:&error];
     assertThat(user.name, is(equalTo(@"Blake Watters")));
@@ -1784,7 +1779,7 @@
     RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
     operation.dataSource = dataSource;
     id mockDelegate = [OCMockObject niceMockForProtocol:@protocol(RKMappingOperationDelegate)];
-    [[[mockDelegate stub] andReturnValue:OCMOCK_VALUE((BOOL){NO})] mappingOperation:operation shouldSetValue:OCMOCK_ANY forKeyPath:OCMOCK_ANY usingMapping:OCMOCK_ANY];
+    [[[mockDelegate stub] andReturnValue:OCMOCK_VALUE(NO)] mappingOperation:operation shouldSetValue:OCMOCK_ANY forKeyPath:OCMOCK_ANY usingMapping:OCMOCK_ANY];
     [[mockDelegate expect] mappingOperation:operation didNotSetUnchangedValue:OCMOCK_ANY forKeyPath:@"address" usingMapping:hasOneMapping];
     operation.delegate = mockDelegate;
     [operation performMapping:nil];
@@ -1843,8 +1838,7 @@
     NSMutableDictionary *dictionary = [[RKTestFixture parsedObjectWithContentsOfFixture:@"user.json"] mutableCopy];
     [dictionary removeObjectForKey:@"address"];
     id mockMapping = [OCMockObject partialMockForObject:userMapping];
-    BOOL returnValue = YES;
-    [[[mockMapping expect] andReturnValue:OCMOCK_VALUE(returnValue)] assignsNilForMissingRelationships];
+    [[[mockMapping expect] andReturnValue:@YES] assignsNilForMissingRelationships];
     RKMappingOperation *operation = [[RKMappingOperation alloc] initWithSourceObject:dictionary destinationObject:mockUser mapping:mockMapping];
     RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
     operation.dataSource = dataSource;
@@ -1873,8 +1867,7 @@
     NSMutableDictionary *dictionary = [[RKTestFixture parsedObjectWithContentsOfFixture:@"user.json"] mutableCopy];
     [dictionary removeObjectForKey:@"address"];
     id mockMapping = [OCMockObject partialMockForObject:userMapping];
-    BOOL returnValue = YES;
-    [[[mockMapping expect] andReturnValue:OCMOCK_VALUE(returnValue)] setNilForMissingRelationships];
+    [[[mockMapping expect] andReturnValue:@YES] setNilForMissingRelationships];
     RKMappingOperation *operation = [[RKMappingOperation alloc] initWithSourceObject:dictionary destinationObject:mockUser mapping:mockMapping];
     RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
     operation.dataSource = dataSource;

--- a/Tests/Logic/ObjectMapping/RKPaginatorTest.m
+++ b/Tests/Logic/ObjectMapping/RKPaginatorTest.m
@@ -137,8 +137,7 @@ static NSString * const RKPaginatorTestResourcePathPatternWithOffset = @"/pagina
     NSURLRequest *request = [NSURLRequest requestWithURL:self.paginationURL];
     RKPaginator *paginator = [[RKPaginator alloc] initWithRequest:request paginationMapping:self.paginationMapping responseDescriptors:@[ self.responseDescriptor ]];
     id mockPaginator = [OCMockObject partialMockForObject:paginator];
-    NSUInteger currentPage = 1;
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(currentPage)] currentPage];
+    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE((NSUInteger)1)] currentPage];
     expect([paginator.URL relativeString]).to.equal(@"/paginate?per_page=25&page=1");
 }
 
@@ -147,8 +146,7 @@ static NSString * const RKPaginatorTestResourcePathPatternWithOffset = @"/pagina
     NSURLRequest *request = [NSURLRequest requestWithURL:self.paginationURL];
     RKPaginator *paginator = [[RKPaginator alloc] initWithRequest:request paginationMapping:self.paginationMapping responseDescriptors:@[ self.responseDescriptor ]];
     id mockPaginator = [OCMockObject partialMockForObject:paginator];
-    NSUInteger currentPage = 1;
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(currentPage)] currentPage];
+    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE((NSUInteger)1)] currentPage];
     expect([[mockPaginator URL] query]).to.equal(@"per_page=25&page=1");
 }
 
@@ -157,8 +155,7 @@ static NSString * const RKPaginatorTestResourcePathPatternWithOffset = @"/pagina
     NSURLRequest *request = [NSURLRequest requestWithURL:self.paginationOffsetURL];
     RKPaginator *paginator = [[RKPaginator alloc] initWithRequest:request paginationMapping:self.paginationMapping responseDescriptors:@[ self.responseDescriptor ]];
     id mockPaginator = [OCMockObject partialMockForObject:paginator];
-    NSUInteger currentPage = 1;
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(currentPage)] currentPage];
+    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE((NSUInteger)1)] currentPage];
     expect([[mockPaginator URL] query]).to.equal(@"limit=25&offset=0");
 }
 
@@ -323,21 +320,15 @@ static NSString * const RKPaginatorTestResourcePathPatternWithOffset = @"/pagina
 {
     RKPaginator *paginator = [RKPaginator new];
     id mockPaginator = [OCMockObject partialMockForObject:paginator];
-    BOOL isLoaded = YES;
-    NSUInteger perPage = 5;
-    NSUInteger pageCount = 3;
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(isLoaded)] isLoaded];
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(perPage)] perPage];
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(pageCount)] pageCount];
+    [[[mockPaginator stub] andReturnValue:@YES] isLoaded];
+    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE((NSUInteger)5)] perPage];
+    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE((NSUInteger)3)] pageCount];
 
-    NSUInteger currentPage = 1;
-    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE(currentPage)] currentPage];
+    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE((NSUInteger)1)] currentPage];
     assertThatBool([mockPaginator hasNextPage], is(equalToBool(YES)));
-    currentPage = 2;
-    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE(currentPage)] currentPage];
+    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE((NSUInteger)2)] currentPage];
     assertThatBool([mockPaginator hasNextPage], is(equalToBool(YES)));
-    currentPage = 3;
-    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE(currentPage)] currentPage];
+    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE((NSUInteger)3)] currentPage];
     assertThatBool([mockPaginator hasNextPage], is(equalToBool(NO)));
 }
 
@@ -345,8 +336,7 @@ static NSString * const RKPaginatorTestResourcePathPatternWithOffset = @"/pagina
 {
     RKPaginator *paginator = [RKPaginator new];
     id mockPaginator = [OCMockObject partialMockForObject:paginator];
-    BOOL loaded = NO;
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(loaded)] isLoaded];
+    [[[mockPaginator stub] andReturnValue:@NO] isLoaded];
     XCTAssertThrows([mockPaginator hasNextPage], @"Expected exception due to isLoaded == NO");
 }
 
@@ -354,10 +344,8 @@ static NSString * const RKPaginatorTestResourcePathPatternWithOffset = @"/pagina
 {
     RKPaginator *paginator = [RKPaginator new];
     id mockPaginator = [OCMockObject partialMockForObject:paginator];
-    BOOL loaded = YES;
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(loaded)] isLoaded];
-    BOOL hasPageCount = NO;
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(hasPageCount)] hasPageCount];
+    [[[mockPaginator stub] andReturnValue:@YES] isLoaded];
+    [[[mockPaginator stub] andReturnValue:@NO] hasPageCount];
     XCTAssertThrows([mockPaginator hasNextPage], @"Expected exception due to pageCount == NSUIntegerMax");
 }
 
@@ -365,8 +353,7 @@ static NSString * const RKPaginatorTestResourcePathPatternWithOffset = @"/pagina
 {
     RKPaginator *paginator = [RKPaginator new];
     id mockPaginator = [OCMockObject partialMockForObject:paginator];
-    BOOL loaded = NO;
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(loaded)] isLoaded];
+    [[[mockPaginator stub] andReturnValue:@NO] isLoaded];
     XCTAssertThrows([mockPaginator hasPreviousPage], @"Expected exception due to isLoaded == NO");
 }
 
@@ -374,21 +361,15 @@ static NSString * const RKPaginatorTestResourcePathPatternWithOffset = @"/pagina
 {
     RKPaginator *paginator = [RKPaginator new];
     id mockPaginator = [OCMockObject partialMockForObject:paginator];
-    BOOL isLoaded = YES;
-    NSUInteger perPage = 5;
-    NSUInteger pageCount = 3;
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(isLoaded)] isLoaded];
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(perPage)] perPage];
-    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE(pageCount)] pageCount];
+    [[[mockPaginator stub] andReturnValue:@YES] isLoaded];
+    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE((NSUInteger)5)] perPage];
+    [[[mockPaginator stub] andReturnValue:OCMOCK_VALUE((NSUInteger)3)] pageCount];
 
-    NSUInteger currentPage = 3;
-    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE(currentPage)] currentPage];
+    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE((NSUInteger)3)] currentPage];
     assertThatBool([mockPaginator hasPreviousPage], is(equalToBool(YES)));
-    currentPage = 2;
-    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE(currentPage)] currentPage];
+    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE((NSUInteger)2)] currentPage];
     assertThatBool([mockPaginator hasPreviousPage], is(equalToBool(YES)));
-    currentPage = 1;
-    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE(currentPage)] currentPage];
+    [[[mockPaginator expect] andReturnValue:OCMOCK_VALUE((NSUInteger)1)] currentPage];
     assertThatBool([mockPaginator hasPreviousPage], is(equalToBool(NO)));
 }
 

--- a/Tests/Logic/Search/RKSearchIndexerTest.m
+++ b/Tests/Logic/Search/RKSearchIndexerTest.m
@@ -396,11 +396,9 @@ static NSManagedObjectModel *RKManagedObjectModel()
     [human setValue:@"This is my name" forKey:@"name"];
     
     id mockDelegate = [OCMockObject niceMockForProtocol:@protocol(RKSearchIndexerDelegate)];
-    BOOL returnValue = NO;
-    [[[mockDelegate expect] andReturnValue:OCMOCK_VALUE(returnValue)] searchIndexer:OCMOCK_ANY shouldInsertSearchWordForWord:@"this" inManagedObjectContext:managedObjectContext];
-    returnValue = YES;
-    [[[mockDelegate expect] andReturnValue:OCMOCK_VALUE(returnValue)] searchIndexer:OCMOCK_ANY shouldInsertSearchWordForWord:@"my" inManagedObjectContext:managedObjectContext];
-    [[[mockDelegate expect] andReturnValue:OCMOCK_VALUE(returnValue)] searchIndexer:OCMOCK_ANY shouldInsertSearchWordForWord:@"name" inManagedObjectContext:managedObjectContext];
+    [[[mockDelegate expect] andReturnValue:@NO] searchIndexer:OCMOCK_ANY shouldInsertSearchWordForWord:@"this" inManagedObjectContext:managedObjectContext];
+    [[[mockDelegate expect] andReturnValue:@YES] searchIndexer:OCMOCK_ANY shouldInsertSearchWordForWord:@"my" inManagedObjectContext:managedObjectContext];
+    [[[mockDelegate expect] andReturnValue:@YES] searchIndexer:OCMOCK_ANY shouldInsertSearchWordForWord:@"name" inManagedObjectContext:managedObjectContext];
     indexer.delegate = mockDelegate;
      
     NSUInteger count = [indexer indexManagedObject:human];
@@ -429,8 +427,7 @@ static NSManagedObjectModel *RKManagedObjectModel()
     [human setValue:@"This is my name" forKey:@"name"];
     
     id mockDelegate = [OCMockObject niceMockForProtocol:@protocol(RKSearchIndexerDelegate)];
-    BOOL returnValue = YES;
-    [[[mockDelegate stub] andReturnValue:OCMOCK_VALUE(returnValue)] searchIndexer:indexer shouldInsertSearchWordForWord:OCMOCK_ANY inManagedObjectContext:OCMOCK_ANY];
+    [[[mockDelegate stub] andReturnValue:@YES] searchIndexer:indexer shouldInsertSearchWordForWord:OCMOCK_ANY inManagedObjectContext:OCMOCK_ANY];
     [[mockDelegate expect] searchIndexer:indexer didInsertSearchWord:OCMOCK_ANY forWord:@"this" inManagedObjectContext:managedObjectContext];
     [[mockDelegate expect] searchIndexer:indexer didInsertSearchWord:OCMOCK_ANY forWord:@"is" inManagedObjectContext:managedObjectContext];
     [[mockDelegate expect] searchIndexer:indexer didInsertSearchWord:OCMOCK_ANY forWord:@"my" inManagedObjectContext:managedObjectContext];
@@ -458,13 +455,12 @@ static NSManagedObjectModel *RKManagedObjectModel()
     [human setValue:@"This is my name" forKey:@"name"];
     
     id mockDelegate = [OCMockObject niceMockForProtocol:@protocol(RKSearchIndexerDelegate)];
-    BOOL returnValue = NO;
     RKSearchWord *searchWord = [NSEntityDescription insertNewObjectForEntityForName:@"RKSearchWord" inManagedObjectContext:managedObjectContext];
     [[[mockDelegate expect] andReturn:searchWord] searchIndexer:indexer searchWordForWord:@"this" inManagedObjectContext:managedObjectContext error:(NSError * __autoreleasing *)[OCMArg anyPointer]];
     [[[mockDelegate expect] andReturn:searchWord] searchIndexer:indexer searchWordForWord:@"is" inManagedObjectContext:managedObjectContext error:(NSError * __autoreleasing *)[OCMArg anyPointer]];
     [[[mockDelegate expect] andReturn:searchWord] searchIndexer:indexer searchWordForWord:@"my" inManagedObjectContext:managedObjectContext error:(NSError * __autoreleasing *)[OCMArg anyPointer]];
     [[[mockDelegate expect] andReturn:searchWord] searchIndexer:indexer searchWordForWord:@"name" inManagedObjectContext:managedObjectContext error:(NSError * __autoreleasing *)[OCMArg anyPointer]];
-    [[[mockDelegate stub] andReturnValue:OCMOCK_VALUE(returnValue)] searchIndexer:indexer shouldInsertSearchWordForWord:OCMOCK_ANY inManagedObjectContext:OCMOCK_ANY];
+    [[[mockDelegate stub] andReturnValue:@NO] searchIndexer:indexer shouldInsertSearchWordForWord:OCMOCK_ANY inManagedObjectContext:OCMOCK_ANY];
     [[mockDelegate reject] searchIndexer:indexer didInsertSearchWord:OCMOCK_ANY forWord:OCMOCK_ANY inManagedObjectContext:OCMOCK_ANY];
     indexer.delegate = mockDelegate;
     
@@ -489,8 +485,7 @@ static NSManagedObjectModel *RKManagedObjectModel()
     [human setValue:@"This is my name" forKey:@"name"];
     
     id mockDelegate = [OCMockObject niceMockForProtocol:@protocol(RKSearchIndexerDelegate)];
-    BOOL returnValue = NO;
-    [[[mockDelegate expect] andReturnValue:OCMOCK_VALUE(returnValue)] searchIndexer:indexer shouldIndexManagedObject:human];
+    [[[mockDelegate expect] andReturnValue:@NO] searchIndexer:indexer shouldIndexManagedObject:human];
     indexer.delegate = mockDelegate;
     
     [indexer indexChangedObjectsInManagedObjectContext:managedObjectContext waitUntilFinished:YES];


### PR DESCRIPTION
Upgrade to OCMock 2.2.4.  It has some bug fixes, and some enhancements. Updated some usages of OCMOCK_VALUE, and also updated one unit test which failed (mainly because mock objects return the original class from the -class method now).
