### PR TITLE
fixes regression caused by [21db7ec] - Cache the propertyMappings in dictionary form by both the destination

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -256,7 +256,7 @@ static NSArray *RKRemoveProperty(NSArray *array, RKPropertyMapping *mapping)
     NSAssert(propertyMapping.objectMapping == nil, @"Cannot add a property mapping object that has already been added to another `RKObjectMapping` object. You probably want to obtain a copy of the mapping: `[propertyMapping copy]`");
     propertyMapping.objectMapping = self;
     self.propertyMappings = [self.propertyMappings arrayByAddingObject:propertyMapping];
-    [self.propertiesBySourceKeyPath setObject:propertyMapping forKey:propertyMapping.sourceKeyPath ? propertyMapping.sourceKeyPath : [NSNull null]];
+    [self.propertiesBySourceKeyPath setObject:propertyMapping forKey:propertyMapping.sourceKeyPath ?: [NSNull null]];
     if (propertyMapping.destinationKeyPath) (self.propertiesByDestinationKeyPath)[propertyMapping.destinationKeyPath] = propertyMapping;
     if ([propertyMapping isMemberOfClass:[RKRelationshipMapping class]]) {
         self.relationshipMappings = RKAddProperty(self.relationshipMappings, propertyMapping);
@@ -293,7 +293,7 @@ static NSArray *RKRemoveProperty(NSArray *array, RKPropertyMapping *mapping)
 
 - (id)mappingForSourceKeyPath:(NSString *)sourceKeyPath
 {
-    return _propertiesBySourceKeyPath[sourceKeyPath ? sourceKeyPath : [NSNull null]];
+    return _propertiesBySourceKeyPath[sourceKeyPath ?: [NSNull null]];
 }
 
 - (id)mappingForDestinationKeyPath:(NSString *)destinationKeyPath
@@ -364,7 +364,7 @@ static NSArray *RKRemoveProperty(NSArray *array, RKPropertyMapping *mapping)
         self.attributeMappings = RKRemoveProperty(self.attributeMappings, attributeOrRelationshipMapping);
         self.keyAttributeMappings = RKRemoveProperty(self.keyAttributeMappings, attributeOrRelationshipMapping);
         self.keyPathAttributeMappings = RKRemoveProperty(self.keyPathAttributeMappings, attributeOrRelationshipMapping);
-        [self.propertiesBySourceKeyPath removeObjectForKey:attributeOrRelationshipMapping.sourceKeyPath ? attributeOrRelationshipMapping.sourceKeyPath : [NSNull null]];
+        [self.propertiesBySourceKeyPath removeObjectForKey:attributeOrRelationshipMapping.sourceKeyPath ?: [NSNull null]];
         [self.propertiesByDestinationKeyPath removeObjectForKey:attributeOrRelationshipMapping.destinationKeyPath];
     }
 }

--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -256,7 +256,7 @@ static NSArray *RKRemoveProperty(NSArray *array, RKPropertyMapping *mapping)
     NSAssert(propertyMapping.objectMapping == nil, @"Cannot add a property mapping object that has already been added to another `RKObjectMapping` object. You probably want to obtain a copy of the mapping: `[propertyMapping copy]`");
     propertyMapping.objectMapping = self;
     self.propertyMappings = [self.propertyMappings arrayByAddingObject:propertyMapping];
-    if (propertyMapping.sourceKeyPath) (self.propertiesBySourceKeyPath)[propertyMapping.sourceKeyPath] = propertyMapping;
+    [self.propertiesBySourceKeyPath setObject:propertyMapping forKey:propertyMapping.sourceKeyPath ? propertyMapping.sourceKeyPath : [NSNull null]];
     if (propertyMapping.destinationKeyPath) (self.propertiesByDestinationKeyPath)[propertyMapping.destinationKeyPath] = propertyMapping;
     if ([propertyMapping isMemberOfClass:[RKRelationshipMapping class]]) {
         self.relationshipMappings = RKAddProperty(self.relationshipMappings, propertyMapping);
@@ -293,7 +293,7 @@ static NSArray *RKRemoveProperty(NSArray *array, RKPropertyMapping *mapping)
 
 - (id)mappingForSourceKeyPath:(NSString *)sourceKeyPath
 {
-    return _propertiesBySourceKeyPath[sourceKeyPath];
+    return _propertiesBySourceKeyPath[sourceKeyPath ? sourceKeyPath : [NSNull null]];
 }
 
 - (id)mappingForDestinationKeyPath:(NSString *)destinationKeyPath
@@ -364,7 +364,7 @@ static NSArray *RKRemoveProperty(NSArray *array, RKPropertyMapping *mapping)
         self.attributeMappings = RKRemoveProperty(self.attributeMappings, attributeOrRelationshipMapping);
         self.keyAttributeMappings = RKRemoveProperty(self.keyAttributeMappings, attributeOrRelationshipMapping);
         self.keyPathAttributeMappings = RKRemoveProperty(self.keyPathAttributeMappings, attributeOrRelationshipMapping);
-        [self.propertiesBySourceKeyPath removeObjectForKey:attributeOrRelationshipMapping.sourceKeyPath];
+        [self.propertiesBySourceKeyPath removeObjectForKey:attributeOrRelationshipMapping.sourceKeyPath ? attributeOrRelationshipMapping.sourceKeyPath : [NSNull null]];
         [self.propertiesByDestinationKeyPath removeObjectForKey:attributeOrRelationshipMapping.destinationKeyPath];
     }
 }

--- a/Tests/Logic/ObjectMapping/RKObjectMappingTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectMappingTest.m
@@ -112,6 +112,19 @@
     assertThatBool([mapping1 isEqualToMapping:mapping2], is(equalToBool(NO)));
 }
 
+- (void)testThatTwoMappingsWithNilSourceKeyPathAreConsideredEqual
+{
+    RKObjectMapping *relationshipMapping1 = [RKObjectMapping mappingForClass:[NSNumber class]];
+    RKObjectMapping *relationshipMapping2 = [RKObjectMapping mappingForClass:[NSNumber class]];
+    
+    RKObjectMapping *mapping1 = [RKObjectMapping mappingForClass:[NSString class]];
+    [mapping1 addPropertyMapping:[RKRelationshipMapping relationshipMappingFromKeyPath:nil toKeyPath:@"that" withMapping:relationshipMapping1]];;
+    RKObjectMapping *mapping2 = [RKObjectMapping mappingForClass:[NSString class]];
+    [mapping2 addPropertyMapping:[RKRelationshipMapping relationshipMappingFromKeyPath:nil toKeyPath:@"that" withMapping:relationshipMapping2]];;
+    
+    assertThatBool([mapping1 isEqualToMapping:mapping2], is(equalToBool(YES)));
+}
+
 - (void)testThatAddingAPropertyMappingThatExistsInAnotherMappingTriggersException
 {
     RKObjectMapping *firstMapping = [RKObjectMapping mappingForClass:[NSMutableDictionary class]];


### PR DESCRIPTION
With this patch also mapping with `nil` sourceKeyPath can be cached properly in order to be compared and retrieved.