### PR TITLE
XCTest fix for class comparison

### DIFF
--- a/Code/Network/RKRouteSet.m
+++ b/Code/Network/RKRouteSet.m
@@ -145,7 +145,9 @@
 - (RKRoute *)routeForRelationship:(NSString *)relationshipName ofClass:(Class)objectClass method:(RKRequestMethod)method
 {
     for (RKRoute *route in [self relationshipRoutes]) {
-        if ([route.name isEqualToString:relationshipName] && [route.objectClass isEqual:objectClass] && (route.method == method || route.method == RKRequestMethodAny)) {
+        if ([route.name isEqualToString:relationshipName] &&
+            [NSStringFromClass(route.objectClass) isEqualToString:NSStringFromClass(objectClass)] &&
+            (route.method == method || route.method == RKRequestMethodAny)) {
             return route;
         }
     }


### PR DESCRIPTION
I've run into an issue where when I'm running tests (XCTest) the `routeForRelationship:ofClass:method:` method isn't able to find the route that I had set previously. 

For some reason, the class comparison is failing and the pointer to the saved class is different than the pointer to the passed in class despite them being the same. So, for the fix, I've changed it from a pointer comparison to a string comparison for the class. 

This doesn't seem like the best way to fix this, but it does fix the issue. Thanks!
