### PR TITLE
Fix for issue #984 also applied for resetPersistentStores method.

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -404,7 +404,7 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
             // that is not expected in this method.
             NSMutableDictionary *mutableOptions = [persistentStore.options mutableCopy];
             [mutableOptions removeObjectForKey:RKSQLitePersistentStoreSeedDatabasePathOption];
-            mutableOptions = [[mutableOptions allKeys] count] > 0 ? mutableOptions : nil;
+            mutableOptions = [mutableOptions count] > 0 ? mutableOptions : nil;
             NSPersistentStore *newStore = [self addSQLitePersistentStoreAtPath:[persistentStore.URL path]
                                                         fromSeedDatabaseAtPath:seedPath
                                                              withConfiguration:persistentStore.configurationName

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -399,11 +399,17 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
                 }
             }
 
-            // Add a new store with the same options
-            NSPersistentStore *newStore = [self.persistentStoreCoordinator addPersistentStoreWithType:persistentStore.type
-                                                                                        configuration:persistentStore.configurationName
-                                                                                                  URL:persistentStore.URL
-                                                                                              options:persistentStore.options error:&localError];
+            NSString *seedPath = [persistentStore.options valueForKey:RKSQLitePersistentStoreSeedDatabasePathOption];
+            // Add a new store with the same options, except RKSQLitePersistentStoreSeedDatabasePathOption option
+            // that is not expected in this method.
+            NSMutableDictionary *mutableOptions = [persistentStore.options mutableCopy];
+            [mutableOptions removeObjectForKey:RKSQLitePersistentStoreSeedDatabasePathOption];
+            mutableOptions = [[mutableOptions allKeys] count] > 0 ? mutableOptions : nil;
+            NSPersistentStore *newStore = [self addSQLitePersistentStoreAtPath:[persistentStore.URL path]
+                                                        fromSeedDatabaseAtPath:seedPath
+                                                             withConfiguration:persistentStore.configurationName
+                                                                       options:mutableOptions
+                                                                         error:&localError];
             if (! newStore) {
                 if (error) *error = localError;
                 return NO;

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -386,20 +386,15 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
                 RKLogDebug(@"Skipped removal of persistent store file: URL for persistent store is not a file URL. (%@)", URL);
             }
 
-            // Reclone the persistent store from the seed path if necessary
+            NSString *seedPath;
+            // Seed path for reclone the persistent store from the seed path if necessary
             if ([persistentStore.type isEqualToString:NSSQLiteStoreType]) {
-                NSString *seedPath = [persistentStore.options valueForKey:RKSQLitePersistentStoreSeedDatabasePathOption];
-                if (seedPath && ![seedPath isEqual:[NSNull null]]) {
-                    success = [self copySeedDatabaseIfNecessaryFromPath:seedPath toPath:[persistentStore.URL path] error:&localError];
-                    if (! success) {
-                        RKLogError(@"Failed reset of SQLite persistent store: Failed to copy seed database.");
-                        if (error) *error = localError;
-                        return NO;
-                    }
+                seedPath = [persistentStore.options valueForKey:RKSQLitePersistentStoreSeedDatabasePathOption];
+                if ([seedPath isEqual:[NSNull null]]) {
+                    seedPath = nil;
                 }
             }
-
-            NSString *seedPath = [persistentStore.options valueForKey:RKSQLitePersistentStoreSeedDatabasePathOption];
+            
             // Add a new store with the same options, except RKSQLitePersistentStoreSeedDatabasePathOption option
             // that is not expected in this method.
             NSMutableDictionary *mutableOptions = [persistentStore.options mutableCopy];


### PR DESCRIPTION
I found the problem when reseting persistent store in resetPersistentStores method we don't used fix for issue 
#984. There seems to be trouble with combining configurations and migration when create persistent store with cocoa method addPersistentStoreWithType. So we should use restkit method addSQLitePersistentStoreAtPath that has this issue fixed.