### PR TITLE
Reduce Amount of Exception-throwing in RKManagedObjectRequestOperation

### DIFF
--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -390,12 +390,15 @@ static NSSet *RKManagedObjectsFromObjectWithMappingInfo(id object, RKMappingInfo
             if([object conformsToProtocol:@protocol(NSFastEnumeration)]) {
                 NSMutableSet* results = [NSMutableSet set];
                 for (id item in object) {
+					id value = nil;
                     @try {
-                        id value = [item valueForKeyPath:destinationKeyPath];
-                        [results addObject:value];
+                        value = [item valueForKeyPath:destinationKeyPath];
                     } @catch(NSException*) {
                         continue;
                     }
+					if (value != nil) {
+						[results addObject:value];
+					}
                 }
                 
                 relationshipValue = results;

--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -390,15 +390,15 @@ static NSSet *RKManagedObjectsFromObjectWithMappingInfo(id object, RKMappingInfo
             if([object conformsToProtocol:@protocol(NSFastEnumeration)]) {
                 NSMutableSet* results = [NSMutableSet set];
                 for (id item in object) {
-					id value = nil;
+                    id value = nil;
                     @try {
                         value = [item valueForKeyPath:destinationKeyPath];
                     } @catch(NSException*) {
                         continue;
                     }
-					if (value != nil) {
-						[results addObject:value];
-					}
+                    if (value != nil) {
+                        [results addObject:value];
+                    }
                 }
                 
                 relationshipValue = results;


### PR DESCRIPTION
If `valueForKeyPath:` returns nil – which happens a lot – we shouldn't attempt to insert nil into the set. @segiddins 