### PR TITLE
Map relationships unmodified objects

### DIFF
--- a/Code/CoreData/RKEntityMapping.h
+++ b/Code/CoreData/RKEntityMapping.h
@@ -133,6 +133,15 @@
 @property (nonatomic, strong) NSAttributeDescription *modificationAttribute;
 
 /**
+ If this is YES, mapping operations will map relationships of the object even if the `modificationAttribute` shows that the object has not been modified.
+ 
+ This is useful if a response contains a nested object that has been updated inside an object that has not.
+ 
+ Defaults to NO.
+ */
+@property (nonatomic) BOOL shouldMapRelationshipsIfObjectIsUnmodified;
+
+/**
  Sets the `modificationAttribute` to the receiver to the attribute with the specified name.
  
  The given name must correspond to the name of an attribute within the receiver's entity.

--- a/Code/CoreData/RKEntityMapping.m
+++ b/Code/CoreData/RKEntityMapping.m
@@ -142,6 +142,7 @@ static BOOL entityIdentificationInferenceEnabled = YES;
 @implementation RKEntityMapping
 
 @synthesize identificationAttributes = _identificationAttributes;
+@synthesize shouldMapRelationshipsIfObjectIsUnmodified = _shouldMapRelationshipsIfObjectIsUnmodified;
 
 + (instancetype)mappingForClass:(Class)objectClass
 {

--- a/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
+++ b/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
@@ -467,8 +467,7 @@ extern NSString * const RKObjectMappingNestingAttributeKeyName;
     return [mappingOperation isNewDestinationObject];
 }
 
-- (BOOL)mappingOperationShouldSkipPropertyMapping:(RKMappingOperation *)mappingOperation
-{
+- (BOOL)isDestinationObjectNotModifiedInMappingOperation:(RKMappingOperation *)mappingOperation {
     // Use concrete mapping or original mapping if not available
     RKMapping *checkedMapping = mappingOperation.objectMapping ?: mappingOperation.mapping;
     
@@ -495,6 +494,25 @@ extern NSString * const RKObjectMappingNestingAttributeKeyName;
         return [currentValue isEqualToString:transformedValue];
     } else {
         return [currentValue compare:transformedValue] != NSOrderedAscending;
+    }
+}
+
+- (BOOL)mappingOperationShouldSkipAttributeMapping:(RKMappingOperation *)mappingOperation
+{
+    return [self isDestinationObjectNotModifiedInMappingOperation:mappingOperation];
+}
+
+- (BOOL)mappingOperationShouldSkipRelationshipMapping:(RKMappingOperation *)mappingOperation
+{
+    // Use concrete mapping or original mapping if not available
+    RKMapping *checkedMapping = mappingOperation.objectMapping ?: mappingOperation.mapping;
+    
+    if (! [checkedMapping isKindOfClass:[RKEntityMapping class]]) return NO;
+    RKEntityMapping *entityMapping = (id)checkedMapping;
+    if (entityMapping.shouldMapRelationshipsIfObjectIsUnmodified) {
+        return NO;
+    } else {
+        return [self isDestinationObjectNotModifiedInMappingOperation:mappingOperation];
     }
 }
 

--- a/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
+++ b/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
@@ -497,11 +497,6 @@ extern NSString * const RKObjectMappingNestingAttributeKeyName;
     }
 }
 
-- (BOOL)mappingOperationShouldSkipPropertyMapping:(RKMappingOperation *)mappingOperation
-{
-    return [self isDestinationObjectNotModifiedInMappingOperation:mappingOperation];
-}
-
 - (BOOL)mappingOperationShouldSkipAttributeMapping:(RKMappingOperation *)mappingOperation
 {
     return [self isDestinationObjectNotModifiedInMappingOperation:mappingOperation];

--- a/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
+++ b/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
@@ -497,6 +497,11 @@ extern NSString * const RKObjectMappingNestingAttributeKeyName;
     }
 }
 
+- (BOOL)mappingOperationShouldSkipPropertyMapping:(RKMappingOperation *)mappingOperation
+{
+    return [self isDestinationObjectNotModifiedInMappingOperation:mappingOperation];
+}
+
 - (BOOL)mappingOperationShouldSkipAttributeMapping:(RKMappingOperation *)mappingOperation
 {
     return [self isDestinationObjectNotModifiedInMappingOperation:mappingOperation];

--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -1204,18 +1204,27 @@ static NSArray *RKInsertInMetadataList(NSArray *list, id metadata1, id metadata2
         }
     }
     
-    BOOL canSkipMapping = [dataSource respondsToSelector:@selector(mappingOperationShouldSkipPropertyMapping:)] && [dataSource mappingOperationShouldSkipPropertyMapping:self];
-    if (! canSkipMapping) {
-        [self applyNestedMappings];
-        if ([self isCancelled]) return;
-        BOOL mappedSimpleAttributes = [self applyAttributeMappings:[self simpleAttributeMappings]];
-        if ([self isCancelled]) return;
-        BOOL mappedRelationships = [[self relationshipMappings] count] ? [self applyRelationshipMappings] : NO;
-        if ([self isCancelled]) return;
-        // NOTE: We map key path attributes last to allow you to map across the object graphs for objects created/updated by the relationship mappings
-        BOOL mappedKeyPathAttributes = [self applyAttributeMappings:[self keyPathAttributeMappings]];
-        
-        if (!mappedSimpleAttributes && !mappedRelationships && !mappedKeyPathAttributes) {
+    BOOL canSkipAttributes = [dataSource respondsToSelector:@selector(mappingOperationShouldSkipAttributeMapping:)] && [dataSource mappingOperationShouldSkipAttributeMapping:self];
+    BOOL canSkipRelationships = [dataSource respondsToSelector:@selector(mappingOperationShouldSkipRelationshipMapping:)] && [dataSource mappingOperationShouldSkipRelationshipMapping:self];
+    if (!canSkipRelationships || !canSkipAttributes) {
+        BOOL foundNoSimpleAttributes = NO;
+        BOOL foundNoRelationships = NO;
+        BOOL foundNoKeyPathAttributes = NO;
+        if (!canSkipAttributes) {
+            [self applyNestedMappings];
+            if ([self isCancelled]) return;
+            foundNoSimpleAttributes = ![self applyAttributeMappings:[self simpleAttributeMappings]];
+        }
+        if (!canSkipRelationships) {
+            if ([self isCancelled]) return;
+            foundNoRelationships = [[self relationshipMappings] count] ? ![self applyRelationshipMappings] : YES;
+        }
+        if (!canSkipAttributes) {
+            if ([self isCancelled]) return;
+            // NOTE: We map key path attributes last to allow you to map across the object graphs for objects created/updated by the relationship mappings
+            foundNoKeyPathAttributes = ![self applyAttributeMappings:[self keyPathAttributeMappings]];
+        }
+        if (foundNoSimpleAttributes && foundNoRelationships && foundNoKeyPathAttributes) {
             // We did not find anything to do
             RKLogDebug(@"Mapping operation did not find any mappable values for the attribute and relationship mappings in the given object representation");
             NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: @"No mappable values found for any of the attributes or relationship mappings" };

--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -1204,8 +1204,15 @@ static NSArray *RKInsertInMetadataList(NSArray *list, id metadata1, id metadata2
         }
     }
     
-    BOOL canSkipAttributes = [dataSource respondsToSelector:@selector(mappingOperationShouldSkipAttributeMapping:)] && [dataSource mappingOperationShouldSkipAttributeMapping:self];
-    BOOL canSkipRelationships = [dataSource respondsToSelector:@selector(mappingOperationShouldSkipRelationshipMapping:)] && [dataSource mappingOperationShouldSkipRelationshipMapping:self];
+    BOOL canSkipProperties = [dataSource respondsToSelector:@selector(mappingOperationShouldSkipPropertyMapping:)] && [dataSource mappingOperationShouldSkipPropertyMapping:self];
+    BOOL canSkipAttributes = canSkipProperties;
+    BOOL canSkipRelationships = canSkipProperties;
+    if ([dataSource respondsToSelector:@selector(mappingOperationShouldSkipRelationshipMapping:)]) {
+        canSkipRelationships = [dataSource mappingOperationShouldSkipRelationshipMapping:self];
+    }
+    if ([dataSource respondsToSelector:@selector(mappingOperationShouldSkipAttributeMapping:)]) {
+        canSkipAttributes = [dataSource mappingOperationShouldSkipAttributeMapping:self];
+    }
     if (!canSkipRelationships || !canSkipAttributes) {
         BOOL foundNoSimpleAttributes = NO;
         BOOL foundNoRelationships = NO;

--- a/Code/ObjectMapping/RKMappingOperationDataSource.h
+++ b/Code/ObjectMapping/RKMappingOperationDataSource.h
@@ -93,10 +93,35 @@
  */
 - (BOOL)mappingOperationShouldSetUnchangedValues:(RKMappingOperation *)mappingOperation;
 
+/**
+ **Deprecated in v0.26.0**
+ Asks the data source if it should skip mapping. This method can significantly improve performance if, for example, the data source has determined that the properties in the representation are not newer than the current target object's properties. See `modificationAttribute` in `RKEntityMapping` for an example of when skipping property mapping would be appropriate.
+ 
+ If this method is not implemented by the data source, then the mapping operation defaults to `NO`.
+ 
+ @param mappingOperation The mapping operation that is querying the data source.
+ @return `YES` if the mapping operation should skip mapping properties, else `NO`.
+ */
 - (BOOL)mappingOperationShouldSkipPropertyMapping:(RKMappingOperation *)mappingOperation DEPRECATED_MSG_ATTRIBUTE("use mappingOperationShouldSkipAttributeMapping: and mappingOperationShouldSkipRelationshipMapping: instead");
 
+/**
+ Asks the data source if it should skip mapping attributes. This method can significantly improve performance if, for example, the data source has determined that the attributes in the representation are not newer than the current target object's attributes. See `modificationAttribute` in `RKEntityMapping` for an example of when skipping attribute mapping would be appropriate.
+ 
+ If this method is not implemented by the data source, then the mapping operation defaults to `NO`.
+ 
+ @param mappingOperation The mapping operation that is querying the data source.
+ @return `YES` if the mapping operation should skip mapping attributes, else `NO`.
+ */
 - (BOOL)mappingOperationShouldSkipAttributeMapping:(RKMappingOperation *)mappingOperation;
 
+/**
+ Asks the data source if it should skip mapping relationships. This method can significantly improve performance if, for example, the data source has determined that the relationships in the representation are not newer than the current target object's relationships. See `modificationAttribute` and `shouldMapRelationshipsIfObjectIsUnmodified` in `RKEntityMapping` for an example of when skipping relationship mapping might be appropriate.
+ 
+ If this method is not implemented by the data source, then the mapping operation defaults to `NO`.
+ 
+ @param mappingOperation The mapping operation that is querying the data source.
+ @return `YES` if the mapping operation should skip mapping relationships, else `NO`.
+ */
 - (BOOL)mappingOperationShouldSkipRelationshipMapping:(RKMappingOperation *)mappingOperation;
 
 /**

--- a/Code/ObjectMapping/RKMappingOperationDataSource.h
+++ b/Code/ObjectMapping/RKMappingOperationDataSource.h
@@ -93,6 +93,8 @@
  */
 - (BOOL)mappingOperationShouldSetUnchangedValues:(RKMappingOperation *)mappingOperation;
 
+- (BOOL)mappingOperationShouldSkipPropertyMapping:(RKMappingOperation *)mappingOperation DEPRECATED_MSG_ATTRIBUTE("use mappingOperationShouldSkipAttributeMapping: and mappingOperationShouldSkipRelationshipMapping: instead");
+
 - (BOOL)mappingOperationShouldSkipAttributeMapping:(RKMappingOperation *)mappingOperation;
 
 - (BOOL)mappingOperationShouldSkipRelationshipMapping:(RKMappingOperation *)mappingOperation;

--- a/Code/ObjectMapping/RKMappingOperationDataSource.h
+++ b/Code/ObjectMapping/RKMappingOperationDataSource.h
@@ -93,7 +93,9 @@
  */
 - (BOOL)mappingOperationShouldSetUnchangedValues:(RKMappingOperation *)mappingOperation;
 
-- (BOOL)mappingOperationShouldSkipPropertyMapping:(RKMappingOperation *)mappingOperation;
+- (BOOL)mappingOperationShouldSkipAttributeMapping:(RKMappingOperation *)mappingOperation;
+
+- (BOOL)mappingOperationShouldSkipRelationshipMapping:(RKMappingOperation *)mappingOperation;
 
 /**
  Asks the data source if the mapping operation should collect `RKMappingInfo` information during the mapping

--- a/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
@@ -1646,7 +1646,7 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipPropertyMapping:mappingOperation];
+    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
     expect(canSkipMapping).to.equal(YES);
 }
 
@@ -1668,7 +1668,7 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipPropertyMapping:mappingOperation];
+    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
     expect(canSkipMapping).to.equal(NO);
 }
 
@@ -1691,7 +1691,7 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipPropertyMapping:mappingOperation];
+    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
     expect(canSkipMapping).to.equal(YES);
 }
 
@@ -1715,7 +1715,7 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipPropertyMapping:mappingOperation];
+    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
     expect(canSkipMapping).to.equal(YES);
 }
 
@@ -1739,7 +1739,7 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipPropertyMapping:mappingOperation];
+    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
     expect(canSkipMapping).to.equal(NO);
 }
 
@@ -1761,7 +1761,7 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipPropertyMapping:mappingOperation];
+    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
     expect(canSkipMapping).to.equal(YES);
 }
 
@@ -1783,7 +1783,7 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipPropertyMapping:mappingOperation];
+    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
     expect(canSkipMapping).to.equal(YES);
 }
 
@@ -1805,7 +1805,7 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipPropertyMapping:mappingOperation];
+    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
     expect(canSkipMapping).to.equal(NO);
 }
 
@@ -1838,7 +1838,7 @@
     [mappingOperationDataSource.operationQueue waitUntilAllOperationsAreFinished];
     assertThat(error, is(nilValue()));
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipPropertyMapping:mappingOperation];
+    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
     expect(canSkipMapping).to.equal(YES);
 }
 

--- a/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
@@ -1640,8 +1640,8 @@
     RKEntityMapping *humanMapping = [RKEntityMapping mappingForEntityForName:@"Human" inManagedObjectStore:managedObjectStore];
     [humanMapping addAttributeMappingsFromArray:@[ @"name", @"railsID", @"updatedAt" ]];
     [humanMapping setModificationAttributeForName:@"updatedAt"];
-	humanMapping.shouldMapRelationshipsIfObjectIsUnmodified = YES;
-	
+    humanMapping.shouldMapRelationshipsIfObjectIsUnmodified = YES;
+    
     NSManagedObject *human = [NSEntityDescription insertNewObjectForEntityForName:@"Human" inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
     [human setValue:updatedAt forKey:@"updatedAt"];
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
@@ -1674,7 +1674,7 @@
     BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
     BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
     expect(canSkipAttributes).to.equal(YES);
-	expect(canSkipRelationships).to.equal(YES);
+    expect(canSkipRelationships).to.equal(YES);
 }
 
 - (void)testThatStringInequalityCausesSkipPropertyMappingToReturnNO
@@ -1695,10 +1695,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
-	expect(canSkipAttributes).to.equal(NO);
-	expect(canSkipRelationships).to.equal(NO);
+    BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+    BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+    expect(canSkipAttributes).to.equal(NO);
+    expect(canSkipRelationships).to.equal(NO);
 }
 
 - (void)testThatDateEqualityCausesSkipPropertyMappingToReturnYES
@@ -1720,10 +1720,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
-	expect(canSkipAttributes).to.equal(YES);
-	expect(canSkipRelationships).to.equal(YES);
+    BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+    BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+    expect(canSkipAttributes).to.equal(YES);
+    expect(canSkipRelationships).to.equal(YES);
 }
 
 - (void)testThatDateDecensionCausesSkipPropertyMappingToReturnYES
@@ -1746,10 +1746,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
-	expect(canSkipAttributes).to.equal(YES);
-	expect(canSkipRelationships).to.equal(YES);
+    BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+    BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+    expect(canSkipAttributes).to.equal(YES);
+    expect(canSkipRelationships).to.equal(YES);
 }
 
 - (void)testThatDateAscensionCausesSkipPropertyMappingToReturnNO
@@ -1772,10 +1772,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
-	expect(canSkipAttributes).to.equal(NO);
-	expect(canSkipRelationships).to.equal(NO);
+    BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+    BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+    expect(canSkipAttributes).to.equal(NO);
+    expect(canSkipRelationships).to.equal(NO);
 }
 
 - (void)testThatNumericEqualityCausesSkipPropertyMappingToReturnYES
@@ -1796,10 +1796,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
-	expect(canSkipAttributes).to.equal(YES);
-	expect(canSkipRelationships).to.equal(YES);
+    BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+    BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+    expect(canSkipAttributes).to.equal(YES);
+    expect(canSkipRelationships).to.equal(YES);
 }
 
 - (void)testThatNumericDecensionCausesSkipPropertyMappingToReturnYES
@@ -1820,10 +1820,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
-	expect(canSkipAttributes).to.equal(YES);
-	expect(canSkipRelationships).to.equal(YES);
+    BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+    BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+    expect(canSkipAttributes).to.equal(YES);
+    expect(canSkipRelationships).to.equal(YES);
 }
 
 - (void)testThatNumericAscensionCausesSkipPropertyMappingToReturnNO
@@ -1844,10 +1844,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
-	expect(canSkipAttributes).to.equal(NO);
-	expect(canSkipRelationships).to.equal(NO);
+    BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+    BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+    expect(canSkipAttributes).to.equal(NO);
+    expect(canSkipRelationships).to.equal(NO);
 }
 
 - (void)testThatDynamicMappingCanSkipPropertyMapping
@@ -1879,10 +1879,10 @@
     [mappingOperationDataSource.operationQueue waitUntilAllOperationsAreFinished];
     assertThat(error, is(nilValue()));
     
-	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
-	expect(canSkipAttributes).to.equal(YES);
-	expect(canSkipRelationships).to.equal(YES);
+    BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+    BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+    expect(canSkipAttributes).to.equal(YES);
+    expect(canSkipRelationships).to.equal(YES);
 }
 
 @end

--- a/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectMappingOperationDataSourceTest.m
@@ -1671,8 +1671,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-    expect(canSkipMapping).to.equal(YES);
+    BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+    BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+    expect(canSkipAttributes).to.equal(YES);
+	expect(canSkipRelationships).to.equal(YES);
 }
 
 - (void)testThatStringInequalityCausesSkipPropertyMappingToReturnNO
@@ -1693,8 +1695,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-    expect(canSkipMapping).to.equal(NO);
+	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+	expect(canSkipAttributes).to.equal(NO);
+	expect(canSkipRelationships).to.equal(NO);
 }
 
 - (void)testThatDateEqualityCausesSkipPropertyMappingToReturnYES
@@ -1716,8 +1720,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-    expect(canSkipMapping).to.equal(YES);
+	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+	expect(canSkipAttributes).to.equal(YES);
+	expect(canSkipRelationships).to.equal(YES);
 }
 
 - (void)testThatDateDecensionCausesSkipPropertyMappingToReturnYES
@@ -1740,8 +1746,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-    expect(canSkipMapping).to.equal(YES);
+	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+	expect(canSkipAttributes).to.equal(YES);
+	expect(canSkipRelationships).to.equal(YES);
 }
 
 - (void)testThatDateAscensionCausesSkipPropertyMappingToReturnNO
@@ -1764,8 +1772,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-    expect(canSkipMapping).to.equal(NO);
+	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+	expect(canSkipAttributes).to.equal(NO);
+	expect(canSkipRelationships).to.equal(NO);
 }
 
 - (void)testThatNumericEqualityCausesSkipPropertyMappingToReturnYES
@@ -1786,8 +1796,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-    expect(canSkipMapping).to.equal(YES);
+	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+	expect(canSkipAttributes).to.equal(YES);
+	expect(canSkipRelationships).to.equal(YES);
 }
 
 - (void)testThatNumericDecensionCausesSkipPropertyMappingToReturnYES
@@ -1808,8 +1820,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-    expect(canSkipMapping).to.equal(YES);
+	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+	expect(canSkipAttributes).to.equal(YES);
+	expect(canSkipRelationships).to.equal(YES);
 }
 
 - (void)testThatNumericAscensionCausesSkipPropertyMappingToReturnNO
@@ -1830,8 +1844,10 @@
     RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:representation destinationObject:human mapping:humanMapping];
     mappingOperation.dataSource = mappingOperationDataSource;
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-    expect(canSkipMapping).to.equal(NO);
+	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+	expect(canSkipAttributes).to.equal(NO);
+	expect(canSkipRelationships).to.equal(NO);
 }
 
 - (void)testThatDynamicMappingCanSkipPropertyMapping
@@ -1863,8 +1879,10 @@
     [mappingOperationDataSource.operationQueue waitUntilAllOperationsAreFinished];
     assertThat(error, is(nilValue()));
     
-    BOOL canSkipMapping = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
-    expect(canSkipMapping).to.equal(YES);
+	BOOL canSkipAttributes = [mappingOperationDataSource mappingOperationShouldSkipAttributeMapping:mappingOperation];
+	BOOL canSkipRelationships = [mappingOperationDataSource mappingOperationShouldSkipRelationshipMapping:mappingOperation];
+	expect(canSkipAttributes).to.equal(YES);
+	expect(canSkipRelationships).to.equal(YES);
 }
 
 @end


### PR DESCRIPTION
@segiddins This resolves #1716 in a backwards-compatible way. 

- Add `RKEntity.shouldMapRelationshipsIfObjectIsUnmodified` flag. Defaults to `NO` (previous behavior)
- Deprecate `mappingOperationShouldSkipPropertyMapping`
- Add `mappingOperationShouldSkipAttributeMapping`.
  - In `RKEntityMapping` this uses the old behavior of comparing `modificationAttribute`
- Add `mappingOperationShouldSkipRelationshipMapping`. 
  - In `RKEntityMapping` this uses the same, but consults the new flag to force relationship mapping
- Add tests
