### PR TITLE
Update TransitionKit dependency to version 2.2

### DIFF
--- a/RestKit.podspec
+++ b/RestKit.podspec
@@ -100,6 +100,6 @@ EOS
 
   s.subspec 'Support' do |ss|
     ss.source_files   = 'Code/RestKit.h', 'Code/Support.h', 'Code/Support', 'Vendor/LibComponentLogging/Core'
-    ss.dependency 'TransitionKit', '~> 2.1.0'
+    ss.dependency 'TransitionKit', '~> 2.2'
   end
 end


### PR DESCRIPTION
Version 2.2.0 introduced some enhancements to the state change notifications. If other projects depend on version 2.2.x, this `~> 2.1.0` dependency would make CocoaPods’ dependency resolver unhappy.

Also changing from `~> 2.1.0` to `~> 2.2` so that all future 2.x versions will make the resolver happy.