### PR TITLE
Don't try to fix NSCachedURLResponse's leak on iOS 8 and later

### DIFF
--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -623,6 +623,11 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
 
 - (NSData *)rkData
 {
+    BOOL isSystemVersion8OrLater = [NSProcessInfo instancesRespondToSelector:@selector(operatingSystemVersion)];
+    if (isSystemVersion8OrLater) {
+        return self.data;
+    }
+    
     @synchronized(self) {
         NSData *result;
         CFIndex count;

--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -623,6 +623,7 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
 
 - (NSData *)rkData
 {
+#if TARGET_OS_IPHONE
     BOOL isSystemVersion8OrLater = [NSProcessInfo instancesRespondToSelector:@selector(operatingSystemVersion)];
     if (isSystemVersion8OrLater) {
         return self.data;
@@ -645,6 +646,9 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
         
         return result;
     }
+#else
+    return self.data;
+#endif
 }
 
 @end


### PR DESCRIPTION
Since iOS 8, we are seeing crash reports with a stack trace identical to the one found on [Cannot track down [NSData getBytes:length:] crash][1].

```
Thread : Crashed: com.apple.CFNetwork.addPersistCacheToStorageDaemon
0  libsystem_platform.dylib       0x3044a208 _platform_memmove$VARIANT$CortexA9 + 160
1  Foundation                     0x22df9167 -[NSData(NSData) getBytes:length:] + 118
2  Foundation                     0x22df9167 -[NSData(NSData) getBytes:length:] + 118
3  Foundation                     0x22e21a1b -[NSData(NSData) replacementObjectForCoder:] + 134
4  Foundation                     0x22dc2aff -[NSXPCEncoder _replaceObject:] + 90
5  Foundation                     0x22e240dd -[NSXPCEncoder _encodeArrayOfObjects:forKey:] + 192
6  Foundation                     0x22e212ff -[NSDictionary(NSDictionary) encodeWithCoder:] + 922
7  Foundation                     0x22dc32c9 -[NSXPCEncoder _encodeObject:] + 604
8  Foundation                     0x22dc379d encodeInvocationArguments + 460
9  Foundation                     0x22dc3455 -[NSXPCEncoder encodeInvocation:] + 360
10 Foundation                     0x22dc32c9 -[NSXPCEncoder _encodeObject:] + 604
11 Foundation                     0x22dc2335 -[NSXPCConnection _sendInvocation:proxyNumber:remoteInterface:withErrorHandler:timeout:userInfo:] + 1860
12 Foundation                     0x22dd2823 -[NSXPCConnection _sendInvocation:proxyNumber:remoteInterface:withErrorHandler:] + 58
13 Foundation                     0x22dd27db -[_NSXPCDistantObjectWithError forwardInvocation:] + 114
14 CoreFoundation                 0x2217e831 ___forwarding___ + 352
15 CoreFoundation                 0x220afb88 _CF_forwarding_prep_0 + 24
16 CFNetwork                      0x21c52ac9 -[NSURLStorage_CacheClient addCachedResponseWithDictionary:key:] + 120
17 CFNetwork                      0x21c21e29 ___ZN12__CFURLCache23CreateAndStoreCacheNodeEP16__CFURLCacheNodePK20_CFCachedURLResponsePK10__CFStringPK13_CFURLRequestPKvbRb_block_invoke + 1576
18 libdispatch.dylib              0x302cf423 _dispatch_call_block_and_release + 10
19 libdispatch.dylib              0x302d95d9 _dispatch_queue_drain$VARIANT$mp + 948
20 libdispatch.dylib              0x302d90a9 _dispatch_queue_invoke$VARIANT$mp + 84
21 libdispatch.dylib              0x302db0d3 _dispatch_root_queue_drain + 330
22 libdispatch.dylib              0x302dc1fb _dispatch_worker_thread3 + 106
23 libsystem_pthread.dylib        0x3044ce25 _pthread_wqthread + 668
```

The crash happens while adding a cached response (frame 16) when accessing some NSData instance which seems bogus (frame 1).

It turns out that RestKit is intentionally over releasing a NSData instance in  [`[NSCachedURLResponse rkData]`][2] as a fix for a leak in the `[NSCachedURLResponse data]` method. This workaround was introduced in commit b4a49c11ffce2954b5252d266516053a0e518bed (pull request #1459).

I can not reproduce this crash but it seems clear to me that the workaround for the leak and the crash are linked. I think a change in iOS 8 somehow exposed this behavior.

  [1]: http://stackoverflow.com/questions/28949799/cannot-track-down-nsdata-getbyteslength-crash
  [2]: https://github.com/RestKit/RestKit/blob/45aee2634cb03f05543ede557b470232af846daf/Code/Network/RKObjectRequestOperation.m#L622-L645