### PR TITLE
Cleanup 2 deprecation warnings (RKHTTPRequestOperation, RKMappingOperation)

### DIFF
--- a/Code/Network/RKHTTPRequestOperation.m
+++ b/Code/Network/RKHTTPRequestOperation.m
@@ -111,14 +111,6 @@ static BOOL RKResponseRequiresContentTypeMatch(NSHTTPURLResponse *response, NSUR
 }
 
 #pragma mark - NSURLConnectionDelegate methods
-
-- (void)connection:(NSURLConnection *)connection didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
-{
-    [super connection:connection didReceiveAuthenticationChallenge:challenge];
-
-    RKLogDebug(@"Received authentication challenge");
-}
-
 - (NSURLRequest *)connection:(NSURLConnection *)connection willSendRequest:(NSURLRequest *)request redirectResponse:(NSURLResponse *)redirectResponse
 {
     if ([AFHTTPRequestOperation instancesRespondToSelector:@selector(connection:willSendRequest:redirectResponse:)]) {

--- a/Code/ObjectMapping/RKMappingOperation.m
+++ b/Code/ObjectMapping/RKMappingOperation.m
@@ -1217,9 +1217,8 @@ static NSArray *RKInsertInMetadataList(NSArray *list, id metadata1, id metadata2
         }
     }
     
-    BOOL canSkipProperties = [dataSource respondsToSelector:@selector(mappingOperationShouldSkipPropertyMapping:)] && [dataSource mappingOperationShouldSkipPropertyMapping:self];
-    BOOL canSkipAttributes = canSkipProperties;
-    BOOL canSkipRelationships = canSkipProperties;
+    BOOL canSkipAttributes = [dataSource respondsToSelector:@selector(mappingOperationShouldSkipAttributeMapping:)] && [dataSource mappingOperationShouldSkipAttributeMapping:self];
+    BOOL canSkipRelationships = [dataSource respondsToSelector:@selector(mappingOperationShouldSkipRelationshipMapping:)] && [dataSource mappingOperationShouldSkipRelationshipMapping:self];
     if ([dataSource respondsToSelector:@selector(mappingOperationShouldSkipRelationshipMapping:)]) {
         canSkipRelationships = [dataSource mappingOperationShouldSkipRelationshipMapping:self];
     }


### PR DESCRIPTION
RKHTTPRequestOperation: remove unused (and possibly dangerous) NSURLConnectionDelegate method. If it happens to be used it will try to trigger this method on a super - but no superclass implements it, so it will crash.
RKMappingOperation: remove RestKit 'mappingOperationShouldSkipPropertyMapping:' deprecation warning by replacing with two corresponding methods (attribute, relationship mapping). Is it a suitable fix?