### PR TITLE
changed "paginatorWithPattern" to allow subclassing of RKPaginator

### DIFF
--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -804,7 +804,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
 {
     NSAssert(self.paginationMapping, @"Cannot instantiate a paginator when `paginationMapping` is nil.");
     NSMutableURLRequest *request = [self requestWithMethod:@"GET" path:pathPattern parameters:nil];
-    RKPaginator *paginator = [[RKPaginator alloc] initWithRequest:request paginationMapping:self.paginationMapping responseDescriptors:self.responseDescriptors];
+    RKPaginator *paginator = [[self.paginationMapping.objectClass alloc] initWithRequest:request paginationMapping:self.paginationMapping responseDescriptors:self.responseDescriptors];
 #ifdef RKCoreDataIncluded
     paginator.managedObjectContext = self.managedObjectStore.mainQueueManagedObjectContext;
     paginator.managedObjectCache = self.managedObjectStore.managedObjectCache;


### PR DESCRIPTION
When creating the "RKPaginator" object, we're creating it based on the paginatorMapping's objectClass, instead of just creating an RKPaginator object. This allows RKPaginator to be subclassed.