### PR TITLE
Updated broken URLs for those which have a working alternative

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Issues
 
-GitHub Issues is for reporting bugs in RestKit and discussing changes to RestKit itself. Please check the [documentation](http://cocoadocs.org/docsets/RestKit/), [wiki](https://github.com/RestKit/RestKit/wiki), and [existing issues](https://github.com/RestKit/RestKit/issues?state=closed) before opening a new issue.
+GitHub Issues is for reporting bugs in RestKit and discussing changes to RestKit itself. Please check the [documentation](http://cocoadocs.org/docsets/RestKit/), [wiki](https://github.com/RestKit/RestKit/wiki), and [existing issues](https://github.com/RestKit/RestKit/issues?q=is:issue) before opening a new issue.
 
 Additionaly, please do not post general usage questions to Issues, but instead take them to [Stack Overflow](http://stackoverflow.com/questions/tagged/restkit).
 

--- a/Docs/MobileTuts Advanced RestKit/Advanced_RestKit_Tutorial.md
+++ b/Docs/MobileTuts Advanced RestKit/Advanced_RestKit_Tutorial.md
@@ -717,7 +717,7 @@ We hope that you have found learning about RestKit fun and rewarding. At this po
 
 ## Learning More
 * RestKit: [http://restkit.org]()
-* Github: [https://github.com/twotoasters/RestKit]()
-* API Docs: [http://restkit.org/api/]()
+* Github: [https://github.com/RestKit/RestKit]()
+* API Docs: [http://cocoadocs.org/docsets/RestKit/]()
 * Google Group: [http://groups.google.com/group/restkit]()
 * Brought to you by Two Toasters: [http://twotoasters.com/]()

--- a/Docs/MobileTuts Introduction to RestKit/index.html
+++ b/Docs/MobileTuts Introduction to RestKit/index.html
@@ -381,7 +381,7 @@ This article has explored the basics of working with RestKit. You should now hav
 
 <ul>
 <li><a href="http://restkit.org">RestKit.org</a></li>
-<li><a href="https://github.com/twotoasters/RestKit">Github Project Page</a></li>
+<li><a href="https://github.com/RestKit/RestKit">Github Project Page</a></li>
 <li><a href="http://groups.google.com/group/restkit">Official Google Group</a></li>
 <li><a href="http://twotoasters.com/">Two Toasters</a></li>
 </ul>

--- a/Docs/WRITING_DOCS.md
+++ b/Docs/WRITING_DOCS.md
@@ -1,7 +1,7 @@
 Writing Documentation
 =====================
 
-RestKit utilizes the excellent [Appledoc](http://www.gentlebytes.com/home/appledocapp/) utility from [Gentle Bytes](http://www.gentlebytes.com/). 
+RestKit utilizes the excellent [Appledoc](http://www.gentlebytes.com/appledoc/) utility from [Gentle Bytes](http://www.gentlebytes.com/). 
 Appledoc provides a commandline utility for parsing and generating documentation from Objective-C code in HTML and DocSet format. This HTML can be
 published to the Web and installed directly within Xcode. 
 
@@ -21,7 +21,7 @@ The tasks available for working with Appledoc are:
 
 ## Writing Documentation
 
-Writing documentation in Appledoc markup is simple. There is extensive documentation available on the [Appledoc project page](http://tomaz.github.com/appledoc/comments.html), but 
+Writing documentation in Appledoc markup is simple. There is extensive documentation available on the [Appledoc project page](https://github.com/tomaz/appledoc), but 
 the guidelines below should be sufficient for basic authoring tasks. For clarity, let's consider the following example class:    
     
     /**
@@ -107,6 +107,6 @@ If you want to contribute documentation, the process is simple:
 1. Edit the headers in Code/ and regenerate the docs via `rake docs`
 1. Repeat the editing and reload cycle until your are happy.
 1. Commit the code and push to Github
-1. Submit a Pull Request to the RestKit repository on Github at: https://github.com/RestKit/RestKit/pull/new/master
+1. Submit a Pull Request to the RestKit repository on Github at: https://github.com/RestKit/RestKit/compare
 
 You may want to coordinate your efforts via the mailing list to ensure nobody else is working on documentation in the same place.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ RKObjectRequestOperation *operation = [[RKObjectRequestOperation alloc] initWith
 - First time with RestKit? Read the ["Overview"](#overview) section below and then check out the ["Getting Acquainted with RestKit"](https://github.com/RestKit/RKGist/blob/master/TUTORIAL.md) tutorial and [Object Mapping Reference](https://github.com/RestKit/RestKit/wiki/Object-mapping) documents in the wiki to jump right in.
 - Upgrading from RestKit 0.9.x or 0.10.x? Read the ["Upgrading to RestKit 0.20.x"](https://github.com/RestKit/RestKit/wiki/Upgrading-from-v0.10.x-to-v0.20.0) guide in the wiki
 - Adding RestKit to an existing [AFNetworking](https://github.com/AFNetworking/AFNetworking) application? Read the [AFNetworking Integration](https://github.com/RestKit/RestKit/wiki/AFNetworking-Integration) document to learn details about how the frameworks fit together.
-- Review the [source code API documentation](http://restkit.org/api/latest) for a detailed look at the classes and API's in RestKit. A great place to start is [RKObjectManager](http://restkit.org/api/latest/Classes/RKObjectManager.html).
+- Review the [source code API documentation](http://cocoadocs.org/docsets/RestKit/) for a detailed look at the classes and API's in RestKit. A great place to start is [RKObjectManager](http://restkit.org/api/latest/Classes/RKObjectManager.html).
 - Still need some help? Ask questions on [Stack Overflow](http://stackoverflow.com/questions/tagged/restkit) or the [mailing list](http://groups.google.com/group/restkit), ping us on [Twitter](http://twitter.com/RestKit) or chat with us on [IRC](https://kiwiirc.com/client/irc.freenode.net/?nick=rkuser|?&theme=basic#RestKit).
 
 ## Overview
@@ -60,7 +60,7 @@ Object mapping is a deep topic and is explored in exhaustive detail in the [Obje
 RestKit is broken into several modules that cleanly separate the mapping engine from the HTTP and Core Data integrations to provide maximum flexibility. Key classes in each module are highlighted below and each module is hyperlinked to the README.md contained within the source code.
 
 <table>
-  <tr><th colspan="2" style="text-align:center;"><a href="Code/ObjectMapping/README.md">Object Mapping</a></th></tr>
+  <tr><th colspan="2" style="text-align:center;"><a href="https://github.com/RestKit/RestKit/wiki/Object-mapping">Object Mapping</a></th></tr>
   <tr>
     <td><a href="http://restkit.org/api/latest/Classes/RKObjectMapping.html">RKObjectMapping</a></td>
     <td>Encapsulates configuration for transforming object representations as expressed by key-value coding keypaths.</td>
@@ -534,7 +534,7 @@ Several third-party open source libraries are used within RestKit, including:
 
 1. [AFNetworking](https://github.com/AFNetworking/AFNetworking) - Networking Support
 2. [LibComponentLogging](http://0xc0.de/LibComponentLogging) - Logging Support
-3. [SOCKit](https://github.com/jverkoey/sockit) - String <-> Object Coding
+3. [SOCKit](https://github.com/NimbusKit/sockit) - String <-> Object Coding
 4. [iso8601parser](http://boredzo.org/iso8601parser/) - Support for parsing and generating ISO-8601 dates
 
 The following Cocoa frameworks must be linked into the application target for proper compilation:
@@ -590,11 +590,11 @@ $ touch Podfile
 $ edit Podfile
 platform :ios, '5.0'
 # Or platform :osx, '10.7'
-pod 'RestKit', '~> 0.20.0'
+pod 'RestKit', '~> 0.24.0'
 
 # Testing and Search are optional components
-pod 'RestKit/Testing', '~> 0.20.0'
-pod 'RestKit/Search',  '~> 0.20.0'
+pod 'RestKit/Testing', '~> 0.24.0'
+pod 'RestKit/Search',  '~> 0.24.0'
 ```
 
 Install into your project:

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -6,7 +6,7 @@ RestKit ships with a testing infrastructure built around OCUnit and a Ruby testi
 1. Install the Xcode **Command Line Tools** by selecting the **Xcode** > **Preferences…** menu and then navigating to the **Downloads** tab, then clicking the **Install** button next to the appropriate entry in the table.
 1. After installation completes, ensure your command line Xcode installation is configured by executing `xcode-select -print-path`. If no path is returned, configure xcode-select by executing `xcode-select -switch /Applications/Xcode.app/Contents/Developer`.
 1. Check out the Git submodules: `git submodule update --init --recursive`
-1. Ensure that you have **Ruby 2.0.0** available. We recommend installation via [rbenv](https://github.com/sstephenson/rbenv), [RVM](http://beginrescueend.com/rvm/install/) or [Homebrew](http://mxcl.github.com/homebrew/).
+1. Ensure that you have **Ruby 2.0.0** available. We recommend installation via [rbenv](https://github.com/sstephenson/rbenv), [RVM](https://rvm.io/) or [Homebrew](http://brew.sh/).
 1. Install the Ruby Bundler Gem (if necessary): `gem install bundler`
 1. Install the other required Gems via Bundler: `bundle`
 1. Install the required CocoaPods: `pod install`
@@ -66,13 +66,13 @@ configured and there are integration tests that test the full request/response l
 1. Tests are implemented in Objective-C and run inside the Simulator or on the Device.
 1. Test files live in sub-directories under Tests/ appropriate to the layer the code under test belongs to
 1. Tests begin with "test" and should be camel-cased descriptive. i.e. testShouldConsiderA200ResponseSuccessful
-1. Expectations are provided using [Expecta](https://github.com/petejkim/expecta) and [OCHamcrest](http://jonreid.github.com/OCHamcrest/). Expectations are generally of th form:
+1. Expectations are provided using [Expecta](https://github.com/specta/expecta) and [OCHamcrest](https://github.com/hamcrest/OCHamcrest). Expectations are generally of th form:
         expect(someObject).to.equal(@"some value"); // Expecta
         assertThat([someObject someMethod], is(equalTo(@"some value"))); // OCHamcrest
         
     There is a corresponding `notTo` and `isNot` method available as well.
 1. The RKTestEnvironment.h header includes a number of helpers for initializing and configuring a clean testing environment.
-1. OCMock is available for mock objects support. See [http://www.mulle-kybernetik.com/software/OCMock/](http://www.mulle-kybernetik.com/software/OCMock/) for details.
+1. OCMock is available for mock objects support. See [http://ocmock.org/](http://ocmock.org/) for details.
 1. RestKit is available for 32bit (iOS) and 64bit (OS X) platforms. This introduces some complexity when working with integer data types as NSInteger
 and NSUInteger are int's on 32bit and long's on 64bit. Cocoa and OC Hamcrest provide helper methods for dealing with these differences. Rather than using the **Int**
 flavor of methods (i.e. `[NSNumber numberWithInt:3]`) use the **Integer** flavor (i.e. `[NSNumber numberWithInteger:]`). This will account for the type differences without
@@ -125,12 +125,14 @@ That's really all there is to it. Consult the existing test code in Tests/ for r
 Continuous Integration
 -------------
 
+**Note:** RestKit currently uses [Travis CI](https://travis-ci.org/RestKit/RestKit)
+
 The RestKit team keeps the master, development, and active branches of RestKit under the watchful eye of the [Jenkins Continuous Integration Server](http://jenkins-ci.org/). There is a fair amount of complexity involved in getting iOS projects running under Jenkins, so to make things as easy as possible all Jenkins configuration has been collected into a single script within the source code. Currently use of the Jenkins build **requires** the use of RVM for managing the Ruby environment.
 
 To configure Jenkins to build RestKit, do the following:
 
 1. Ensure the RestKit test suite executes cleanly on the CI host using the above reference.
-1. Install Jenkins (again, we recommend [Homebrew](http://mxcl.github.com/)): `brew install jenkins`
+1. Install Jenkins (again, we recommend [Homebrew](https://github.com/Homebrew/homebrew)): `brew install jenkins`
 2. Install Jenkins as a system service. Instructions are printed post installation via Homebrew
 3. Configure your CI user's OS X account to automatically manage the RVM environment. Create an `~/.rvmrc` file and populate it with the following:
 ```bash

--- a/Vendor/LibComponentLogging/Core/README.md
+++ b/Vendor/LibComponentLogging/Core/README.md
@@ -24,15 +24,15 @@ This Git repository contains the library's Core part.
 Download the files of the library Core and a logging back-end, e.g. the
 LogFile logger, from their repositories on GitHub:
 
-* [Library Core](http://github.com/aharren/LibComponentLogging-Core/downloads)
+* [Library Core](http://github.com/aharren/LibComponentLogging-Core)
 
-* [LogFile Logger](http://github.com/aharren/LibComponentLogging-LogFile/downloads)
+* [LogFile Logger](http://github.com/aharren/LibComponentLogging-LogFile)
 
-* [SystemLog Logger](http://github.com/aharren/LibComponentLogging-SystemLog/downloads)
+* [SystemLog Logger](http://github.com/aharren/LibComponentLogging-SystemLog)
 
-* [NSLog Logger](http://github.com/aharren/LibComponentLogging-NSLog/downloads)
+* [NSLog Logger](http://github.com/aharren/LibComponentLogging-NSLog)
 
-* [NSLogger Logger](http://github.com/aharren/LibComponentLogging-NSLogger/downloads)
+* [NSLogger Logger](http://github.com/aharren/LibComponentLogging-NSLogger)
 
 Extract the files and copy the extracted files to your application's source
 directory.


### PR DESCRIPTION
I updated a bunch of broken URLs. Some where old and redirecting, so I changed those URLs to the one it redirects too. For other external broken links, I found the official link and used that.

There are still a lot of broken links due to Restkit.org being down. Most of the documentation links would need to be removed or linked to a hard coded version on cocoadocs.