### PR TITLE
Define contexts for CocoaLumberjack

### DIFF
--- a/Code/Support/RKLumberjackLogger.m
+++ b/Code/Support/RKLumberjackLogger.m
@@ -75,7 +75,7 @@
     [DDLog log:async
          level:componentLevel
           flag:flag
-       context:0 /* Could define a special value here to identify RestKit logs to any backend loggers */
+       context:0x524B5F00 + component
           file:path function:function line:line
            tag:nil
         format:format args:args];


### PR DESCRIPTION
As recommended by [CocoaLumberjack logging contexts documentation](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/8adde11d0b16843cb45b81dc9b60d1430eb9b538/Documentation/CustomContext.md#example-2)

> This will allow application developers to easily manage the log statements coming from your framework.