### PR TITLE
Send NSNotification When Will Save Mapping Context

### DIFF
--- a/Code/Network/RKManagedObjectRequestOperation.h
+++ b/Code/Network/RKManagedObjectRequestOperation.h
@@ -207,3 +207,17 @@ NSArray *RKArrayOfFetchRequestFromBlocksWithURL(NSArray *fetchRequestBlocks, NSU
 
 #endif
 #endif
+
+///--------------------
+/// @name Notifications
+///--------------------
+
+/**
+ Posted synchronously when a managed object request operation will save its mapping context, just after the `willSaveMappingContextBlock` is invoked.
+ */
+extern NSString *const RKManagedObjectRequestOperationWillSaveMappingContextNotification;
+
+/**
+ The key for the `NSManagedObjectContext` object used to perform the mapping for this operation. This context will be saved immediately after RKManagedObjectRequestOperationWillSaveMappingContextNotification is sent.
+ */
+extern NSString *const RKManagedObjectRequestOperationMappingContextUserInfoKey;

--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -40,6 +40,9 @@
 #undef RKLogComponent
 #define RKLogComponent RKlcl_cRestKitNetworkCoreData
 
+NSString *const RKManagedObjectRequestOperationWillSaveMappingContextNotification = @"RKManagedObjectRequestOperationWillSaveMappingContextNotification";
+NSString *const RKManagedObjectRequestOperationMappingContextUserInfoKey = @"RKManagedObjectRequestOperationMappingContextUserInfoKey";
+
 @interface RKEntityMappingEvent : NSObject
 @property (nonatomic, copy) id rootKey;
 @property (nonatomic, copy) NSString *keyPath;

--- a/Tests/Logic/Network/RKManagedObjectRequestOperationTest.m
+++ b/Tests/Logic/Network/RKManagedObjectRequestOperationTest.m
@@ -1687,6 +1687,26 @@ NSSet *RKSetByRemovingSubkeypathsFromSet(NSSet *setOfKeyPaths);
     expect(blockMappingContext).notTo.beNil();
 }
 
+- (void)testThatWillSaveMappingContextNotificationIsSent
+{
+    RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
+    RKEntityMapping *entityMapping = [RKEntityMapping mappingForEntityForName:@"Human" inManagedObjectStore:managedObjectStore];
+    [entityMapping addAttributeMappingsFromDictionary:@{ @"name": @"name" }];
+    RKResponseDescriptor *responseDescriptor = [RKResponseDescriptor responseDescriptorWithMapping:entityMapping method:RKRequestMethodAny pathPattern:nil keyPath:@"human" statusCodes:RKStatusCodeIndexSetForClass(RKStatusCodeClassSuccessful)];
+    
+    NSMutableURLRequest *request = [NSMutableURLRequest  requestWithURL:[NSURL URLWithString:@"/humans/1" relativeToURL:[RKTestFactory baseURL]]];
+    RKManagedObjectRequestOperation *managedObjectRequestOperation = [[RKManagedObjectRequestOperation alloc] initWithRequest:request responseDescriptors:@[ responseDescriptor ]];
+    managedObjectRequestOperation.managedObjectContext = managedObjectStore.persistentStoreManagedObjectContext;
+    __block NSManagedObjectContext *blockMappingContext = nil;
+    id observer = [NSNotificationCenter.defaultCenter addObserverForName:RKManagedObjectRequestOperationWillSaveMappingContextNotification object:managedObjectRequestOperation queue:nil usingBlock:^(NSNotification * _Nonnull note) {
+        blockMappingContext = note.userInfo[RKManagedObjectRequestOperationMappingContextUserInfoKey];
+    }];
+    [managedObjectRequestOperation start];
+    [managedObjectRequestOperation waitUntilFinished];
+    [NSNotificationCenter.defaultCenter removeObserver:observer];
+    expect(blockMappingContext).notTo.beNil();
+}
+
 - (void)testThatWillSaveMappingContextMappingResultIsAvailable {
     RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
     RKEntityMapping *entityMapping = [RKEntityMapping mappingForEntityForName:@"Human" inManagedObjectStore:managedObjectStore];


### PR DESCRIPTION
This will be useful when you want loosely-coupled changes to be made before mapping contexts get saved. @segiddins Thoughts?