### PR TITLE
Assign properties of NSDateComponents object to zero before use.…

### DIFF
--- a/Code/ObjectMapping/RKHTTPUtilities.m
+++ b/Code/ObjectMapping/RKHTTPUtilities.m
@@ -350,12 +350,12 @@ static NSDate *_parseHTTPDate(const char *buf, size_t bufLen) {
     memset(&gdate, 0, sizeof(CFGregorianDate));
 #else
     NSDateComponents *gdate = [[NSDateComponents alloc] init];
-	gdate.year = 0;
-	gdate.month = 0;
-	gdate.day = 0;
-	gdate.hour = 0;
-	gdate.minute = 0;
-	gdate.second = 0;
+    gdate.year = 0;
+    gdate.month = 0;
+    gdate.day = 0;
+    gdate.hour = 0;
+    gdate.minute = 0;
+    gdate.second = 0;
 #endif
     
     {

--- a/Code/ObjectMapping/RKHTTPUtilities.m
+++ b/Code/ObjectMapping/RKHTTPUtilities.m
@@ -350,6 +350,12 @@ static NSDate *_parseHTTPDate(const char *buf, size_t bufLen) {
     memset(&gdate, 0, sizeof(CFGregorianDate));
 #else
     NSDateComponents *gdate = [[NSDateComponents alloc] init];
+	gdate.year = 0;
+	gdate.month = 0;
+	gdate.day = 0;
+	gdate.hour = 0;
+	gdate.minute = 0;
+	gdate.second = 0;
 #endif
     
     {

--- a/Tests/Logic/Support/RKHTTPUtilitiesTest.m
+++ b/Tests/Logic/Support/RKHTTPUtilitiesTest.m
@@ -139,36 +139,36 @@
 
 - (void)testRKDateFromHTTPDateString
 {
-	void (^testBlock)(NSDateComponents *) = ^void(NSDateComponents *dateComponents) {
-		NSDateFormatter * const dateFormatter = [[NSDateFormatter alloc] init];
-		dateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
-		dateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
-		dateFormatter.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss z";
-
-		NSCalendar * const calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-		calendar.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
-		
-		NSDate * const sourceDate = [calendar dateFromComponents:dateComponents];
-		NSString * const sourceString = [dateFormatter stringFromDate:sourceDate];
-		NSDate * const destdate = RKDateFromHTTPDateString(sourceString);
-		expect(destdate).to.equal(sourceDate);
-	};
-	
-	NSDateComponents * const dateComponents = [[NSDateComponents alloc] init];
-	dateComponents.hour = 0; dateComponents.minute = 0; dateComponents.second = 0;
-	
-	// epoch
-	dateComponents.year = 1970; dateComponents.month = 1; dateComponents.day = 1;
-	testBlock(dateComponents);
-	
-	// pre epoc
-	dateComponents.year = 1969; dateComponents.month = 1; dateComponents.day = 27;
-	testBlock(dateComponents);
-	
-	// release of U2's Achtung Baby album
-	dateComponents.year = 1991; dateComponents.month = 11; dateComponents.day = 18;
-	dateComponents.hour = 12; dateComponents.minute = 34; dateComponents.second = 56;
-	testBlock(dateComponents);
+    void (^testBlock)(NSDateComponents *) = ^void(NSDateComponents *dateComponents) {
+        NSDateFormatter * const dateFormatter = [[NSDateFormatter alloc] init];
+        dateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+        dateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+        dateFormatter.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss z";
+        
+        NSCalendar * const calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+        calendar.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
+        
+        NSDate * const sourceDate = [calendar dateFromComponents:dateComponents];
+        NSString * const sourceString = [dateFormatter stringFromDate:sourceDate];
+        NSDate * const destdate = RKDateFromHTTPDateString(sourceString);
+        expect(destdate).to.equal(sourceDate);
+    };
+    
+    NSDateComponents * const dateComponents = [[NSDateComponents alloc] init];
+    dateComponents.hour = 0; dateComponents.minute = 0; dateComponents.second = 0;
+    
+    // epoch
+    dateComponents.year = 1970; dateComponents.month = 1; dateComponents.day = 1;
+    testBlock(dateComponents);
+    
+    // pre epoc
+    dateComponents.year = 1969; dateComponents.month = 1; dateComponents.day = 27;
+    testBlock(dateComponents);
+    
+    // release of U2's Achtung Baby album
+    dateComponents.year = 1991; dateComponents.month = 11; dateComponents.day = 18;
+    dateComponents.hour = 12; dateComponents.minute = 34; dateComponents.second = 56;
+    testBlock(dateComponents);
 }
 
 @end

--- a/Tests/Logic/Support/RKHTTPUtilitiesTest.m
+++ b/Tests/Logic/Support/RKHTTPUtilitiesTest.m
@@ -137,4 +137,38 @@
     expect(RKStringFromRequestMethod(RKRequestMethodGET|RKRequestMethodDELETE)).to.beNil();
 }
 
+- (void)testRKDateFromHTTPDateString
+{
+	void (^testBlock)(NSDateComponents *) = ^void(NSDateComponents *dateComponents) {
+		NSDateFormatter * const dateFormatter = [[NSDateFormatter alloc] init];
+		dateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+		dateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+		dateFormatter.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss z";
+
+		NSCalendar * const calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+		calendar.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
+		
+		NSDate * const sourceDate = [calendar dateFromComponents:dateComponents];
+		NSString * const sourceString = [dateFormatter stringFromDate:sourceDate];
+		NSDate * const destdate = RKDateFromHTTPDateString(sourceString);
+		expect(destdate).to.equal(sourceDate);
+	};
+	
+	NSDateComponents * const dateComponents = [[NSDateComponents alloc] init];
+	dateComponents.hour = 0; dateComponents.minute = 0; dateComponents.second = 0;
+	
+	// epoch
+	dateComponents.year = 1970; dateComponents.month = 1; dateComponents.day = 1;
+	testBlock(dateComponents);
+	
+	// pre epoc
+	dateComponents.year = 1969; dateComponents.month = 1; dateComponents.day = 27;
+	testBlock(dateComponents);
+	
+	// release of U2's Achtung Baby album
+	dateComponents.year = 1991; dateComponents.month = 11; dateComponents.day = 18;
+	dateComponents.hour = 12; dateComponents.minute = 34; dateComponents.second = 56;
+	testBlock(dateComponents);
+}
+
 @end


### PR DESCRIPTION
… They default to NSUndefinedDateComponent (NSIntegerMax), which caused string conversions to NSDate to fail when using the latest SDKs.

The changed method (_parseHTTPDate) is used by RKDateFromHTTPDateString and indirectly by RKHTTPCacheExpirationDateFromHeadersWithStatusCode.