### PR TITLE
Fault updated objects before merging changes into mainQueueManagedObject...

### DIFF
--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -593,6 +593,7 @@
 		73D3907A14CA1DD50093E3D6 /* channels.xml in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907814CA1D710093E3D6 /* channels.xml */; };
 		7AF2905218DF249C009AEB94 /* RKObjectiveCppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2501405215366000004E0466 /* RKObjectiveCppTest.mm */; };
 		7F9CBC6174004E31AEC35813 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 86EC453810D648768BF62304 /* libPods-osx.a */; };
+		8AB68F0B1AE5B3B300DD655A /* RKFetchedResultsControllerUpdateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB68F0A1AE5B3B300DD655A /* RKFetchedResultsControllerUpdateTest.m */; };
 		BE05BDD11782109F00F7C9C9 /* RKRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */; };
 		BE05BDD2178214AA00F7C9C9 /* RKRouteTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */; };
 		C0F11CE3190883380054AEA0 /* RKPathMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C0F11CE1190883380054AEA0 /* RKPathMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -981,6 +982,7 @@
 		73D3907314CA1A4A0093E3D6 /* child.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = child.json; sourceTree = "<group>"; };
 		73D3907814CA1D710093E3D6 /* channels.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = channels.xml; sourceTree = "<group>"; };
 		86EC453810D648768BF62304 /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8AB68F0A1AE5B3B300DD655A /* RKFetchedResultsControllerUpdateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKFetchedResultsControllerUpdateTest.m; sourceTree = "<group>"; };
 		BE05BDCF1782109F00F7C9C9 /* RKRouteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRouteTest.m; sourceTree = "<group>"; };
 		C0F11CE1190883380054AEA0 /* RKPathMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKPathMatcher.h; sourceTree = "<group>"; };
 		C0F11CE2190883380054AEA0 /* RKPathMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKPathMatcher.m; sourceTree = "<group>"; };
@@ -1353,6 +1355,7 @@
 				2564E40A16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m */,
 				2546A95716628EDD0078E044 /* RKConnectionDescriptionTest.m */,
 				2582F56C173038750043B8BB /* RKInMemoryManagedObjectCacheTest.m */,
+				8AB68F0A1AE5B3B300DD655A /* RKFetchedResultsControllerUpdateTest.m */,
 			);
 			name = CoreData;
 			path = Logic/CoreData;
@@ -2386,6 +2389,7 @@
 				25E36E0215195CED00F9E448 /* RKFetchRequestMappingCacheTest.m in Sources */,
 				25DB7508151BD551009F01AF /* NSManagedObjectContext+RKAdditionsTest.m in Sources */,
 				259D985A1550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m in Sources */,
+				8AB68F0B1AE5B3B300DD655A /* RKFetchedResultsControllerUpdateTest.m in Sources */,
 				259D986415521B20008C90F5 /* RKEntityCacheTest.m in Sources */,
 				252029091577C78600076FB4 /* RKRouteSetTest.m in Sources */,
 				2519764315823BA1004FE9DD /* RKAttributeMappingTest.m in Sources */,

--- a/Tests/Logic/CoreData/RKFetchedResultsControllerUpdateTest.m
+++ b/Tests/Logic/CoreData/RKFetchedResultsControllerUpdateTest.m
@@ -1,0 +1,121 @@
+//
+//  RKFetchedResultsControllerUpdateTest.m
+//  RestKit
+//
+//  Created by Patrick Pierson on 4/20/15.
+//  Copyright (c) 2015 RestKit. All rights reserved.
+//
+
+#import "RKTestEnvironment.h"
+#import "RKHuman.h"
+#import <CoreData/CoreData.h>
+
+@interface MockFRCDelegate : NSObject <NSFetchedResultsControllerDelegate>
+
+@property (nonatomic, copy) void (^controllerDidChangeContentBlock)();
+
+@end
+
+@implementation MockFRCDelegate
+
+#pragma mark - NSFetchedResultsControllerDelegate
+- (void)controllerDidChangeContent:(NSFetchedResultsController *)controller
+{
+    if (self.controllerDidChangeContentBlock) self.controllerDidChangeContentBlock();
+}
+
+@end
+
+//--------
+
+@interface RKFetchedResultsControllerUpdateTest : RKTestCase <NSFetchedResultsControllerDelegate>
+
+@end
+
+@implementation RKFetchedResultsControllerUpdateTest
+
+- (void)setUp
+{
+    [RKTestFactory setUp];
+}
+
+- (void)tearDown
+{
+    [RKTestFactory tearDown];
+}
+
+- (void)testFetchedResultsController
+{
+    //Managed object store and managed object contexts
+    RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
+    NSManagedObjectContext *persistentStoreContext = managedObjectStore.persistentStoreManagedObjectContext;
+    NSManagedObjectContext *persistentStoreChild = [managedObjectStore newChildManagedObjectContextWithConcurrencyType:NSPrivateQueueConcurrencyType tracksChanges:NO];
+    NSManagedObjectContext *mainQueueContext = managedObjectStore.mainQueueManagedObjectContext;
+
+    //1. Create initial ManagedObjects and save to store
+    [persistentStoreContext performBlockAndWait:^{
+        RKHuman *human1 = [persistentStoreContext insertNewObjectForEntityForName:@"Human"];
+        human1.name = @"human1";
+        human1.railsID = @1;
+
+        NSError *error = nil;
+        [persistentStoreContext save:&error];
+        if (error) {
+            XCTAssertNil(error, @"Error: %@", error);
+        }
+    }];
+
+    //2. Create NSFetchedResultsController
+    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:@"Human"];
+    fetchRequest.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
+    NSFetchedResultsController *fetchedResultsController = [[NSFetchedResultsController alloc] initWithFetchRequest:fetchRequest managedObjectContext:mainQueueContext sectionNameKeyPath:nil cacheName:nil];
+
+    //3. Add delegate to detect FRC updates
+    XCTestExpectation *expectation = [self expectationWithDescription:@"NSFetchedResultsController Updates"];
+    MockFRCDelegate *frcDelegate = [[MockFRCDelegate alloc] init];
+    frcDelegate.controllerDidChangeContentBlock = ^{
+        [expectation fulfill];
+    };
+    fetchedResultsController.delegate = frcDelegate;
+    [fetchedResultsController performFetch:nil];
+
+    XCTAssert(fetchedResultsController.fetchedObjects.count == 1, @"Expecting NSFetchedResultsController to contain single human object.");
+
+    //4. Update name of managed object in child managed object context
+    [persistentStoreChild performBlockAndWait:^{
+        NSFetchRequest *human1FetchRequest = [[NSFetchRequest alloc] initWithEntityName:@"Human"];
+        NSError *error = nil;
+        NSArray *results = [persistentStoreChild executeFetchRequest:human1FetchRequest error:&error];
+        XCTAssertNil(error, @"Error: %@", error);
+
+        RKHuman *childHuman1 = [results firstObject];
+        XCTAssertNotNil(childHuman1, @"Failed to fetch human1");
+
+        childHuman1.name = @"Updated Human";
+
+        error = nil;
+        [persistentStoreChild save:&error];
+        if (error) {
+            XCTAssertNil(error, @"Error: %@", error);
+        }
+    }];
+
+    //5. Save persistent store context to store
+    [persistentStoreContext performBlockAndWait:^{
+        NSError *error = nil;
+        [persistentStoreContext save:&error];
+        XCTAssertNil(error, @"Error: %@", error);
+    }];
+
+    //6. Wait for NSFetchedResultsController update expectation
+    [self waitForExpectationsWithTimeout:1 handler:^(NSError *error) {
+        XCTAssertNil(error, @"Error: %@", error);
+    }];
+
+    //7. Check for new human name update in NSFetchedResultsController
+    NSArray *humanNames = [fetchedResultsController.fetchedObjects valueForKeyPath:@"name"];
+    XCTAssertTrue([humanNames containsObject:@"Updated Human"], @"Does not contain updated human name.");
+    XCTAssertFalse([humanNames containsObject:@"human1"], @"FetchedResultsController contains original human name.");
+}
+
+@end


### PR DESCRIPTION
...Context.

This enables NSFetchedResultsController to update and re-sort its fetch results and to call its delegate methods
in response to these updates.
See http://stackoverflow.com/questions/3923826/nsfetchedresultscontroller-with-predicate-ignores-changes-merged-from-different
for issue details.

-----

I am having an issue where an instance of NSFetchedResultsController is not responding to updates to its non-faulted fetched objects when updates are merged into the mainQueueManagedObjectContext. It is not re-sorting its data set, nor is it calling its delegate methods. However, once I scroll through my tableview and fault some of the fetched objects into memory, the NSFetchedResultsController does respond to changes to those objects. 

I've found a similar issue on stackoverflow: http://stackoverflow.com/a/3927811/489376 and have made similar changes to `[RKManagedObjectStore handleManagedObjectContextDidSaveNotification:]` to resolve this issue.