### PR TITLE
Mapping: Ignore NSNull in source collections

### DIFF
--- a/Code/ObjectMapping/RKMapperOperation.m
+++ b/Code/ObjectMapping/RKMapperOperation.m
@@ -229,7 +229,7 @@ static NSString *RKFailureReasonErrorStringForMappingNotFoundError(id representa
     NSArray *metadataList = [NSArray arrayWithObjects:metadata, self.metadata, nil];
     NSMutableArray *mappedObjects = [NSMutableArray arrayWithCapacity:[representations count]];
     [objectsToMap enumerateObjectsUsingBlock:^(id mappableObject, NSUInteger index, BOOL *stop) {
-		if (mappableObject == [NSNull null]) { return; }
+        if (mappableObject == [NSNull null]) { return; }
         
         id destinationObject = [self objectForRepresentation:mappableObject withMapping:mapping];
         if (destinationObject) {

--- a/Code/ObjectMapping/RKMapperOperation.m
+++ b/Code/ObjectMapping/RKMapperOperation.m
@@ -229,6 +229,8 @@ static NSString *RKFailureReasonErrorStringForMappingNotFoundError(id representa
     NSArray *metadataList = [NSArray arrayWithObjects:metadata, self.metadata, nil];
     NSMutableArray *mappedObjects = [NSMutableArray arrayWithCapacity:[representations count]];
     [objectsToMap enumerateObjectsUsingBlock:^(id mappableObject, NSUInteger index, BOOL *stop) {
+		if (mappableObject == [NSNull null]) { return; }
+        
         id destinationObject = [self objectForRepresentation:mappableObject withMapping:mapping];
         if (destinationObject) {
             mappingData.collectionIndex = index;

--- a/Tests/Fixtures/JSON/users.json
+++ b/Tests/Fixtures/JSON/users.json
@@ -5,7 +5,11 @@
   },
   {
      "id":187,
-     "name":"Jeremy Ellison"
+     "name":"Jeremy Ellison",
+     "friend": {
+         "id": 255,
+         "name": "Anthony Stark"
+     }
   },
   {
      "id":7,

--- a/Tests/Logic/ObjectMapping/RKObjectMappingNextGenTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectMappingNextGenTest.m
@@ -262,6 +262,23 @@
     assertThat(blake.name, is(equalTo(@"Blake Watters")));
 }
 
+- (void)testShouldIgnoreNSNullInCollections {
+    RKObjectMapping *mapping = [RKObjectMapping mappingForClass:[RKTestUser class]];
+    RKAttributeMapping *idMapping = [RKAttributeMapping attributeMappingFromKeyPath:@"id" toKeyPath:@"userID"];
+    [mapping addPropertyMapping:idMapping];
+    RKAttributeMapping *nameMapping = [RKAttributeMapping attributeMappingFromKeyPath:@"name" toKeyPath:@"name"];
+    [mapping addPropertyMapping:nameMapping];
+    
+    RKMapperOperation *mapper = [RKMapperOperation new];
+    mapper.mappingOperationDataSource = [RKObjectMappingOperationDataSource new];
+    id userInfo = [RKTestFixture parsedObjectWithContentsOfFixture:@"users.json"];
+    NSArray *friendReps = [userInfo valueForKey:@"friend"];
+    NSArray *friends = [mapper mapRepresentations:friendReps atKeyPath:@"" usingMapping:mapping];
+    assertThatUnsignedInteger([friends count], is(equalToInt(1)));
+    RKTestUser *tony = friends[0];
+    assertThat(tony.name, is(equalTo(@"Anthony Stark")));
+}
+
 - (void)testShouldDetermineTheObjectMappingByConsultingTheMappingProviderWhenThereIsATargetObject
 {
     RKObjectMapping *mapping = [RKObjectMapping mappingForClass:[RKTestUser class]];


### PR DESCRIPTION
@segiddins This is useful if you're mapping a nested optional value from a collection. Say you want to map all the parole officers in the response, you might add a descriptor for key path `users.parole_officer`. But without this fix, RestKit will attempt to map `NSNull` onto a newly-created `ParoleOfficer` entity and everything will explode.

```json
{
  "users": [{
  		"id": 1,
  		"username": "dan",
  		"parole_officer": {
  			"id": 3,
  			"username": "iamthelaw"
  		}
	},{
		"id": 2,
		"username": "jake"
	}]
}
```