### PR TITLE
Allow user to disable context change tracking

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.h
+++ b/Code/CoreData/RKManagedObjectStore.h
@@ -237,6 +237,14 @@
 @property (nonatomic, strong, readonly) NSManagedObjectContext *mainQueueManagedObjectContext;
 
 /**
+ If YES, then when `persistentStoreManagedObjectContext` is saved, the changes will be merged into `mainQueueManagedObjectContext`
+ 
+ This is useful if your application saves changes from background contexts directly into `persistentStoreManagedObjectContext` so that those changes will be reflected in the `mainQueueManagedObjectContext`-driven user interface after the merge.
+ Default value: YES
+ */
+@property (nonatomic) BOOL shouldMergeChangesFromPersistenceContextIntoMainQueueContext;
+
+/**
  Creates a new child managed object context of the persistent store managed object context with a given concurrency type, optionally tracking changes saved to the parent context and merging them on save.
 
  @param concurrencyType The desired concurrency type for the new context.

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -79,8 +79,8 @@ static NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification
     if (self) {
         self.observedContext = observedContext;
         self.mergeContext = mergeContext;
-		self.active = YES;
-		
+        self.active = YES;
+        
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleManagedObjectContextDidSaveNotification:) name:NSManagedObjectContextDidSaveNotification object:observedContext];
         
         if (RKIsManagedObjectContextDescendentOfContext(mergeContext, observedContext)) {
@@ -98,17 +98,17 @@ static NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification
 
 - (void)handleManagedObjectContextWillSaveNotification:(NSNotification *)notification
 {
-	if (!self.active) { return; }
+    if (!self.active) { return; }
     self.objectIDsFromChildDidSaveNotification = RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(notification);
 }
 
 - (void)handleManagedObjectContextDidSaveNotification:(NSNotification *)notification
 {
-	if (!self.active) {
-		self.objectIDsFromChildDidSaveNotification = nil;
-		return;
-	}
-	
+    if (!self.active) {
+        self.objectIDsFromChildDidSaveNotification = nil;
+        return;
+    }
+    
     NSAssert([notification object] == self.observedContext, @"Received Managed Object Context Did Save Notification for Unexpected Context: %@", [notification object]);
     if (! [self.objectIDsFromChildDidSaveNotification isEqual:RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(notification)]) {
         [self.mergeContext performBlock:^{
@@ -180,8 +180,8 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
     if (self) {
         self.managedObjectModel = managedObjectModel;
         self.managedObjectCache = [RKFetchRequestManagedObjectCache new];
-		self.shouldMergeChangesFromPersistenceContextIntoMainQueueContext = YES;
-		
+        self.shouldMergeChangesFromPersistenceContextIntoMainQueueContext = YES;
+        
         // Hydrate the defaultStore
         if (! defaultStore) {
             [RKManagedObjectStore setDefaultStore:self];
@@ -353,7 +353,7 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
 
     // Merge changes from a primary MOC back into the main queue when complete
     RKManagedObjectContextChangeMergingObserver *observer = [[RKManagedObjectContextChangeMergingObserver alloc] initWithObservedContext:self.persistentStoreManagedObjectContext mergeContext:self.mainQueueManagedObjectContext];
-	observer.active = self.shouldMergeChangesFromPersistenceContextIntoMainQueueContext;
+    observer.active = self.shouldMergeChangesFromPersistenceContextIntoMainQueueContext;
     objc_setAssociatedObject(self.mainQueueManagedObjectContext,
                              &RKManagedObjectContextChangeMergingObserverAssociationKey,
                              observer,
@@ -361,10 +361,10 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
 }
 
 - (void)setShouldMergeChangesFromPersistenceContextIntoMainQueueContext:(BOOL)shouldMergeChangesFromPersistenceContextIntoMainQueueContext {
-	_shouldMergeChangesFromPersistenceContextIntoMainQueueContext = shouldMergeChangesFromPersistenceContextIntoMainQueueContext;
-	
-	RKManagedObjectContextChangeMergingObserver *observer = objc_getAssociatedObject(self.mainQueueManagedObjectContext, &RKManagedObjectContextChangeMergingObserverAssociationKey);
-	observer.active = self.shouldMergeChangesFromPersistenceContextIntoMainQueueContext;
+    _shouldMergeChangesFromPersistenceContextIntoMainQueueContext = shouldMergeChangesFromPersistenceContextIntoMainQueueContext;
+    
+    RKManagedObjectContextChangeMergingObserver *observer = objc_getAssociatedObject(self.mainQueueManagedObjectContext, &RKManagedObjectContextChangeMergingObserverAssociationKey);
+    observer.active = self.shouldMergeChangesFromPersistenceContextIntoMainQueueContext;
 }
 
 - (void)recreateManagedObjectContexts


### PR DESCRIPTION
This was motivated by an app I'm working on where I always save through the main queue context, and Core Data is crashing me whenever I try to merge changes up from the persistence context, which I don't need to do anyway.