### PR TITLE
Fix nested refetched objects

### DIFF
--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -868,6 +868,7 @@
 		25FBB851159272DD00955D27 /* RKRouter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRouter.m; sourceTree = "<group>"; };
 		3E886DC0169E10A70069C56B /* has_many_with_to_one_relationship.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = has_many_with_to_one_relationship.json; sourceTree = "<group>"; };
 		3EB0D83816ADCEFC00E9CEA2 /* empty_human.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = empty_human.json; sourceTree = "<group>"; };
+		538B0BD51BBCAF8C0068C386 /* with_to_one_relationship_inside_collection.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = with_to_one_relationship_inside_collection.json; sourceTree = "<group>"; };
 		54CDB45917B408B100FAC285 /* RKStringTokenizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKStringTokenizer.h; sourceTree = "<group>"; };
 		54CDB45A17B408B100FAC285 /* RKStringTokenizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKStringTokenizer.m; sourceTree = "<group>"; };
 		5910B0B01AC9811900721876 /* hoarderWithCats_issue_2192.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = hoarderWithCats_issue_2192.json; sourceTree = "<group>"; };
@@ -1335,6 +1336,7 @@
 				3E886DC0169E10A70069C56B /* has_many_with_to_one_relationship.json */,
 				25160FE31456F2330060A5C5 /* with_to_one_relationship.json */,
 				F66056291744FF9000A87A45 /* and_cats.json */,
+				538B0BD51BBCAF8C0068C386 /* with_to_one_relationship_inside_collection.json */,
 			);
 			path = humans;
 			sourceTree = "<group>";

--- a/Tests/Fixtures/JSON/humans/with_to_one_relationship_inside_collection.json
+++ b/Tests/Fixtures/JSON/humans/with_to_one_relationship_inside_collection.json
@@ -1,0 +1,14 @@
+[{
+    "name": "Blake Watters",
+    "id": null,
+    "age": 28,
+    "favorite_cat_id": 1234,
+    "children": [ {
+        "name": "Marc Berube",
+        "id": null,
+        "age": 29,
+        "favorite_cat_id": 1234}
+    ]
+}
+]
+


### PR DESCRIPTION
  * Managed objects that were nested inside a sub-collection using a nil source key path were not refetched resulting on them being faulted (and not restorable) when they were accessed
  * Add test that covers the case

Fixes #2312 