### PR TITLE
Log non-CoreData validation errors in RKLogValidationError

### DIFF
--- a/Code/Support/RKLog.m
+++ b/Code/Support/RKLog.m
@@ -170,7 +170,7 @@ void RKLogIntegerAsBinary(NSUInteger bitMask)
 void RKLogValidationError(NSError *error)
 {
 #ifdef _COREDATADEFINES_H    
-    if ([[error domain] isEqualToString:@"NSCocoaErrorDomain"]) {
+    if ([[error domain] isEqualToString:NSCocoaErrorDomain]) {
         NSDictionary *userInfo = [error userInfo];
         NSArray *errors = [userInfo valueForKey:@"NSDetailedErrors"];
         if (errors) {
@@ -197,10 +197,10 @@ void RKLogValidationError(NSError *error)
                        [userInfo valueForKey:NSValidationPredicateErrorKey],
                        [userInfo valueForKey:NSValidationObjectErrorKey]);
         }
+        return;
     }
-#else
-    RKLogError(@"Validation Error: %@ (userInfo: %@)", error, [error userInfo]);
 #endif
+    RKLogError(@"Validation Error: %@ (userInfo: %@)", error, [error userInfo]);
 }
 
 #ifdef _COREDATADEFINES_H


### PR DESCRIPTION
As discovered in issue #2151, RKLogValidationError prints nothing out in a CoreData context if the validation error is not one of Apple's.  Any custom validation code which creates errors with other domains will then silently not give any reason why the assignment failed. Fix this by falling back to the non-CoreData code of just logging the basic values.