### PR TITLE
RKRefetchManagedObjectInContext() can return object on incorrect context

### DIFF
--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -126,7 +126,7 @@ static NSManagedObject *RKRefetchManagedObjectInContext(NSManagedObject *managed
     NSManagedObjectID *managedObjectID = [managedObject objectID];
     if ([managedObjectID isTemporaryID]) {
         RKLogWarning(@"Unable to refetch managed object %@: the object has a temporary managed object ID.", managedObject);
-        return managedObject;
+        return nil;
     }
     NSError *error = nil;
     NSManagedObject *refetchedObject = [managedObjectContext existingObjectWithID:managedObjectID error:&error];
@@ -241,7 +241,7 @@ static id RKRefetchedValueInManagedObjectContext(id value, NSManagedObjectContex
     NSAssert(!self.refetched, @"Mapping result should only be refetched once");
     if (! [self.mappingResult count]) return self.mappingResult;
     
-    NSMutableDictionary *newDictionary = [self.mappingResult.dictionary mutableCopy];
+    NSMutableDictionary *newDictionary = [NSMutableDictionary dictionary];
     [self.managedObjectContext performBlockAndWait:^{
         NSArray *entityMappingEvents = [RKEntityMappingEvent entityMappingEventsForMappingInfo:self.mappingInfo];
         NSSet *rootKeys = [NSSet setWithArray:[entityMappingEvents valueForKey:@"rootKey"]];
@@ -251,7 +251,7 @@ static id RKRefetchedValueInManagedObjectContext(id value, NSManagedObjectContex
             // If keyPaths contains null, then the root object is a managed object and we only need to refetch it
             NSSet *nonNestedKeyPaths = ([keyPaths containsObject:[NSNull null]]) ? [NSSet setWithObject:[NSNull null]] : RKSetByRemovingSubkeypathsFromSet(keyPaths);
             
-            NSDictionary *mappingResultsAtRootKey = newDictionary[rootKey];
+            NSDictionary *mappingResultsAtRootKey = self.mappingResult.dictionary[rootKey];
             for (NSString *keyPath in nonNestedKeyPaths) {
                 id value = nil;
                 if ([keyPath isEqual:[NSNull null]]) {

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -542,6 +542,7 @@
 		C0F11CE6190883460054AEA0 /* RKPathMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F11CE2190883380054AEA0 /* RKPathMatcher.m */; };
 		C0F11CE81908C7E60054AEA0 /* RKCoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = C0F11CE71908C7E60054AEA0 /* RKCoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C0F11CE91908C7E60054AEA0 /* RKCoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = C0F11CE71908C7E60054AEA0 /* RKCoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DEAC698D1B8F55A600FF6134 /* RKRefetchingMappingResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DEAC698C1B8F55A600FF6134 /* RKRefetchingMappingResultTests.m */; };
 		FFD7948D0AE44A4290977909 /* libPods-RestKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EA1EF52129B3341280753E4 /* libPods-RestKit.a */; };
 /* End PBXBuildFile section */
 
@@ -899,6 +900,7 @@
 		C5608EB544CBB19BBACC13BA /* Pods-RestKitFramework.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RestKitFramework.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RestKitFramework/Pods-RestKitFramework.debug.xcconfig"; sourceTree = "<group>"; };
 		DB867C56C81696C5E9366366 /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC09A8FD6016D24B797977A1 /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DEAC698C1B8F55A600FF6134 /* RKRefetchingMappingResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRefetchingMappingResultTests.m; sourceTree = "<group>"; };
 		F66056291744FF9000A87A45 /* and_cats.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = and_cats.json; sourceTree = "<group>"; };
 		F6B428543BF5CF359F239FE1 /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1254,20 +1256,21 @@
 		25160FC61456F2330060A5C5 /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
-				25160FC71456F2330060A5C5 /* RKManagedObjectLoaderTest.m */,
-				25160FC91456F2330060A5C5 /* RKEntityMappingTest.m */,
-				25160FCB1456F2330060A5C5 /* RKManagedObjectStoreTest.m */,
-				25E36E0115195CED00F9E448 /* RKFetchRequestMappingCacheTest.m */,
 				25079C75151B952200266AE7 /* NSEntityDescription+RKAdditionsTest.m */,
 				25DB7507151BD551009F01AF /* NSManagedObjectContext+RKAdditionsTest.m */,
+				2546A95716628EDD0078E044 /* RKConnectionDescriptionTest.m */,
 				259D98591550C6BE008C90F5 /* RKEntityByAttributeCacheTest.m */,
 				259D986315521B1F008C90F5 /* RKEntityCacheTest.m */,
+				25160FC91456F2330060A5C5 /* RKEntityMappingTest.m */,
+				8AB68F0A1AE5B3B300DD655A /* RKFetchedResultsControllerUpdateTest.m */,
+				25E36E0115195CED00F9E448 /* RKFetchRequestMappingCacheTest.m */,
+				2582F56C173038750043B8BB /* RKInMemoryManagedObjectCacheTest.m */,
+				25160FC71456F2330060A5C5 /* RKManagedObjectLoaderTest.m */,
 				25AA23D315AF4F25006EF62D /* RKManagedObjectMappingOperationDataSourceTest.m */,
 				258EFF7915C0CE1400EE4E0D /* RKManagedObjectSeederTest.m */,
+				25160FCB1456F2330060A5C5 /* RKManagedObjectStoreTest.m */,
+				DEAC698C1B8F55A600FF6134 /* RKRefetchingMappingResultTests.m */,
 				2564E40A16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m */,
-				2546A95716628EDD0078E044 /* RKConnectionDescriptionTest.m */,
-				2582F56C173038750043B8BB /* RKInMemoryManagedObjectCacheTest.m */,
-				8AB68F0A1AE5B3B300DD655A /* RKFetchedResultsControllerUpdateTest.m */,
 			);
 			name = CoreData;
 			path = Logic/CoreData;
@@ -2340,6 +2343,7 @@
 				25C246A415C83B090032212E /* RKSearchTest.m in Sources */,
 				5C927E141608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m in Sources */,
 				25E9C8F01612523400647F84 /* RKObjectParameterizationTest.m in Sources */,
+				DEAC698D1B8F55A600FF6134 /* RKRefetchingMappingResultTests.m in Sources */,
 				25EDFCE3161538F6008BAA1D /* RKObjectManagerTest.m in Sources */,
 				2564E40B16173F7B00C12D7D /* RKRelationshipConnectionOperationTest.m in Sources */,
 				25CDA0E7161E828D00F583F3 /* RKISODateFormatterTest.m in Sources */,

--- a/Tests/Logic/CoreData/RKRefetchingMappingResultTests.m
+++ b/Tests/Logic/CoreData/RKRefetchingMappingResultTests.m
@@ -1,0 +1,113 @@
+//
+//  RKRefetchingMappingResultTests.m
+//  RestKit
+//
+//  Created by Peter Robinett on 8/27/15.
+//  Copyright (c) 2015 RestKit. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import "RKTestEnvironment.h"
+#import "RKHuman.h"
+
+#import "RKMappingResult.h"
+
+// Expose the private constructor
+@interface RKMappingInfo ()
+
+- (instancetype)initWithObjectMapping:(RKObjectMapping *)objectMapping dynamicMapping:(RKDynamicMapping *)dynamicMapping;
+- (void)addPropertyMapping:(RKPropertyMapping *)propertyMapping;
+
+@end
+
+// Expose the private object declared in RKManagedObjectRequestOperation.m
+@interface RKRefetchingMappingResult : NSProxy
+
+- (instancetype)initWithMappingResult:(RKMappingResult *)mappingResult
+       managedObjectContext:(NSManagedObjectContext *)managedObjectContext
+                mappingInfo:(NSDictionary *)mappingInfo;
+@end
+
+@interface RKRefetchingMappingResultTests : XCTestCase
+
+@property RKManagedObjectStore *managedObjectStore;
+@property RKObjectManager *objectManager;
+@property RKObjectMapping *mapping;
+@property RKMappingInfo *mappingInfo;
+@property NSManagedObjectContext *destinationContext;
+
+@end
+
+static NSString * const RKRefetchingMappingResultTestsKey = @"human";
+static NSString * const RKRefetchingMappingResultTestsEntityName = @"Human";
+
+@implementation RKRefetchingMappingResultTests
+
+- (void)setUp
+{
+    self.managedObjectStore = [RKTestFactory managedObjectStore];
+
+    self.objectManager = [RKTestFactory objectManager];
+    self.objectManager.managedObjectStore = self.managedObjectStore;
+
+    self.mapping = [RKEntityMapping mappingForEntityForName:RKRefetchingMappingResultTestsEntityName inManagedObjectStore:self.managedObjectStore];
+    self.mappingInfo = [[RKMappingInfo alloc] initWithObjectMapping:self.mapping dynamicMapping:nil];
+
+    self.destinationContext = [self.managedObjectStore newChildManagedObjectContextWithConcurrencyType:NSMainQueueConcurrencyType tracksChanges:NO];
+}
+
+- (void)tearDown
+{
+    self.destinationContext = nil;
+    self.mappingInfo = nil;
+    self.mapping = nil;
+    self.objectManager = nil;
+    self.managedObjectStore = nil;
+}
+
+- (void)testPermanentObjectID {
+    RKHuman *human = [NSEntityDescription insertNewObjectForEntityForName:RKRefetchingMappingResultTestsEntityName inManagedObjectContext:self.managedObjectStore.persistentStoreManagedObjectContext];
+    human.name = @"Blake Watters";
+    human.railsID = @1;
+    [self.objectManager.managedObjectStore.persistentStoreManagedObjectContext save:nil];
+
+    XCTAssertFalse([human.objectID isTemporaryID], @"The object should have a permanent objectID");
+
+    RKMappingResult *result = [[RKMappingResult alloc] initWithDictionary:@{RKRefetchingMappingResultTestsKey: human}];
+
+    RKRefetchingMappingResult *refetchingResult = [[RKRefetchingMappingResult alloc] initWithMappingResult:result managedObjectContext:self.destinationContext mappingInfo:@{RKRefetchingMappingResultTestsKey: @[self.mappingInfo]}];
+
+    // treat the proxy as a normal mapping result
+    RKMappingResult *proxiedResult = (RKMappingResult *)refetchingResult;
+    // interact with the mapping result as normal
+    RKHuman *refetchedHuman = proxiedResult.dictionary[RKRefetchingMappingResultTestsKey];
+
+    XCTAssertNotNil(refetchedHuman, @"There should be a object");
+    XCTAssertTrue([refetchedHuman isKindOfClass:[RKHuman class]], @"The object should be an RKHuman");
+    XCTAssertNotEqualObjects(human, refetchedHuman, @"The objects should not match");
+    XCTAssertEqualObjects(refetchedHuman.managedObjectContext, self.destinationContext, @"The object should be on the destination context");
+    XCTAssertEqualObjects(human.objectID, refetchedHuman.objectID, @"The objectIDs should match");
+}
+
+- (void)testTemporaryObjectID {
+    RKHuman *human = [NSEntityDescription insertNewObjectForEntityForName:RKRefetchingMappingResultTestsEntityName inManagedObjectContext:self.managedObjectStore.persistentStoreManagedObjectContext];
+    human.name = @"Blake Watters";
+    human.railsID = @1;
+
+    XCTAssertTrue([human.objectID isTemporaryID], @"The object should have a temporary objectID");
+
+    RKMappingResult *result = [[RKMappingResult alloc] initWithDictionary:@{RKRefetchingMappingResultTestsKey: human}];
+
+    RKRefetchingMappingResult *refetchingResult = [[RKRefetchingMappingResult alloc] initWithMappingResult:result managedObjectContext:self.destinationContext mappingInfo:@{RKRefetchingMappingResultTestsKey: @[self.mappingInfo]}];
+
+    // treat the proxy as a normal mapping result
+    RKMappingResult *proxiedResult = (RKMappingResult *)refetchingResult;
+    // interact with the mapping result as normal
+    RKHuman *refetchedHuman = proxiedResult.dictionary[RKRefetchingMappingResultTestsKey];
+
+    XCTAssertNil(refetchedHuman, @"There shouldn't be a object");
+}
+
+@end


### PR DESCRIPTION
The `RKRefetchManagedObjectInContext()` function takes an object in an original context and refetches it on the provided destination context. However, if the object only has a temporary ID, the same object is returned. While it is true that refetching on the destination context would fail in the absence of a permanent ID, returning the original object can lead to it being used on the wrong, destination queue.

While this function is only called inside of an `RKRefetchingMappingResult`, which in turn only gets created by `RKManagedObjectRequestOperation` after permanent IDs are obtained, I think it's dangerous to leave a potential context-crossing error in place and would be better to return `nil`.