### PR TITLE
Obtain permanent NSManagedObjectIDs

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -134,8 +134,12 @@ static NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification
         }
     }
     
-    NSError* err = nil;
-    [context obtainPermanentIDsForObjects:[objectsForTemps allObjects] error:&err];
+    __block NSError* err = nil;
+    [context performBlockAndWait:^
+    {
+        [context obtainPermanentIDsForObjects:[objectsForTemps allObjects] error:&err];
+    }];
+    
     NSCAssert(!err, @"unable to obtain permanent ids for objects");
     
     [permanentIds unionSet:[objectsForTemps valueForKey:@"objectID"]];

--- a/Tests/Logic/CoreData/RKManagedObjectStoreTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectStoreTest.m
@@ -640,7 +640,7 @@ static NSManagedObjectModel *RKManagedObjectModelWithNameAtVersion(NSString *mod
     [contextPartialMock performBlock:^
     {
         NSError* firstSaveErr = nil;
-        [contextPartialMock save:&firstSaveErr];
+        [(NSManagedObjectContext*)contextPartialMock save:&firstSaveErr];
         NSAssert(!firstSaveErr, @"Error saving");
         
         [seedStore.persistentStoreManagedObjectContext performBlock:^

--- a/Tests/Logic/CoreData/RKManagedObjectStoreTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectStoreTest.m
@@ -641,7 +641,7 @@ static NSManagedObjectModel *RKManagedObjectModelWithNameAtVersion(NSString *mod
     {
         NSError* firstSaveErr = nil;
         [(NSManagedObjectContext*)contextPartialMock save:&firstSaveErr];
-        NSAssert(!firstSaveErr, @"Error saving");
+        expect(firstSaveErr).to.beNil();
         
         [seedStore.persistentStoreManagedObjectContext performBlock:^
          {


### PR DESCRIPTION
I was running in to a bug where I was both inserting and updating a record before it was saved to the persistent store. The temporary IDs being used for prevention of merging changes in to the same child context that generated the change to begin with was failing, and the resulting merge-in was causing several NSFetchedResultsControllers to become inaccurate until performFetch: was called again.

These changes will attempt to ensure that any objectIDs being compared are permanent IDs, so that the comparison is accurate in this instance.
