### PR TITLE
Add the ISO8601 formatter into default transformers earlier

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -140,7 +140,7 @@ static RKSourceToDesinationKeyTransformationBlock defaultSourceToDestinationKeyT
     return objectMapping;
 }
 
-+ (void)initialize
++ (void)load
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{


### PR DESCRIPTION
In a production app, I couldn't figure out with the 8601 formatter was still firing, after I removed all date formatters. Turns out I removed the formatters before I accessed `RKObjectMapping`, so in `initialize` it was getting added back in _after_ I'd made my changes without me knowing. This moves it into `load` so that it happens earlier