### PR TITLE
Fix a multithreading violation introduced in RKEntityByAttributeCache

### DIFF
--- a/Code/CoreData/RKEntityByAttributeCache.m
+++ b/Code/CoreData/RKEntityByAttributeCache.m
@@ -219,9 +219,9 @@ static NSArray *RKCacheKeysForEntityFromAttributeValues(NSEntityDescription *ent
     __block NSManagedObject *object;
     [context performBlockAndWait:^{
         object = [context existingObjectWithID:objectID error:&error];
+        // Don't return the object if it has been deleted.
+        if ([object isDeleted]) object = nil;
     }];
-    // Don't return the object if it has been deleted.
-    if ([object isDeleted]) object = nil;
     if (! object) {
         // Referential integrity errors often indicates that the temporary objectID does not exist in the specified context
         if (error && !([objectID isTemporaryID] && [error code] == NSManagedObjectReferentialIntegrityError)) {


### PR DESCRIPTION
The last pull request I submitted introduced a multithreading violation, which is fixed now