### PR TITLE
Concurrency Fixes

### DIFF
--- a/Code/CoreData/RKRelationshipConnectionOperation.m
+++ b/Code/CoreData/RKRelationshipConnectionOperation.m
@@ -148,7 +148,14 @@ static NSDictionary *RKConnectionAttributeValuesWithObject(RKConnectionDescripti
 {
     *shouldConnectRelationship = YES;
     id connectionResult = nil;
-    if (connection.sourcePredicate && ![connection.sourcePredicate evaluateWithObject:self.managedObject]) return nil;
+    if (connection.sourcePredicate) {
+        __block BOOL evaluationResult;
+        [self.managedObject.managedObjectContext performBlockAndWait:^{
+            evaluationResult = [connection.sourcePredicate evaluateWithObject:self.managedObject];
+        }];
+        
+        if (!evaluationResult) return nil;
+    }
     
     if ([connection isForeignKeyConnection]) {
         NSDictionary *attributeValues = RKConnectionAttributeValuesWithObject(connection, self.managedObject);
@@ -157,11 +164,15 @@ static NSDictionary *RKConnectionAttributeValuesWithObject(RKConnectionDescripti
             *shouldConnectRelationship = NO;
             return nil;
         }
-        NSSet *managedObjects = [self.managedObjectCache managedObjectsWithEntity:[connection.relationship destinationEntity]
+        __block NSSet *managedObjects = [self.managedObjectCache managedObjectsWithEntity:[connection.relationship destinationEntity]
                                                                   attributeValues:attributeValues
                                                            inManagedObjectContext:self.managedObjectContext];
-        if (connection.destinationPredicate) managedObjects = [managedObjects filteredSetUsingPredicate:connection.destinationPredicate];
-        if (!connection.includesSubentities) managedObjects = [managedObjects filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"entity == %@", [connection.relationship destinationEntity]]];
+
+        [self.managedObjectContext performBlockAndWait:^{
+            if (connection.destinationPredicate) managedObjects = [managedObjects filteredSetUsingPredicate:connection.destinationPredicate];
+            if (!connection.includesSubentities) managedObjects = [managedObjects filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"entity == %@", [connection.relationship destinationEntity]]];
+        }];
+        
         if ([connection.relationship isToMany]) {
             connectionResult = managedObjects;
         } else {

--- a/Code/CoreData/RKRelationshipConnectionOperation.m
+++ b/Code/CoreData/RKRelationshipConnectionOperation.m
@@ -165,8 +165,8 @@ static NSDictionary *RKConnectionAttributeValuesWithObject(RKConnectionDescripti
             return nil;
         }
         __block NSSet *managedObjects = [self.managedObjectCache managedObjectsWithEntity:[connection.relationship destinationEntity]
-                                                                  attributeValues:attributeValues
-                                                           inManagedObjectContext:self.managedObjectContext];
+                                                                          attributeValues:attributeValues
+                                                                   inManagedObjectContext:self.managedObjectContext];
 
         [self.managedObjectContext performBlockAndWait:^{
             if (connection.destinationPredicate) managedObjects = [managedObjects filteredSetUsingPredicate:connection.destinationPredicate];


### PR DESCRIPTION
When running our app with the -com.apple.CoreData.ConcurrencyDebug flag to 1, two RestKit issues were flagged by CoreData.  This patch fixes both of them.