### PR TITLE
fix RKManagedObjectDeletionOperation memory leak

### DIFF
--- a/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
+++ b/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
@@ -174,6 +174,8 @@ static BOOL RKDeleteInvalidNewManagedObject(NSManagedObject *managedObject)
             [self.managedObjectContext deleteObject:managedObject];
         }
     }];
+
+    self.entityMappings = nil;
 }
 
 @end


### PR DESCRIPTION
Break retain cycle between RKManagedObjectDeletionOperation and RKMapperOperation. Fixes #2182