### PR TITLE
Made RKPathMatcher thread safe to fix #2133 and #1998

### DIFF
--- a/Code/Network/RKPathMatcher.h
+++ b/Code/Network/RKPathMatcher.h
@@ -73,7 +73,7 @@ NSString *RKPathFromPatternWithObject(NSString *pathPattern, id object);
  @param arguments A pointer to a dictionary that contains the key/values from the pattern (and parameter) matching.
  @return A boolean value indicating if the path string successfully matched the pattern.
  */
-- (BOOL)matchesPattern:(NSString *)patternString tokenizeQueryStrings:(BOOL)shouldTokenize parsedArguments:(NSDictionary **)arguments;
+//- (BOOL)matchesPattern:(NSString *)patternString tokenizeQueryStrings:(BOOL)shouldTokenize parsedArguments:(NSDictionary **)arguments;
 
 ///---------------------------------
 /// @name Matching Patterns to Paths

--- a/Code/Network/RKPathMatcher.h
+++ b/Code/Network/RKPathMatcher.h
@@ -73,7 +73,7 @@ NSString *RKPathFromPatternWithObject(NSString *pathPattern, id object);
  @param arguments A pointer to a dictionary that contains the key/values from the pattern (and parameter) matching.
  @return A boolean value indicating if the path string successfully matched the pattern.
  */
-//- (BOOL)matchesPattern:(NSString *)patternString tokenizeQueryStrings:(BOOL)shouldTokenize parsedArguments:(NSDictionary **)arguments;
+- (BOOL)matchesPattern:(NSString *)patternString tokenizeQueryStrings:(BOOL)shouldTokenize parsedArguments:(NSDictionary **)arguments;
 
 ///---------------------------------
 /// @name Matching Patterns to Paths

--- a/Code/Network/RKPathMatcher.m
+++ b/Code/Network/RKPathMatcher.m
@@ -146,7 +146,7 @@ NSString *RKPathFromPatternWithObject(NSString *pathPattern, id object)
         NSMutableDictionary *parsedParameters = [[self.socPattern parameterDictionaryFromSourceString:path] mutableCopy];
         if (addEscapes) {
             for (NSString *key in [parsedParameters allKeys]) {
-                NSString *unescapedParameter = [[parsedParameters objectForKey:key] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                NSString *unescapedParameter = [parsedParameters[key] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
                 [parsedParameters setValue:unescapedParameter forKey:key];
             }
         }


### PR DESCRIPTION
RKPathMatcher had two instance variables sourcePath and rootPath, which was changed every time it was queried for a match. This was not thread safe and was the cause of two reported bugs. 

The common use-case where submitting restkit requests to a concurrent dispatch queue, can result in RKPathMatcher being called almost simultaneously, which is being messed up when sourcePath and rootPath is changed in the middle of everything.

I commented out matchesPattern method as it was not used and also messed with the socPattern variable. If we shall re-enable this method, we also have to remove the socPattern variable and pass that on a pr. method call basis.

An alternative fix to this is to never keep RKPathMatcher instances and create them on a pr. match basis in RKResponseDescriptor. I tried this first, and that also worked fine, but this was a better solution i think.