### PR TITLE
Copy on RKEntityMapping instance triggers assert

### DIFF
--- a/Code/CoreData/RKEntityMapping.m
+++ b/Code/CoreData/RKEntityMapping.m
@@ -184,16 +184,22 @@ static BOOL entityIdentificationInferenceEnabled = YES;
     return self;
 }
 
+- (void)copyPropertiesFromMapping:(RKEntityMapping *)mapping
+{
+    self.entity = mapping.entity;
+    self.identificationAttributes = mapping.identificationAttributes;
+    self.identificationPredicate = mapping.identificationPredicate;
+    self.identificationPredicateBlock = mapping.identificationPredicateBlock;
+    self.deletionPredicate = mapping.deletionPredicate;
+    self.modificationAttribute = mapping.modificationAttribute;
+    self.mutableConnections = [NSMutableArray array];
+    
+    [super copyPropertiesFromMapping:mapping];
+}
+
 - (id)copyWithZone:(NSZone *)zone
 {
     RKEntityMapping *copy = [super copyWithZone:zone];
-    copy.entity = self.entity;
-    copy.identificationAttributes = self.identificationAttributes;
-    copy.identificationPredicate = self.identificationPredicate;
-    copy.identificationPredicateBlock = self.identificationPredicateBlock;
-    copy.deletionPredicate = self.deletionPredicate;
-    copy.modificationAttribute = self.modificationAttribute;
-    copy.mutableConnections = [NSMutableArray array];
     
     for (RKConnectionDescription *connection in self.connections) {
         [copy addConnection:[connection copy]];

--- a/Code/ObjectMapping/RKObjectMapping.h
+++ b/Code/ObjectMapping/RKObjectMapping.h
@@ -68,6 +68,8 @@
  */
 @interface RKObjectMapping : RKMapping <NSCopying>
 
+- (void)copyPropertiesFromMapping:(RKObjectMapping *)mapping;
+
 ///---------------------------------
 /// @name Creating an Object Mapping
 ///---------------------------------

--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -35,10 +35,6 @@ NSString * const RKObjectMappingNestingAttributeKeyName = @"<RK_NESTING_ATTRIBUT
 
 static RKSourceToDesinationKeyTransformationBlock defaultSourceToDestinationKeyTransformationBlock = nil;
 
-@interface RKObjectMapping (Copying)
-- (void)copyPropertiesFromMapping:(RKObjectMapping *)mapping;
-@end
-
 @interface RKMappingInverter : NSObject
 @property (nonatomic, strong) RKObjectMapping *mapping;
 @property (nonatomic, strong) NSMutableDictionary *invertedMappings;


### PR DESCRIPTION
Calling copy on RKEntityMapping instance triggers assert because object is missing entity property at inspection time. Fixed by adding copyPropertiesFromMapping method RKEntityMapping class.

Please include this fix in next release. :)