### PR TITLE
Added not nil check also on destination keypath

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -365,7 +365,7 @@ static NSArray *RKRemoveProperty(NSArray *array, RKPropertyMapping *mapping)
         self.keyAttributeMappings = RKRemoveProperty(self.keyAttributeMappings, attributeOrRelationshipMapping);
         self.keyPathAttributeMappings = RKRemoveProperty(self.keyPathAttributeMappings, attributeOrRelationshipMapping);
         [self.propertiesBySourceKeyPath removeObjectForKey:attributeOrRelationshipMapping.sourceKeyPath ?: [NSNull null]];
-        [self.propertiesByDestinationKeyPath removeObjectForKey:attributeOrRelationshipMapping.destinationKeyPath];
+        [self.propertiesByDestinationKeyPath removeObjectForKey:attributeOrRelationshipMapping.destinationKeyPath ?: [NSNull null]];
     }
 }
 

--- a/Tests/Logic/ObjectMapping/RKObjectMappingTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectMappingTest.m
@@ -267,4 +267,17 @@
     expect(operation.destinationObject).to.equal(@{ @"Blake": @{} });
 }
 
+- (void)testRemoveAttributeMappingWithNilDestinationKeyPath
+{
+    // This test fails also if we create directly a mapping from "(something) => (null)"
+    // but the inverseMapping case is a more common use case
+    RKObjectMapping *mapping = [RKObjectMapping mappingForClass:[RKTestUser class]];
+    [mapping addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:nil toKeyPath:@"name"]];
+
+    RKObjectMapping *inverseMapping = [mapping inverseMapping];
+    [inverseMapping removePropertyMapping:[inverseMapping mappingForSourceKeyPath:@"name"]];
+    expect([inverseMapping mappingForSourceKeyPath:@"name"]).to.beNil;
+}
+
+
 @end


### PR DESCRIPTION
This solves this use case:

```objc
[aMapping addPropertyMapping:[RKRelationshipMapping relationshipMappingFromKeyPath:nil
toKeyPath:@"relationship"
withMapping:relationshipEntityMapping]];

// => Attribute Mapping is
//  (null) => "relationship"

RKObjectMapping *serializationMapping = [aMapping inverseMapping];
// "relationship" =>  (null)

//Exception here: NSDictionary removeObjectForKey: key cannot be nil]
[serializationMapping removePropertyMapping:[serializationMapping mappingForSourceKeyPath:@"relationship]];


```