### PR TITLE
Fixed a circular retain, causing non used request operations to leak

### DIFF
--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -127,7 +127,6 @@ static void *RKOperationFinishDate = &RKOperationFinishDate;
 
 - (void)objectRequestOperationDidStart:(NSNotification *)notification
 {
-    // Weakly tag the HTTP operation with its parent object request operation
     RKObjectRequestOperation *objectRequestOperation = [notification object];
     objc_setAssociatedObject(objectRequestOperation, RKOperationStartDate, [NSDate date], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     

--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -420,34 +420,30 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
 - (void)setCompletionBlockWithSuccess:(void (^)(RKObjectRequestOperation *operation, RKMappingResult *mappingResult))success
                               failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
-// See above setCompletionBlock:
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-retain-cycles"
-
     //Keep blocks for copyWithZone
     self.successBlock = success;
     self.failureBlock = failure;
-
+    
+    __weak __typeof(self) const weakSelf = self;
     self.completionBlock = ^ {
-        if ([self isCancelled] && !self.error) {
-            self.error = [NSError errorWithDomain:RKErrorDomain code:RKOperationCancelledError userInfo:nil];
+        if ([weakSelf isCancelled] && !weakSelf.error) {
+            weakSelf.error = [NSError errorWithDomain:RKErrorDomain code:RKOperationCancelledError userInfo:nil];
         }
-
-        if (self.error) {
+        
+        if (weakSelf.error) {
             if (failure) {
-                dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
-                    failure(self, self.error);
+                dispatch_async(weakSelf.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    failure(weakSelf, weakSelf.error);
                 });
             }
         } else {
             if (success) {
-                dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
-                    success(self, self.mappingResult);
+                dispatch_async(weakSelf.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    success(weakSelf, weakSelf.mappingResult);
                 });
             }
         }
     };
-#pragma clang diagnostic pop
 }
 
 - (void)performMappingOnResponseWithCompletionBlock:(void(^)(RKMappingResult *mappingResult, NSError *error))completionBlock

--- a/Code/Network/RKObjectRequestOperation.m
+++ b/Code/Network/RKObjectRequestOperation.m
@@ -426,21 +426,25 @@ static NSString *RKStringDescribingURLResponseWithData(NSURLResponse *response, 
     
     __weak __typeof(self) const weakSelf = self;
     self.completionBlock = ^ {
-        if ([weakSelf isCancelled] && !weakSelf.error) {
-            weakSelf.error = [NSError errorWithDomain:RKErrorDomain code:RKOperationCancelledError userInfo:nil];
-        }
-        
-        if (weakSelf.error) {
-            if (failure) {
-                dispatch_async(weakSelf.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
-                    failure(weakSelf, weakSelf.error);
-                });
+		__typeof(self) const strongSelf = weakSelf; // Retain object, so we for sure have something to pass to the success and/or failure blocks.
+		if(strongSelf)
+        {
+            if ([strongSelf isCancelled] && !strongSelf.error) {
+                strongSelf.error = [NSError errorWithDomain:RKErrorDomain code:RKOperationCancelledError userInfo:nil];
             }
-        } else {
-            if (success) {
-                dispatch_async(weakSelf.successCallbackQueue ?: dispatch_get_main_queue(), ^{
-                    success(weakSelf, weakSelf.mappingResult);
-                });
+            
+            if (strongSelf.error) {
+                if (failure) {
+                    dispatch_async(strongSelf.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                        failure(strongSelf, strongSelf.error);
+                    });
+                }
+            } else {
+                if (success) {
+                    dispatch_async(strongSelf.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                        success(strongSelf, strongSelf.mappingResult);
+                    });
+                }
             }
         }
     };


### PR DESCRIPTION
Also removed the confusing comment "Weakly tag the HTTP operation with its parent object request operation". The HTTP operation is not tagged anymore and when it was it was not weak (in the end), which caused a major leak.
