### PR TITLE
Change the RKPropertyInspector cache writeback to use dispatch_barrier_sync

### DIFF
--- a/Code/ObjectMapping/RKPropertyInspector.m
+++ b/Code/ObjectMapping/RKPropertyInspector.m
@@ -148,7 +148,8 @@ NSString * const RKPropertyInspectionIsPrimitiveKey = @"isPrimitive";
         currentClass = (superclass == [NSObject class] || (nsManagedObject && superclass == nsManagedObject)) ? nil : superclass;
     }
 
-    dispatch_barrier_async(self.queue, ^{
+    /* dispatch_barrier_async is dangerous if we are called from +initialize */
+    dispatch_barrier_sync(self.queue, ^{
         (self.inspectionCache)[(id<NSCopying>)objectClass] = inspection;
         RKLogDebug(@"Cached property inspection for Class '%@': %@", NSStringFromClass(objectClass), inspection);
     });


### PR DESCRIPTION
Change the RKPropertyInspector cache writeback to use dispatch_barrier_sync instead of _async.

Due to the change in #2095 this code is now much more likely to be called from an +initialize method, and the async call at that point is dangerous, potentially leading to deadlocks with ObjC runtime locks (see #2101).  Keeping everything on the same thread should avoid deadlock possibilities.

It may even be better anyways, as any object mapping with more than one property will immediately call back to get the attributes for the same class so it would be waiting on the cache write anyways, and the async would just add potential thread context switches on top of a simple sync call.
