### PR TITLE
Report errors from obtainPermanentObjectIDsForInsertedObjects

### DIFF
--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -850,7 +850,7 @@ BOOL RKDoesArrayOfResponseDescriptorsContainOnlyEntityMappings(NSArray *response
     [self.privateContext performBlockAndWait:^{
         NSArray *insertedObjects = [[self.privateContext insertedObjects] allObjects];
         RKLogDebug(@"Obtaining permanent ID's for %ld managed objects", (unsigned long) [insertedObjects count]);
-        _blockSuccess = [self.privateContext obtainPermanentIDsForObjects:insertedObjects error:nil];
+        _blockSuccess = [self.privateContext obtainPermanentIDsForObjects:insertedObjects error:&localError];
     }];
     if (!_blockSuccess && error) *error = localError;
 


### PR DESCRIPTION
The implementation of `-[RKManagedObjectRequestOperation obtainPermanentObjectIDsForInsertedObjects:]` calls `-[NSManagedObjectContext obtainPermanentIDsForObjects:error:]`, but does not pass an error pointer. This means that when the attempt to obtain IDs fails, and the method returns `NO`, it doesn't pass an error back up. That, in turn, means that the chain of completion blocks gets called with `nil` for _both_ arguments, which is ultimately, and incorrectly, interpreted as success.

I have seen accounts of crashes when passing a non-`NULL` pointer to this method, which may be why this code is this way now. If that's the case, and the real Core Data error can't be obtained and returned, this method should at least generate a new synthetic RestKit error in its failure case, so that everything else behaves properly.
