### PR TITLE
Fix crash when expectation block fails

### DIFF
--- a/Code/Testing/RKMappingTest.m
+++ b/Code/Testing/RKMappingTest.m
@@ -256,10 +256,10 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
                     NSString *reason = [NSString stringWithFormat:@"expected to %@ with value %@ '%@', but it did not",
                                         expectation, [event.value class], event.value];
                     if (error) *error = [self errorForExpectation:expectation
-                                              withCode:RKMappingTestEvaluationBlockError
-                                              userInfo:userInfo
-                                           description:description
-                                                reason:reason];
+                                                         withCode:RKMappingTestEvaluationBlockError
+                                                         userInfo:userInfo
+                                                      description:description
+                                                           reason:reason];
                 }
             }
         } else if (propertyExpectation.value) {

--- a/Code/Testing/RKMappingTest.m
+++ b/Code/Testing/RKMappingTest.m
@@ -255,11 +255,13 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
                     NSString *description = [NSString stringWithFormat:@"evaluation block returned `NO` for %@ value '%@'", [event.value class], event.value];
                     NSString *reason = [NSString stringWithFormat:@"expected to %@ with value %@ '%@', but it did not",
                                         expectation, [event.value class], event.value];
-                    if (error) *error = [self errorForExpectation:expectation
-                                                         withCode:RKMappingTestEvaluationBlockError
-                                                         userInfo:userInfo
-                                                      description:description
-                                                           reason:reason];
+                    if (error) {
+                        *error = [self errorForExpectation:expectation
+                                                  withCode:RKMappingTestEvaluationBlockError
+                                                  userInfo:userInfo
+                                               description:description
+                                                    reason:reason];
+                    }
                 }
             }
         } else if (propertyExpectation.value) {
@@ -270,11 +272,13 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
                 NSString *description = [NSString stringWithFormat:@"mapped to unexpected %@ value '%@'", [event.value class], event.value];
                 NSString *reason = [NSString stringWithFormat:@"expected to %@, but instead got %@ '%@'",
                                     expectation, [event.value class], event.value];
-                if (error) *error = [self errorForExpectation:expectation
-                                                     withCode:RKMappingTestValueInequalityError
-                                                     userInfo:userInfo
-                                                  description:description
-                                                       reason:reason];
+                if (error) {
+                    *error = [self errorForExpectation:expectation
+                                              withCode:RKMappingTestValueInequalityError
+                                              userInfo:userInfo
+                                           description:description
+                                                reason:reason];
+                }
             }
         } else if (propertyExpectation.mapping) {
             if ([event.propertyMapping isKindOfClass:[RKRelationshipMapping class]]) {
@@ -286,21 +290,25 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
                     NSString *description = [NSString stringWithFormat:@"mapped using unexpected mapping: %@", relationshipMapping];
                     NSString *reason = [NSString stringWithFormat:@"expected to %@, but was instead mapped using: %@",
                                         expectation, relationshipMapping];
-                    if (error) *error = [self errorForExpectation:expectation
-                                                         withCode:RKMappingTestMappingMismatchError
-                                                         userInfo:userInfo
-                                                      description:description
-                                                           reason:reason];
+                    if (error) {
+                        *error = [self errorForExpectation:expectation
+                                                  withCode:RKMappingTestMappingMismatchError
+                                                  userInfo:userInfo
+                                               description:description
+                                                    reason:reason];
+                    }
                 }
             } else {
                 NSString *description = [NSString stringWithFormat:@"expected a property mapping of type `RKRelationshipMapping` but instead got a `%@`", [propertyExpectation.mapping class]];
                 NSString *reason = [NSString stringWithFormat:@"expected to %@, but instead of a `RKRelationshipMapping` got a `%@`",
                                     expectation, [propertyExpectation.mapping class]];
-                if (error) *error = [self errorForExpectation:expectation
-                                                     withCode:RKMappingTestMappingMismatchError
-                                                     userInfo:userInfo
-                                                  description:description
-                                                       reason:reason];
+                if (error) {
+                    *error = [self errorForExpectation:expectation
+                                              withCode:RKMappingTestMappingMismatchError
+                                              userInfo:userInfo
+                                           description:description
+                                                reason:reason];
+                }
                 
                 // Error message here that a relationship was not mapped!!!
                 return NO;

--- a/Code/Testing/RKMappingTest.m
+++ b/Code/Testing/RKMappingTest.m
@@ -241,18 +241,21 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
                     [mutableUserInfo setValue:blockError forKey:NSUnderlyingErrorKey];
                     NSString *reason = [NSString stringWithFormat:@"expected to %@ with value %@ '%@', but it did not",
                                         expectation, [event.value class], event.value];
-                    *error = [self errorForExpectation:expectation
-                                              withCode:RKMappingTestEvaluationBlockError
-                                              userInfo:mutableUserInfo
-                                           description:[blockError localizedDescription]
-                                                reason:reason];
                     
-                    *error = blockError;
+                    if (error) {
+                        *error = [self errorForExpectation:expectation
+                                                  withCode:RKMappingTestEvaluationBlockError
+                                                  userInfo:mutableUserInfo
+                                               description:[blockError localizedDescription]
+                                                    reason:reason];
+                        
+                        *error = blockError;
+                    }
                 } else {
                     NSString *description = [NSString stringWithFormat:@"evaluation block returned `NO` for %@ value '%@'", [event.value class], event.value];
                     NSString *reason = [NSString stringWithFormat:@"expected to %@ with value %@ '%@', but it did not",
                                         expectation, [event.value class], event.value];
-                    *error = [self errorForExpectation:expectation
+                    if (error) *error = [self errorForExpectation:expectation
                                               withCode:RKMappingTestEvaluationBlockError
                                               userInfo:userInfo
                                            description:description

--- a/Tests/Logic/Testing/RKMappingTestTest.m
+++ b/Tests/Logic/Testing/RKMappingTestTest.m
@@ -69,7 +69,7 @@
     [self.mappingTest addExpectation:[RKPropertyMappingTestExpectation expectationWithSourceKeyPath:@"name" destinationKeyPath:@"name" evaluationBlock:^BOOL(RKPropertyMappingTestExpectation *expectation, RKPropertyMapping *mapping, id mappedValue, NSError *__autoreleasing *error) {
         return [mappedValue isEqualToString:@"Invalid"];
     }]];
-    expect([self.mappingTest evaluate]).to.equal(YES);
+    expect([self.mappingTest evaluate]).to.equal(NO);
 }
 
 - (void)testMappingTestForRelationship

--- a/Tests/Logic/Testing/RKMappingTestTest.m
+++ b/Tests/Logic/Testing/RKMappingTestTest.m
@@ -64,6 +64,14 @@
     expect([self.mappingTest evaluate]).to.equal(YES);
 }
 
+- (void)testMappingTestFailureForAttributeWithBlock
+{
+    [self.mappingTest addExpectation:[RKPropertyMappingTestExpectation expectationWithSourceKeyPath:@"name" destinationKeyPath:@"name" evaluationBlock:^BOOL(RKPropertyMappingTestExpectation *expectation, RKPropertyMapping *mapping, id mappedValue, NSError *__autoreleasing *error) {
+        return [mappedValue isEqualToString:@"Invalid"];
+    }]];
+    expect([self.mappingTest evaluate]).to.equal(YES);
+}
+
 - (void)testMappingTestForRelationship
 {
     RKTestCoordinate *coordinate = [RKTestCoordinate new];


### PR DESCRIPTION
I had a bug where RKMappingTest always crashed with EXC_BAD_ACCESS when I used evaluate method on a test with expectation which evaluation block returned NO. It happened because there was no check for nil error argument in RKMappingTest event:satisfiesExpectation:error: method. Fixed this. 