### PR TITLE
Fix warning on nil use when NSString expected

### DIFF
--- a/Code/Testing/RKTestNotificationObserver.m
+++ b/Code/Testing/RKTestNotificationObserver.m
@@ -91,7 +91,7 @@
     while (self.isAwaitingNotification) {
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
         if ([[NSDate date] timeIntervalSinceDate:self.startDate] > self.timeout) {
-            [NSException raise:nil format:@"*** Operation timed out after %f seconds...", self.timeout];
+            [NSException raise:@"" format:@"*** Operation timed out after %f seconds...", self.timeout];
             self.awaitingNotification = NO;
         }
     }


### PR DESCRIPTION
The NSException raise is expecting a string as parameter and is receiving a nil.

This is generating a warning on xcode 7.

The change doesn't alter the functionality and removes the warning.