### PR TITLE
Fixed issue when RKPaginator called completion block but was not loaded

### DIFF
--- a/Code/Network/RKPaginator.m
+++ b/Code/Network/RKPaginator.m
@@ -205,9 +205,6 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
 #else
     self.objectRequestOperation = [[RKObjectRequestOperation alloc] initWithRequest:mutableRequest responseDescriptors:self.responseDescriptors];
 #endif
-    
-    // Add KVO to ensure notification of loaded state prior to execution of completion block
-    [self.objectRequestOperation addObserver:self forKeyPath:@"isFinished" options:0 context:nil];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
@@ -230,10 +227,12 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
         return deserializedResponseBody;
     }];
     [self.objectRequestOperation setCompletionBlockWithSuccess:^(RKObjectRequestOperation *operation, RKMappingResult *mappingResult) {
+        [self finish];
         if (self.successBlock) {
             self.successBlock(self, [mappingResult array], self.currentPage);
         }
     } failure:^(RKObjectRequestOperation *operation, NSError *error) {
+        [self finish];
         if (self.failureBlock) {
             self.failureBlock(self, error);
         }
@@ -262,14 +261,11 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
             [self hasObjectCount] ? @(self.objectCount) : @"???"];
 }
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+- (void)finish
 {
-    if ([keyPath isEqualToString:@"isFinished"] && [self.objectRequestOperation isFinished]) {
-        self.loaded = (self.objectRequestOperation.mappingResult != nil);
-        self.mappingResult = self.objectRequestOperation.mappingResult;
-        self.error = self.objectRequestOperation.error;
-        [object removeObserver:self forKeyPath:@"isFinished"];
-    }
+    self.loaded = (self.objectRequestOperation.mappingResult != nil);
+    self.mappingResult = self.objectRequestOperation.mappingResult;
+    self.error = self.objectRequestOperation.error;
 }
 
 - (void)cancel

--- a/Code/Network/RKPathMatcher.h
+++ b/Code/Network/RKPathMatcher.h
@@ -73,7 +73,7 @@ NSString *RKPathFromPatternWithObject(NSString *pathPattern, id object);
  @param arguments A pointer to a dictionary that contains the key/values from the pattern (and parameter) matching.
  @return A boolean value indicating if the path string successfully matched the pattern.
  */
-- (BOOL)matchesPattern:(NSString *)patternString tokenizeQueryStrings:(BOOL)shouldTokenize parsedArguments:(NSDictionary **)arguments;
+//- (BOOL)matchesPattern:(NSString *)patternString tokenizeQueryStrings:(BOOL)shouldTokenize parsedArguments:(NSDictionary **)arguments;
 
 ///---------------------------------
 /// @name Matching Patterns to Paths

--- a/Code/Network/RKPathMatcher.m
+++ b/Code/Network/RKPathMatcher.m
@@ -146,7 +146,7 @@ NSString *RKPathFromPatternWithObject(NSString *pathPattern, id object)
         NSMutableDictionary *parsedParameters = [[self.socPattern parameterDictionaryFromSourceString:path] mutableCopy];
         if (addEscapes) {
             for (NSString *key in [parsedParameters allKeys]) {
-                NSString *unescapedParameter = [[parsedParameters objectForKey:key] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                NSString *unescapedParameter = [parsedParameters[key] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
                 [parsedParameters setValue:unescapedParameter forKey:key];
             }
         }


### PR DESCRIPTION
Sometimes it happens that success block is called in a moment when `RKPaginator` is not loaded (`isLoaded=NO`). I guess it is because completion block is called on different thread than isFinished KVO notification. I think the best solution is to relay on completion block (as Apple stated in documentation, it is always called when isFinished=YES).

You can see commits from @megakode because I forked his project. His code is fixing pretty common crashes I am getting, but was still not merged to development branch and I need it in my project.

I thought about some test case also, but I don't have an idea how to trigger NSOperation to call callback before finishing operation. Maybe someone more experienced could help me here. 

Best regards, Mike. 