### PR TITLE
Fix willFinish race condition identified in #2164 and #2128.  It is possible for th...

### DIFF
--- a/Code/Network/RKResponseMapperOperation.m
+++ b/Code/Network/RKResponseMapperOperation.m
@@ -311,10 +311,12 @@ static NSMutableDictionary *RKRegisteredResponseMapperOperationDataSourceClasses
 {
     if (self.isCancelled && !self.error) self.error = [NSError errorWithDomain:RKErrorDomain code:RKOperationCancelledError userInfo:@{ NSLocalizedDescriptionKey: @"The operation was cancelled." }];
     
-    if (self.didFinishMappingBlock) {
-        if (self.error) self.didFinishMappingBlock(nil, self.error);
-        else self.didFinishMappingBlock(self.mappingResult, nil);
-        [self setDidFinishMappingBlock:nil];
+    @synchronized(self) {
+        if (self.didFinishMappingBlock) {
+            if (self.error) self.didFinishMappingBlock(nil, self.error);
+            else self.didFinishMappingBlock(self.mappingResult, nil);
+            [self setDidFinishMappingBlock:nil];
+        }
     }
 }
 


### PR DESCRIPTION
Fix willFinish race condition identified in #2164 and #2128.

It is possible for the main thread to invoke -cancel on the top-level operation, which then synchronously eventually calls -cancel on the RKResponseMapperOperation, which will then call the -willFinish method.  If this is exquisitely timed (such as in a callback of AFNetworkingOperationDidFinishNotification), then it can happen when the operation subthread has started to call -main but has not executed any code inside.  When that happens, the -main method realizes it has been cancelled and immediately also calls -willFinish.  Thus, two calls to -willFinish can be executing on separate threads at the same time.  The code in -willFinish invokes the finish block, then nils it out so it can't be called again.  However, that is not threadsafe, as both threads can invoke the block.  When this happens, there is an RKStateMachine error as the second call will try to move to the finished state when it was already in the finished state.

The fix is to add a synchronized block around the invocation of the finish block, which should ensure it can only be invoked once.