### PR TITLE
fixed RKObjectMapping equality

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -465,7 +465,7 @@ static NSArray *RKRemoveProperty(NSArray *array, RKPropertyMapping *mapping)
     if ([self.propertyMappings count] != [otherMapping.propertyMappings count]) return NO;
 
     for (RKPropertyMapping *propertyMapping in self.propertyMappings) {
-        RKPropertyMapping *otherPropertyMapping = [otherMapping mappingForSourceKeyPath:propertyMapping.sourceKeyPath];
+        RKPropertyMapping *otherPropertyMapping = [otherMapping mappingForDestinationKeyPath:propertyMapping.destinationKeyPath];
         if (! [propertyMapping isEqualToMapping:otherPropertyMapping]) return NO;
     }
 

--- a/Tests/Logic/ObjectMapping/RKObjectMappingTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectMappingTest.m
@@ -86,6 +86,18 @@
     assertThatBool([mapping1 isEqualToMapping:mapping2], is(equalToBool(YES)));
 }
 
+- (void)testThatTwoMappingsWithMultipleSourceKeyPathAndSameDestinationKeyPathAreConsideredEqual
+{
+    RKObjectMapping *mapping1 = [RKObjectMapping mappingForClass:[NSString class]];
+    [mapping1 addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:@"this" toKeyPath:@"that"]];
+    [mapping1 addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:@"this" toKeyPath:@"that2"]];
+    RKObjectMapping *mapping2 = [RKObjectMapping mappingForClass:[NSString class]];
+    [mapping2 addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:@"this" toKeyPath:@"that"]];
+    [mapping2 addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:@"this" toKeyPath:@"that2"]];
+    
+    assertThatBool([mapping1 isEqualToMapping:mapping2], is(equalToBool(YES)));
+}
+
 - (void)testThatTwoMappingsWithDifferingRelationshipMappingClassesAreNotConsideredEqual
 {
     RKObjectMapping *relationshipMapping1 = [RKObjectMapping mappingForClass:[NSSet class]];

--- a/Tests/Logic/ObjectMapping/RKObjectMappingTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectMappingTest.m
@@ -86,7 +86,7 @@
     assertThatBool([mapping1 isEqualToMapping:mapping2], is(equalToBool(YES)));
 }
 
-- (void)testThatTwoMappingsWithMultipleSourceKeyPathAndSameDestinationKeyPathAreConsideredEqual
+- (void)testThatTwoMappingsWithMultipleDestinationKeyPathAndSameSourceKeyPathAreConsideredEqual
 {
     RKObjectMapping *mapping1 = [RKObjectMapping mappingForClass:[NSString class]];
     [mapping1 addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:@"this" toKeyPath:@"that"]];


### PR DESCRIPTION
As per the current status of the project:

It's possible to have multiple attribute mappings with the same `sourceKeyPath`.
It's *NOT* possible to have multiple attribute mappings with the same `destinationKeyPath`.

Therefore to check the equality of two `RKObjectMapping` is necessary to retrieve the `RKPropertyMapping` to compare by `destinationKeyPath` (as it's unique) and not by `sourceKeyPath`.