### PR TITLE
Allow creation of identification predicate based on representation

### DIFF
--- a/Code/CoreData/RKEntityMapping.h
+++ b/Code/CoreData/RKEntityMapping.h
@@ -115,6 +115,13 @@
 @property (nonatomic, copy) NSPredicate *identificationPredicate;
 
 /**
+ An optional block which returns a predicate used to filter identified objects during mapping.
+ 
+ @return The identification predicate block.
+ */
+@property (nonatomic, copy) NSPredicate *(^identificationPredicateBlock)(NSDictionary *representation, NSManagedObjectContext *managedObjectContext);
+
+/**
  An optional attribute of the receiver's entity that can be used to detect modification of a given instance. This is used to improve the performance of mapping operations by skipping the property mappings for a given object if it is found to be not modified.
  
  A common modification attribute is a 'last modified' or 'updated at' timestamp that specifies the timestamp of the last change to an object. When the `modificationAttribute` is non-nil, the mapper will compare the value returned of the attribute on an existing object instance with the value in the representation being mapped. 

--- a/Code/CoreData/RKEntityMapping.m
+++ b/Code/CoreData/RKEntityMapping.m
@@ -190,6 +190,7 @@ static BOOL entityIdentificationInferenceEnabled = YES;
     copy.entity = self.entity;
     copy.identificationAttributes = self.identificationAttributes;
     copy.identificationPredicate = self.identificationPredicate;
+    copy.identificationPredicateBlock = self.identificationPredicateBlock;
     copy.deletionPredicate = self.deletionPredicate;
     copy.modificationAttribute = self.modificationAttribute;
     copy.mutableConnections = [NSMutableArray array];

--- a/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
+++ b/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
@@ -277,6 +277,10 @@ extern NSString * const RKObjectMappingNestingAttributeKeyName;
                                                            attributeValues:entityIdentifierAttributes
                                                     inManagedObjectContext:self.managedObjectContext];
         if (entityMapping.identificationPredicate) objects = [objects filteredSetUsingPredicate:entityMapping.identificationPredicate];
+        if (entityMapping.identificationPredicateBlock) {
+            NSPredicate *predicate = entityMapping.identificationPredicateBlock(representation, self.managedObjectContext);
+            if (predicate) objects = [objects filteredSetUsingPredicate:predicate];
+        }
         if ([objects count] > 0) {
             managedObject = [objects anyObject];
             if ([objects count] > 1) RKLogWarning(@"Managed object cache returned %ld objects for the identifier configured for the '%@' entity, expected 1.", (long) [objects count], [entity name]);

--- a/Tests/Logic/CoreData/RKEntityMappingTest.m
+++ b/Tests/Logic/CoreData/RKEntityMappingTest.m
@@ -328,6 +328,7 @@
     RKEntityMapping *entityMapping = [RKEntityMapping mappingForEntityForName:@"Human" inManagedObjectStore:managedObjectStore];
     entityMapping.identificationAttributes = RKIdentificationAttributesInferredFromEntity(entityMapping.entity);
     entityMapping.identificationPredicate = [NSPredicate predicateWithValue:YES];
+    entityMapping.identificationPredicateBlock = ^(NSDictionary *representation, NSManagedObjectContext *context) { return [NSPredicate predicateWithValue:YES]; };
     entityMapping.deletionPredicate = [NSPredicate predicateWithValue:NO];
     [entityMapping setModificationAttributeForName:@"railsID"];
     [entityMapping addConnectionForRelationship:@"cats" connectedBy:@{ @"railsID": @"railsID", @"name": @"name" }];
@@ -337,6 +338,7 @@
     expect(entityMappingCopy.entity).to.equal(entityMapping.entity);
     expect(entityMappingCopy.identificationAttributes).to.equal(entityMapping.identificationAttributes);
     expect(entityMappingCopy.identificationPredicate).to.equal(entityMapping.identificationPredicate);
+    expect(entityMappingCopy.identificationPredicateBlock).to.equal(entityMapping.identificationPredicateBlock);
     expect(entityMappingCopy.deletionPredicate).to.equal(entityMapping.deletionPredicate);
     expect(entityMappingCopy.modificationAttribute).to.equal(entityMapping.modificationAttribute);
     expect(entityMappingCopy.connections.count == entityMapping.connections.count);

--- a/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
@@ -580,6 +580,42 @@
     expect(object).to.equal(human1);
 }
 
+- (void)testEntityIdentifierWithPredicateBlock
+{
+    RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
+    managedObjectStore.managedObjectCache = [RKFetchRequestManagedObjectCache new];
+    RKEntityMapping *mapping = [RKEntityMapping mappingForEntityForName:@"Human" inManagedObjectStore:managedObjectStore];
+    mapping.identificationAttributes = @[ @"railsID" ];
+    mapping.identificationPredicateBlock = ^(NSDictionary *representation, NSManagedObjectContext *context) {
+        return [NSPredicate predicateWithFormat:@"age + 94 < %@", representation[@"id"]];
+    };
+    [mapping addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:@"id" toKeyPath:@"railsID"]];
+    
+    // Create two humans matching the identifier, but differ in matching the
+    RKHuman *human1 = [NSEntityDescription insertNewObjectForEntityForName:@"Human" inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
+    human1.name = @"Colin";
+    human1.railsID = @123;
+    human1.age = @28;
+    
+    RKHuman *human2 = [NSEntityDescription insertNewObjectForEntityForName:@"Human" inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
+    human2.name = @"Blake";
+    human2.railsID = @123;
+    human2.age = @30;
+    [managedObjectStore.persistentStoreManagedObjectContext save:nil];
+    
+    NSError *error = nil;
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Human"];
+    NSUInteger count = [managedObjectStore.persistentStoreManagedObjectContext countForFetchRequest:fetchRequest error:&error];
+    expect(count).to.beGreaterThan(0);
+    
+    RKManagedObjectMappingOperationDataSource *dataSource = [[RKManagedObjectMappingOperationDataSource alloc] initWithManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext
+                                                                                                                                      cache:managedObjectStore.managedObjectCache];
+    NSDictionary *data = @{@"id": @123};
+    id object = [dataSource mappingOperation:nil targetObjectForRepresentation:data withMapping:mapping inRelationship:nil];
+    expect(object).notTo.beNil();
+    expect(object).to.equal(human1);
+}
+
 - (void)testMappingInPrivateQueue
 {
     RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];


### PR DESCRIPTION
We have a data structure for rows in our DB which looks like this:

    {
        tableId: 123,
        fields: [
            { columnId: 1231, value: 1},
            { columnId: 1232, value: 2},
            { columnId: 1233, value: 3}
        ]
    }

Elsewhere, we have data specifying that for table 123, columns 1231 and 1232 are primary keys.  So when we're mapping this, we need to identify this data with the row that has those same values in the fields with matching columnIds.

We can't do this with identificationAttributes or a static identificationPredicate, so I've added the option of setting an identificationPredicateBlock that can look at the representation and come up with the appropriate predicate.

I also pass in the managed object context, as I need to fetch the table object to look up the primary key columns.