### PR TITLE
Identification attributes improvements

### DIFF
--- a/Code/CoreData/RKEntityMapping.m
+++ b/Code/CoreData/RKEntityMapping.m
@@ -39,7 +39,15 @@ static NSArray *RKEntityIdentificationAttributesFromUserInfoOfEntity(NSEntityDes
     do {
         id userInfoValue = [[entity userInfo] valueForKey:RKEntityIdentificationAttributesUserInfoKey];
         if (userInfoValue) {
-            NSArray *attributeNames = [userInfoValue isKindOfClass:[NSArray class]] ? userInfoValue : @[ userInfoValue ];
+            NSArray *attributeNames;
+            if ([userInfoValue isKindOfClass:[NSString class]]) {
+                attributeNames = [userInfoValue componentsSeparatedByString:@","];
+            } else if ([userInfoValue isKindOfClass:[NSArray class]]) {
+                attributeNames = userInfoValue;
+            } else {
+                attributeNames = @[ userInfoValue ];
+            }
+            
             NSMutableArray *attributes = [NSMutableArray arrayWithCapacity:[attributeNames count]];
             [attributeNames enumerateObjectsUsingBlock:^(NSString *attributeName, NSUInteger idx, BOOL *stop) {
                 if (! [attributeName isKindOfClass:[NSString class]]) {

--- a/Code/CoreData/RKEntityMapping.m
+++ b/Code/CoreData/RKEntityMapping.m
@@ -49,7 +49,7 @@ static NSArray *RKEntityIdentificationAttributesFromUserInfoOfEntity(NSEntityDes
             }
             
             NSMutableArray *attributes = [NSMutableArray arrayWithCapacity:[attributeNames count]];
-            [attributeNames enumerateObjectsUsingBlock:^(NSString *attributeName, NSUInteger idx, BOOL *stop) {
+            for (NSString *attributeName in attributeNames) {
                 if (! [attributeName isKindOfClass:[NSString class]]) {
                     [NSException raise:NSInvalidArgumentException format:@"Invalid value given in user info key '%@' of entity '%@': expected an `NSString` or `NSArray` of strings, instead got '%@' (%@)", RKEntityIdentificationAttributesUserInfoKey, [entity name], attributeName, [attributeName class]];
                 }
@@ -60,7 +60,7 @@ static NSArray *RKEntityIdentificationAttributesFromUserInfoOfEntity(NSEntityDes
                 }
                 
                 [attributes addObject:attribute];
-            }];
+            };
             return attributes;
         }
         entity = [entity superentity];

--- a/Code/CoreData/RKEntityMapping.m
+++ b/Code/CoreData/RKEntityMapping.m
@@ -111,7 +111,9 @@ NSArray *RKIdentificationAttributesInferredFromEntity(NSEntityDescription *entit
 {
     NSArray *attributes = RKEntityIdentificationAttributesFromUserInfoOfEntity(entity);
     if (attributes) {
-        return RKArrayOfAttributesForEntityFromAttributesOrNames(entity, attributes);
+        NSArray *identificationAttributes = RKArrayOfAttributesForEntityFromAttributesOrNames(entity, attributes);
+        RKLogDebug(@"Inferred identification attributes for %@: %@", entity.name, [[identificationAttributes valueForKeyPath:@"name"] componentsJoinedByString:@", "]);
+        return identificationAttributes;
     }
     
     NSMutableArray *identifyingAttributes = [RKEntityIdentificationAttributeNamesForEntity(entity) mutableCopy];
@@ -119,9 +121,11 @@ NSArray *RKIdentificationAttributesInferredFromEntity(NSEntityDescription *entit
     for (NSString *attributeName in identifyingAttributes) {
         NSAttributeDescription *attribute = [[entity attributesByName] valueForKey:attributeName];
         if (attribute) {
+            RKLogDebug(@"Inferred identification attribute for %@: %@", entity.name, attributeName);
             return @[ attribute ];
         }
     }
+    RKLogDebug(@"No inferred identification attributes for %@", entity.name);
     return nil;
 }
 

--- a/Tests/Logic/CoreData/RKEntityMappingTest.m
+++ b/Tests/Logic/CoreData/RKEntityMappingTest.m
@@ -619,6 +619,22 @@
     expect([identificationAttributes valueForKey:@"name"]).to.equal(attributeNames);
 }
 
+- (void)testEntityIdentifierInferenceFromUserInfoKeyForCommaSeparatedString
+{
+    NSEntityDescription *entity = [[NSEntityDescription alloc] init];
+    [entity setName:@"Monkey"];
+    NSAttributeDescription *identifierAttribute = [NSAttributeDescription new];
+    [identifierAttribute setName:@"monkeyID"];
+    NSAttributeDescription *nameAttribute = [NSAttributeDescription new];
+    [nameAttribute setName:@"name"];
+    [entity setProperties:@[ identifierAttribute, nameAttribute ]];
+    [entity setUserInfo:@{ RKEntityIdentificationAttributesUserInfoKey: @"name,monkeyID" }];
+    NSArray *identificationAttributes = RKIdentificationAttributesInferredFromEntity(entity);
+    expect(identificationAttributes).notTo.beNil();
+    NSArray *attributeNames = @[ @"name", @"monkeyID" ];
+    expect([identificationAttributes valueForKey:@"name"]).to.equal(attributeNames);
+}
+
 - (void)testEntityIdentifierInferenceFromUserInfoKeyForArrayOfValues
 {
     NSEntityDescription *entity = [[NSEntityDescription alloc] init];


### PR DESCRIPTION
##### Handle comma-separated string for `RKEntityIdentificationAttributes`
This is useful if you want to enter the identification attributes directly in the xcdatamodel editor where the only type available for the User Info dictionary is string.

##### Debug logs
Also added a few debug logs to help identifying inferred identification attributes issues.