### PR TITLE
Compute RKPropertyMapping.propertyValueClass early

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -271,6 +271,10 @@ static NSArray *RKRemoveProperty(NSArray *array, RKPropertyMapping *mapping)
             self.keyPathAttributeMappings = RKAddProperty(self.keyPathAttributeMappings, propertyMapping);
         }
     }
+    
+    if (propertyMapping.propertyValueClass == Nil && ![self.objectClass isSubclassOfClass:[NSDictionary class]]) {
+        propertyMapping.propertyValueClass = [self classForKeyPath:propertyMapping.destinationKeyPath];
+    }
 }
 
 - (void)addPropertyMappingsFromArray:(NSArray *)arrayOfPropertyMappings


### PR DESCRIPTION
When profiling for #2065, the RKPropertyInspector code still shows up a bit.  However, the mapping code first checks to see if the RKPropertyMapping.propertyValueClass is set, and will use that instead.  So, if these values are assigned on setup, the mapping code doesn't need to keep re-computing them, and it is a significant speedup.

This patch adds code to addPropertyMapping on RKObjectMapping to immediately set the propertyValueClass if not externally set (and avoids doing it with NSDictionary mappings, in case there happens to be a real property of "count" and things like that).  For the vast majority of properties, this should find a value and avoid mapping time.

This is a change in behavior, though it works fine with my app, the test app, and still passes all the unit tests.  I may be unaware of some situations which could be harmed though (I guess if an RKPropertyMapping instance is moved from one RKObjectMapping to another it may keep the value set from the first one, but that seems unlikely).

If this change is not wanted, we could probably add a method on RKObjectMapping to go through all properties and set the value classes, so at least client code can do it easily, for mappings which are performance issues.  But it would be nice to automatically get the benefit.

Timings before:
(Device) Mapping 5000 students with relationship mapping: 14.170651
(Simulator) Mapping 5000 students with relationship mapping: 1.921922

and after:
(Device) Mapping 5000 students with relationship mapping: 11.540344
(Simulator) Mapping 5000 students with relationship mapping: 1.558126
