### PR TITLE
Support "Age" HTTP response header.

### DIFF
--- a/Code/ObjectMapping/RKHTTPUtilities.m
+++ b/Code/ObjectMapping/RKHTTPUtilities.m
@@ -503,7 +503,16 @@ NSDate * RKHTTPCacheExpirationDateFromHeadersWithStatusCode(NSDictionary *header
             [cacheControlScanner setScanLocation:foundRange.location + foundRange.length];
             [cacheControlScanner scanString:@"=" intoString:nil];
             if ([cacheControlScanner scanInteger:&maxAge]) {
-                return maxAge > 0 ? [[NSDate alloc] initWithTimeInterval:maxAge sinceDate:now] : nil;
+            	if(maxAge > 0)
+                {
+                    const NSInteger age = ((NSString *)headers[@"Age"]).integerValue;
+                    if(age > 0)
+                    	return [[NSDate alloc] initWithTimeIntervalSinceNow:(maxAge - age)];
+                    else
+                    	return [[NSDate alloc] initWithTimeInterval:maxAge sinceDate:now];
+                }
+                else
+                	return nil;
             }
         }
     }

--- a/Tests/Logic/Support/RKHTTPUtilitiesTest.m
+++ b/Tests/Logic/Support/RKHTTPUtilitiesTest.m
@@ -171,4 +171,28 @@
     testBlock(dateComponents);
 }
 
+- (void)testRKHTTPCacheExpirationDateFromHeadersWithStatusCode
+{
+	const NSInteger maxAge = 3600;
+    NSDate * const date = [NSDate dateWithTimeIntervalSinceReferenceDate:1234];
+
+    NSDateFormatter * const dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+    dateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+    dateFormatter.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss z";
+
+	NSMutableDictionary * const headers = [[NSMutableDictionary alloc] initWithDictionary:@{
+    	@"Cache-Control" : [NSString stringWithFormat:@"public, max-age=%d", maxAge],
+        @"Date" : [dateFormatter stringFromDate:date]
+    }];
+    
+    expect(RKHTTPCacheExpirationDateFromHeadersWithStatusCode(headers, 200)).to.equal([date dateByAddingTimeInterval:maxAge]);
+    
+    [headers setObject:[NSNumber numberWithInteger:(maxAge + 60)] forKey:@"Age"];
+    expect(RKHTTPCacheExpirationDateFromHeadersWithStatusCode(headers, 200)).to.beLessThan(NSDate.date);
+
+    [headers setObject:[NSNumber numberWithInteger:(maxAge - 60)] forKey:@"Age"];
+    expect(RKHTTPCacheExpirationDateFromHeadersWithStatusCode(headers, 200)).to.beGreaterThan(NSDate.date);
+}
+
 @end


### PR DESCRIPTION
According to RFC 2616 content delivery networks (CDNs) shall deliver the Date header received from the origin. Amazon CloudFront have this behaviour, many others don't. Clients must use the Age parameter in order to calculate the next validation time, since infrequently changed messages will have old Date values.

This commit makes use of the Age parameter if it exist and is larger than zero. Otherwise the logic is as before.
Previously RestKit returned expire dates from the past during these circumstances.