### PR TITLE
Core data concurrency fixes

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -335,8 +335,12 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
 
 - (BOOL)resetPersistentStores:(NSError **)error
 {
-    [self.mainQueueManagedObjectContext reset];
-    [self.persistentStoreManagedObjectContext reset];
+    [self.mainQueueManagedObjectContext performBlockAndWait:^{
+        [self.mainQueueManagedObjectContext reset];
+    }];
+    [self.persistentStoreManagedObjectContext performBlockAndWait:^{
+        [self.persistentStoreManagedObjectContext reset];
+    }];
     
     NSError *localError;
     for (NSPersistentStore *persistentStore in self.persistentStoreCoordinator.persistentStores) {


### PR DESCRIPTION
These are minor fixes for assertions that occur when debugging while using the `-com.apple.CoreData.ConcurrencyDebug 1` argument. The assertions occurred due to NSManagedObjectContexts or NSManagedObjects being accessed from the wrong dispatch queue.
