### PR TITLE
Fixes designated initializer compiler warnings for iOS9

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -70,6 +70,14 @@ static NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification
 
 @implementation RKManagedObjectContextChangeMergingObserver
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithObservedContext:mergeContext:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithObservedContext:(NSManagedObjectContext *)observedContext mergeContext:(NSManagedObjectContext *)mergeContext
 {
     if (! observedContext) [NSException raise:NSInvalidArgumentException format:@"observedContext cannot be `nil`."];
@@ -165,6 +173,14 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
     }
 }
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithManagedObjectModel:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithManagedObjectModel:(NSManagedObjectModel *)managedObjectModel
 {
     self = [super init];
@@ -189,12 +205,6 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
     }
 
     return self;
-}
-
-- (instancetype)init
-{
-    NSManagedObjectModel *managedObjectModel = [NSManagedObjectModel mergedModelFromBundles:[NSBundle allBundles]];
-    return [self initWithManagedObjectModel:managedObjectModel];
 }
 
 - (void)dealloc

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -173,14 +173,6 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
     }
 }
 
-- (instancetype)init
-{
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithManagedObjectModel:", NSStringFromClass([self class])]
-                                 userInfo:nil];
-    return [self init];
-}
-
 - (instancetype)initWithManagedObjectModel:(NSManagedObjectModel *)managedObjectModel
 {
     self = [super init];
@@ -195,6 +187,12 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
     }
 
     return self;
+}
+
+- (instancetype)init
+{
+    NSManagedObjectModel *managedObjectModel = [NSManagedObjectModel mergedModelFromBundles:[NSBundle allBundles]];
+    return [self initWithManagedObjectModel:managedObjectModel];
 }
 
 - (instancetype)initWithPersistentStoreCoordinator:(NSPersistentStoreCoordinator *)persistentStoreCoordinator

--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -172,6 +172,14 @@ extern NSString *RKStringDescribingRequestMethod(RKRequestMethod method);
 
 @implementation RKMappingGraphVisitor
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithMapping:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithMapping:(RKMapping *)mapping
 {
     self = [super init];
@@ -347,6 +355,14 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFHTTPClientParamet
 @end
 
 @implementation RKObjectManager
+
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithHTTPClient:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
 
 - (instancetype)initWithHTTPClient:(AFHTTPClient *)client
 {

--- a/Code/Network/RKPaginator.h
+++ b/Code/Network/RKPaginator.h
@@ -63,8 +63,8 @@
  @return The receiver, initialized with the request, pagination mapping, and response descriptors.
  */
 - (instancetype)initWithRequest:(NSURLRequest *)request
-    paginationMapping:(RKObjectMapping *)paginationMapping
-  responseDescriptors:(NSArray *)responseDescriptors NS_DESIGNATED_INITIALIZER;
+              paginationMapping:(RKObjectMapping *)paginationMapping
+            responseDescriptors:(NSArray *)responseDescriptors;
 
 ///-----------------------------
 /// @name Configuring Networking

--- a/Code/Network/RKPaginator.m
+++ b/Code/Network/RKPaginator.m
@@ -60,6 +60,14 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
 
 @implementation RKPaginator
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithRequest:paginationMapping:responseDescriptors:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithRequest:(NSURLRequest *)request
     paginationMapping:(RKObjectMapping *)paginationMapping
   responseDescriptors:(NSArray *)responseDescriptors;

--- a/Code/Network/RKPaginator.m
+++ b/Code/Network/RKPaginator.m
@@ -60,13 +60,6 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
 
 @implementation RKPaginator
 
-- (instancetype)init
-{
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithRequest:paginationMapping:responseDescriptors:", NSStringFromClass([self class])]
-                                 userInfo:nil];
-    return [self init];
-}
 
 - (instancetype)initWithRequest:(NSURLRequest *)request
     paginationMapping:(RKObjectMapping *)paginationMapping

--- a/Code/Network/RKResponseMapperOperation.m
+++ b/Code/Network/RKResponseMapperOperation.m
@@ -173,6 +173,14 @@ static NSMutableDictionary *RKRegisteredResponseMapperOperationDataSourceClasses
 
 #pragma mark 
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithRequest:response:data:responseDescriptors:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithRequest:(NSURLRequest *)request
              response:(NSHTTPURLResponse *)response
                  data:(NSData *)data

--- a/Code/ObjectMapping/RKMapperOperation.m
+++ b/Code/ObjectMapping/RKMapperOperation.m
@@ -82,10 +82,7 @@ static NSString *RKFailureReasonErrorStringForMappingNotFoundError(id representa
 
 - (instancetype)init
 {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithRepresentation:mappingDictionary:", NSStringFromClass([self class])]
-                                 userInfo:nil];
-    return [self init];
+    return [self initWithRepresentation:nil mappingsDictionary:nil];
 }
 
 - (instancetype)initWithRepresentation:(id)representation mappingsDictionary:(NSDictionary *)mappingsDictionary;

--- a/Code/ObjectMapping/RKMapperOperation.m
+++ b/Code/ObjectMapping/RKMapperOperation.m
@@ -80,6 +80,14 @@ static NSString *RKFailureReasonErrorStringForMappingNotFoundError(id representa
 
 @implementation RKMapperOperation
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithRepresentation:mappingDictionary:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithRepresentation:(id)representation mappingsDictionary:(NSDictionary *)mappingsDictionary;
 {
     self = [super init];

--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -158,6 +158,14 @@ static NSArray *RKInsertInMetadataList(NSArray *list, id metadata1, id metadata2
 
 @implementation RKMetadataWrapper
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithMappingSource:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithMappingSource:(RKMappingSourceObject *)source {
     if (self = [super init]) {
         self.mappingSource = source;

--- a/Code/ObjectMapping/RKObjectMappingMatcher.m
+++ b/Code/ObjectMapping/RKObjectMappingMatcher.m
@@ -110,6 +110,14 @@
 
 @implementation RKKeyPathObjectMappingMatcher
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use -initWithKeyPath:expectedValue:objectMapping:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithKeyPath:(NSString *)keyPath expectedValue:(id)expectedValue objectMapping:(RKObjectMapping *)objectMapping
 {
     NSParameterAssert(keyPath);
@@ -141,6 +149,14 @@
 
 @implementation RKKeyPathClassObjectMappingMatcher
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use initilizer -initWithKeyPath:expectedClass:objectMapping:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithKeyPath:(NSString *)keyPath expectedClass:(Class)expectedClass objectMapping:(RKObjectMapping *)objectMapping
 {
     NSParameterAssert(keyPath);
@@ -170,6 +186,14 @@
 @end
 
 @implementation RKKeyPathValueMapObjectMappingMatcher
+
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use initilizer -initWithKeyPath:expectedValueMap:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
 
 - (instancetype)initWithKeyPath:(NSString *)keyPath expectedValueMap:(NSDictionary *)valueToObjectMapping
 {
@@ -210,6 +234,14 @@
 
 @implementation RKPredicateObjectMappingMatcher
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use initilizer -initWithPredicate:objectMapping:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithPredicate:(NSPredicate *)predicate objectMapping:(RKObjectMapping *)objectMapping
 {
     NSParameterAssert(predicate);
@@ -236,6 +268,14 @@
 @end
 
 @implementation RKBlockObjectMatchingMatcher
+
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use initilizer -initWithPossibleMappings:block:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
 
 - (instancetype)initWithPossibleMappings:(NSArray *)mappings block:(RKObjectMapping *(^)(id representation))block
 {

--- a/Code/Search/RKSearchPredicate.m
+++ b/Code/Search/RKSearchPredicate.m
@@ -16,6 +16,22 @@
     return [[self alloc] initWithSearchText:searchText type:type];
 }
 
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-initWithcoder: is not a valid initializer for the class %@, use designated initilizer -initWithSearchText:type:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
+- (instancetype)initWithType:(NSCompoundPredicateType)type subpredicates:(NSArray<NSPredicate *> *)subpredicates
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-initWithType: is not a valid initializer for the class %@, use designated initilizer -initWithSearchText:type:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithSearchText:(NSString *)searchText type:(NSCompoundPredicateType)type
 {
     RKStringTokenizer *tokenizer = [RKStringTokenizer new];

--- a/Code/Search/RKSearchPredicate.m
+++ b/Code/Search/RKSearchPredicate.m
@@ -24,7 +24,7 @@
     return [self init];
 }
 
-- (instancetype)initWithType:(NSCompoundPredicateType)type subpredicates:(NSArray<NSPredicate *> *)subpredicates
+- (instancetype)initWithType:(NSCompoundPredicateType)type subpredicates:(NSArray *)subpredicates
 {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                    reason:[NSString stringWithFormat:@"-initWithType: is not a valid initializer for the class %@, use designated initilizer -initWithSearchText:type:", NSStringFromClass([self class])]

--- a/Code/Search/RKSearchPredicate.m
+++ b/Code/Search/RKSearchPredicate.m
@@ -9,6 +9,12 @@
 #import "RKSearchPredicate.h"
 #import "RKStringTokenizer.h"
 
+@interface RKSearchPredicate()
+
+- (instancetype)initWithType:(NSCompoundPredicateType)type subpredicates:(NSArray *)subpredicates NS_DESIGNATED_INITIALIZER;
+
+@end
+
 @implementation RKSearchPredicate
 
 + (NSPredicate *)searchPredicateWithText:(NSString *)searchText type:(NSCompoundPredicateType)type
@@ -26,10 +32,7 @@
 
 - (instancetype)initWithType:(NSCompoundPredicateType)type subpredicates:(NSArray *)subpredicates
 {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:[NSString stringWithFormat:@"-initWithType: is not a valid initializer for the class %@, use designated initilizer -initWithSearchText:type:", NSStringFromClass([self class])]
-                                 userInfo:nil];
-    return [self init];
+    return [super initWithType:type subpredicates:subpredicates];
 }
 
 - (instancetype)initWithSearchText:(NSString *)searchText type:(NSCompoundPredicateType)type

--- a/Code/Support/RKMIMETypeSerialization.m
+++ b/Code/Support/RKMIMETypeSerialization.m
@@ -40,6 +40,14 @@
 
 @implementation RKMIMETypeSerializationRegistration
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithMIMEType:serializationClass:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithMIMEType:(id)MIMETypeStringOrRegularExpression serializationClass:(Class<RKSerialization>)serializationClass
 {
     NSParameterAssert(MIMETypeStringOrRegularExpression);

--- a/Code/Support/RKURLEncodedSerialization.m
+++ b/Code/Support/RKURLEncodedSerialization.m
@@ -49,6 +49,14 @@ static NSString * AFPercentEscapedQueryStringValueFromStringWithEncoding(NSStrin
 
 @implementation RKAFQueryStringPair
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithField:", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithField:(id)field value:(id)value {
     self = [super init];
     if (!self) {

--- a/Code/Testing/RKMappingTest.m
+++ b/Code/Testing/RKMappingTest.m
@@ -152,6 +152,14 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
     return [[self alloc] initWithMapping:mapping sourceObject:sourceObject destinationObject:destinationObject];
 }
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:[NSString stringWithFormat:@"-init is not a valid initializer for the class %@, use designated initilizer -initWithMapping", NSStringFromClass([self class])]
+                                 userInfo:nil];
+    return [self init];
+}
+
 - (instancetype)initWithMapping:(RKMapping *)mapping sourceObject:(id)sourceObject destinationObject:(id)destinationObject
 {
     NSAssert(sourceObject != nil, @"Cannot perform a mapping operation without a sourceObject object");


### PR DESCRIPTION
Overrides superclass designated initializer and throw's an NSException if the designated initializer should be used instead.