### PR TITLE
Fix bug 1714 null serialisation by default

### DIFF
--- a/Code/Network/RKObjectParameterization.m
+++ b/Code/Network/RKObjectParameterization.m
@@ -104,7 +104,12 @@
 - (void)mappingOperation:(RKMappingOperation *)operation didSetValue:(id)value forKeyPath:(NSString *)keyPath usingMapping:(RKAttributeMapping *)mapping
 {
     id transformedValue = nil;
-    if ([value isKindOfClass:[NSDate class]]) {
+    if (value == nil) {
+        if (mapping.objectMapping.assignsDefaultValueForMissingAttributes) {
+            // Serialize nil values as null
+            transformedValue = [NSNull null];
+        }
+    } else if ([value isKindOfClass:[NSDate class]]) {
         [mapping.valueTransformer transformValue:value toValue:&transformedValue ofClass:[NSString class] error:nil];
     } else if ([value isKindOfClass:[NSDecimalNumber class]]) {
         // Precision numbers are serialized as strings to work around Javascript notation limits
@@ -115,9 +120,6 @@
     } else if ([value isKindOfClass:[NSOrderedSet class]]) {
         // NSOrderedSets are not natively serializable, so let's just turn it into an NSArray
         transformedValue = [value array];
-    } else if (value == nil) {
-        // Serialize nil values as null
-        transformedValue = [NSNull null];
     } else {
         Class propertyClass = RKPropertyInspectorGetClassForPropertyAtKeyPathOfObject(mapping.sourceKeyPath, operation.sourceObject);
         if ([propertyClass isSubclassOfClass:NSClassFromString(@"__NSCFBoolean")] || [propertyClass isSubclassOfClass:NSClassFromString(@"NSCFBoolean")]) {

--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -69,8 +69,8 @@ static RKSourceToDesinationKeyTransformationBlock defaultSourceToDestinationKeyT
     inverseMapping = [RKObjectMapping requestMapping];
     (self.invertedMappings)[dictionaryKey] = inverseMapping;
     [inverseMapping copyPropertiesFromMapping:mapping];
-    // We want to serialize `nil` values
-    inverseMapping.assignsDefaultValueForMissingAttributes = YES;
+    // We potentially want to serialize `nil` values, adopt the strategy from the mapping we're inverting.
+    inverseMapping.assignsDefaultValueForMissingAttributes = mapping.assignsDefaultValueForMissingAttributes;
     
     for (RKAttributeMapping *attributeMapping in mapping.attributeMappings) {
         if (predicate && !predicate(attributeMapping)) continue;

--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -69,8 +69,8 @@ static RKSourceToDesinationKeyTransformationBlock defaultSourceToDestinationKeyT
     inverseMapping = [RKObjectMapping requestMapping];
     (self.invertedMappings)[dictionaryKey] = inverseMapping;
     [inverseMapping copyPropertiesFromMapping:mapping];
-    // We potentially want to serialize `nil` values, adopt the strategy from the mapping we're inverting.
-    inverseMapping.assignsDefaultValueForMissingAttributes = mapping.assignsDefaultValueForMissingAttributes;
+    // We want to serialize `nil` values
+    inverseMapping.assignsDefaultValueForMissingAttributes = YES;
     
     for (RKAttributeMapping *attributeMapping in mapping.attributeMappings) {
         if (predicate && !predicate(attributeMapping)) continue;

--- a/Tests/Logic/ObjectMapping/RKObjectParameterizationTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectParameterizationTest.m
@@ -559,6 +559,23 @@
     expect(parameters).to.equal((@{ @"name": @"Blake Watters", @"website": [NSNull null] }));
 }
 
+- (void)testSerializingOmitsNullAttributesWhenAssignsDefaultValueForMissingAttributesIsFalse
+{
+    RKTestUser *blake = [RKTestUser new];
+    blake.name = @"Blake Watters";
+    blake.website = nil;
+
+    RKObjectMapping *mapping = [RKObjectMapping requestMapping];
+    [mapping addAttributeMappingsFromArray:@[@"name", @"website"]];
+    mapping.assignsDefaultValueForMissingAttributes = NO;
+
+    NSError *error = nil;
+    RKRequestDescriptor *requestDescriptor = [RKRequestDescriptor requestDescriptorWithMapping:mapping objectClass:[RKTestUser class] rootKeyPath:nil method:RKRequestMethodAny];
+    NSDictionary *parameters = [RKObjectParameterization parametersWithObject:blake requestDescriptor:requestDescriptor error:&error];
+    expect(error).to.beNil();
+    expect(parameters).to.equal((@{@"name" : @"Blake Watters"}));
+}
+
 @end
 
 #pragma mark - Dynamic Request Paramterization


### PR DESCRIPTION
Attempt to fix attribute mapping so it respects the assignsDefaultValueForMissingAttributes value.

New test method included and the entire suite still passes.