### PR TITLE
Avoid Flushing In-Memory Managed Object Cache while Accessing

### DIFF
--- a/Code/CoreData/RKEntityByAttributeCache.m
+++ b/Code/CoreData/RKEntityByAttributeCache.m
@@ -105,13 +105,6 @@ static NSArray *RKCacheKeysForEntityFromAttributeValues(NSEntityDescription *ent
         _managedObjectContext = context;
         NSString *queueName = [[NSString alloc] initWithFormat:@"%@.%p", @"org.restkit.core-data.entity-by-attribute-cache", self];
         self.queue = dispatch_queue_create([queueName UTF8String], DISPATCH_QUEUE_CONCURRENT);        
-
-#if TARGET_OS_IPHONE
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(didReceiveMemoryWarning:)
-                                                     name:UIApplicationDidReceiveMemoryWarningNotification
-                                                   object:nil];
-#endif
     }
 
     return self;
@@ -119,8 +112,6 @@ static NSArray *RKCacheKeysForEntityFromAttributeValues(NSEntityDescription *ent
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    
 #if !OS_OBJECT_USE_OBJC
     dispatch_release(_queue);
     _queue = NULL;
@@ -396,11 +387,6 @@ static NSArray *RKCacheKeysForEntityFromAttributeValues(NSEntityDescription *ent
         allObjectIDs = [[self.cacheKeysToObjectIDs allValues] valueForKeyPath:@"@distinctUnionOfSets.self"];
     });
     return [allObjectIDs containsObject:object.objectID];
-}
-
-- (void)didReceiveMemoryWarning:(NSNotification *)notification
-{
-    [self flush:nil];
 }
 
 @end

--- a/Code/CoreData/RKEntityByAttributeCache.m
+++ b/Code/CoreData/RKEntityByAttributeCache.m
@@ -18,10 +18,6 @@
 //  limitations under the License.
 //
 
-#if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
-#endif
-
 #import <RestKit/CoreData/NSManagedObject+RKAdditions.h>
 #import <RestKit/CoreData/RKEntityByAttributeCache.h>
 #import <RestKit/CoreData/RKPropertyInspector+CoreData.h>

--- a/Code/CoreData/RKEntityCache.h
+++ b/Code/CoreData/RKEntityCache.h
@@ -155,6 +155,24 @@
  */
 - (BOOL)containsObject:(NSManagedObject *)managedObject;
 
+/**
+ Call this before beginning a sequence of operations that require the cache not to be flushed.
+ 
+ This is used by RKInMemoryManagedObjectCache to workaround https://github.com/RestKit/RestKit/issues/1613 .
+ 
+ @see endAccessing
+ */
+- (void)beginAccessing;
+
+/**
+ Call this after completing a sequence of operations that require the cache not to be flushed.
+
+ This is used by RKInMemoryManagedObjectCache to workaround https://github.com/RestKit/RestKit/issues/1613 .
+
+ @see beginAccessing
+ */
+- (void)endAccessing;
+
 @end
 
 // Deprecated in v0.20.1

--- a/Code/CoreData/RKEntityCache.m
+++ b/Code/CoreData/RKEntityCache.m
@@ -18,6 +18,10 @@
 //  limitations under the License.
 //
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
+
 #import <RestKit/CoreData/RKEntityByAttributeCache.h>
 #import <RestKit/CoreData/RKEntityCache.h>
 

--- a/Code/CoreData/RKEntityCache.m
+++ b/Code/CoreData/RKEntityCache.m
@@ -139,12 +139,11 @@
 - (void)waitForDispatchGroup:(dispatch_group_t)dispatchGroup withCompletionBlock:(void (^)(void))completion
 {
     if (completion) {
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),^{
-            dispatch_group_wait(dispatchGroup, DISPATCH_TIME_FOREVER);
+        dispatch_group_notify(dispatchGroup, self.callbackQueue ?: dispatch_get_main_queue(), ^{
 #if !OS_OBJECT_USE_OBJC
             dispatch_release(dispatchGroup);
 #endif
-            dispatch_async(self.callbackQueue ?: dispatch_get_main_queue(), completion);
+            completion();
         });
     }
 }

--- a/Code/CoreData/RKInMemoryManagedObjectCache.m
+++ b/Code/CoreData/RKInMemoryManagedObjectCache.m
@@ -90,6 +90,7 @@ static dispatch_queue_t RKInMemoryManagedObjectCacheCallbackQueue(void)
     NSParameterAssert(managedObjectContext);
     
     NSArray *attributes = [attributeValues allKeys];
+    [self.entityCache beginAccessing];
     if (! [self.entityCache isEntity:entity cachedByAttributes:attributes]) {
         RKLogInfo(@"Caching instances of Entity '%@' by attributes '%@'", entity.name, [attributes componentsJoinedByString:@", "]);
         dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
@@ -127,7 +128,9 @@ static dispatch_queue_t RKInMemoryManagedObjectCacheCallbackQueue(void)
         RKLogTrace(@"Cached %ld objects", (long)[attributeCache count]);
     }
     
-    return [self.entityCache objectsForEntity:entity withAttributeValues:attributeValues inContext:managedObjectContext];
+    NSSet *result = [self.entityCache objectsForEntity:entity withAttributeValues:attributeValues inContext:managedObjectContext];
+    [self.entityCache endAccessing];
+    return result;
 }
 
 - (void)didFetchObject:(NSManagedObject *)object

--- a/Tests/Logic/CoreData/RKEntityByAttributeCacheTest.m
+++ b/Tests/Logic/CoreData/RKEntityByAttributeCacheTest.m
@@ -422,22 +422,4 @@
     [self.cache objectsWithAttributeValues:attributeValues inContext:self.managedObjectContext];
 }
 
-#if TARGET_OS_IPHONE
-- (void)testCacheIsFlushedOnMemoryWarning
-{
-    RKHuman *human1 = [NSEntityDescription insertNewObjectForEntityForName:@"Human" inManagedObjectContext:self.managedObjectStore.persistentStoreManagedObjectContext];
-    human1.railsID = @12345;
-    RKHuman *human2 = [NSEntityDescription insertNewObjectForEntityForName:@"Human" inManagedObjectContext:self.managedObjectStore.persistentStoreManagedObjectContext];
-    human2.railsID = @12345;
-    [self.managedObjectStore.persistentStoreManagedObjectContext save:nil];
-    
-    [self.cache addObjects:[NSSet setWithObjects:human1, human2, nil] completion:nil];
-    expect([self.cache containsObject:human1]).will.equal(YES);
-    expect([self.cache containsObject:human2]).will.equal(YES);
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidReceiveMemoryWarningNotification object:self];
-    expect([self.cache containsObject:human1]).will.equal(NO);
-    expect([self.cache containsObject:human2]).will.equal(NO);
-}
-#endif
-
 @end


### PR DESCRIPTION
- Elevate `UIApplicationDidReceiveMemoryWarningNotification` observation up to `RKEntityCache` from `RKEntityByAttributeCache`.
- Add `beginAccessing` and `endAccessing` methods to `RKEntityCache` which will defer any calls to `flush` until all accesses are completed.
- Snuck in an improvement of using `dispatch_group_notify` to observe when dispatch groups end rather than holding up a thread with `dispatch_group_wait`.

This works around #1613.