### PR TITLE
Don't return deleted NSManagedObject objects from the in memory cache

### DIFF
--- a/Code/CoreData/RKEntityByAttributeCache.m
+++ b/Code/CoreData/RKEntityByAttributeCache.m
@@ -211,16 +211,17 @@ static NSArray *RKCacheKeysForEntityFromAttributeValues(NSEntityDescription *ent
 {
     /**
      NOTE:
-
+     
      We use `existingObjectWithID:` as opposed to `objectWithID:` as `objectWithID:` can return us a fault
-     that will raise an exception when fired. `existingObjectWithID:error:` will return nil if the ID has been
-     deleted. `objectRegisteredForID:` is also an acceptable approach.
+     that will raise an exception when fired. `objectRegisteredForID:` is also an acceptable approach.
      */
     __block NSError *error = nil;
     __block NSManagedObject *object;
     [context performBlockAndWait:^{
         object = [context existingObjectWithID:objectID error:&error];
     }];
+    // Don't return the object if it has been deleted.
+    if ([object isDeleted]) object = nil;
     if (! object) {
         // Referential integrity errors often indicates that the temporary objectID does not exist in the specified context
         if (error && !([objectID isTemporaryID] && [error code] == NSManagedObjectReferentialIntegrityError)) {


### PR DESCRIPTION
I came across an issue when using ```RKInMemoryManagedObjectCache``` with ```RKAssignmentPolicyReplace``` for a to-many relationship, that was causing the objects in the relationship to get deleted when the json response matched the current values in the database, along with the log message ```Core Data: annotation: repairing missing delete propagation for to-many relationship``` (and some information about the relationship).

I tracked the issue down to ```-[RKEntityByAttributeCache objectForObjectID:inContext:]```, which would return objects that had been deleted in order to satisfy the ```RKAssignmentPolicyReplace``` assignment policy, and then used to re-populate the relationship instead of creating new objects. I noticed a comment that assumed ```-[NSManagedObjectContext existingObjectWithID:error:]``` returns nil for a deleted object, which is not the case in my testing. I don't know if this used to be the case with older versions of iOS/OSX, but it is not the case now. 

These changes ensure that ```-[RKEntityByAttributeCache objectForObjectID:inContext:]``` returns nil instead of an object that has been deleted in the given context, along with a test case.