### PR TITLE
added metadata list to RKTestMapping

### DIFF
--- a/Code/Testing/RKMappingTest.h
+++ b/Code/Testing/RKMappingTest.h
@@ -97,6 +97,18 @@ extern NSString * const RKMappingTestExpectationErrorKey;
 + (instancetype)testForMapping:(RKMapping *)mapping sourceObject:(id)sourceObject destinationObject:(id)destinationObject;
 
 /**
+ Creates and returns a new test for a given object mapping, source object, destination
+ object and metadata list.
+ 
+ @param mapping The mapping being tested.
+ @param sourceObject The source object being mapped from.
+ @param destinationObject The destionation object being to.
+ @param metadataList The additional metadata list to map from.
+ @return A new mapping test object for a mapping, a source object and a destination object.
+ */
++ (instancetype)testForMapping:(RKMapping *)mapping sourceObject:(id)sourceObject destinationObject:(id)destinationObject metadataList:(NSArray *)metadataList;
+
+/**
  Initializes the receiver with a given object mapping, source object, and destination object.
 
  @param mapping The mapping being tested.
@@ -104,7 +116,18 @@ extern NSString * const RKMappingTestExpectationErrorKey;
  @param destinationObject The destionation object being to.
  @return The receiver, initialized with mapping, sourceObject and destinationObject.
  */
-- (instancetype)initWithMapping:(RKMapping *)mapping sourceObject:(id)sourceObject destinationObject:(id)destinationObject NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithMapping:(RKMapping *)mapping sourceObject:(id)sourceObject destinationObject:(id)destinationObject;
+
+/**
+ Initializes the receiver with a given object mapping, source object, and destination object.
+ 
+ @param mapping The mapping being tested.
+ @param sourceObject The source object being mapped from.
+ @param destinationObject The destionation object being to.
+ @param metadataList The additional metadata list to map from.
+ @return The receiver, initialized with mapping, sourceObject and destinationObject.
+ */
+- (instancetype)initWithMapping:(RKMapping *)mapping sourceObject:(id)sourceObject destinationObject:(id)destinationObject metadataList:(NSArray *)metadataList NS_DESIGNATED_INITIALIZER;
 
 ///----------------------------
 /// @name Managing Expectations

--- a/Code/Testing/RKMappingTest.m
+++ b/Code/Testing/RKMappingTest.m
@@ -135,6 +135,7 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
 @property (nonatomic, strong, readwrite) RKMapping *mapping;
 @property (nonatomic, strong, readwrite) id sourceObject;
 @property (nonatomic, strong, readwrite) id destinationObject;
+@property (nonatomic, strong) NSArray *metadataList;
 @property (nonatomic, strong) NSMutableArray *expectations;
 @property (nonatomic, strong) NSMutableArray *events;
 @property (nonatomic, assign, getter = hasPerformedMapping) BOOL performedMapping;
@@ -149,6 +150,11 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
 
 + (instancetype)testForMapping:(RKMapping *)mapping sourceObject:(id)sourceObject destinationObject:(id)destinationObject
 {
+    return [[self class] testForMapping:mapping sourceObject:sourceObject destinationObject:destinationObject metadataList:nil];
+}
+
++ (instancetype)testForMapping:(RKMapping *)mapping sourceObject:(id)sourceObject destinationObject:(id)destinationObject metadataList:(NSArray *)metadataList
+{
     return [[self alloc] initWithMapping:mapping sourceObject:sourceObject destinationObject:destinationObject];
 }
 
@@ -162,19 +168,25 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
 
 - (instancetype)initWithMapping:(RKMapping *)mapping sourceObject:(id)sourceObject destinationObject:(id)destinationObject
 {
+    return [self initWithMapping:mapping sourceObject:sourceObject destinationObject:destinationObject metadataList:nil];
+}
+
+- (instancetype)initWithMapping:(RKMapping *)mapping sourceObject:(id)sourceObject destinationObject:(id)destinationObject metadataList:(NSArray *)metadataList
+{
     NSAssert(sourceObject != nil, @"Cannot perform a mapping operation without a sourceObject object");
     NSAssert(mapping != nil, @"Cannot perform a mapping operation without a mapping");
-
+    
     self = [super init];
     if (self) {
         self.sourceObject = sourceObject;
         self.destinationObject = destinationObject;
+        self.metadataList = metadataList;
         self.mapping = mapping;
         self.expectations = [NSMutableArray new];
         self.events = [NSMutableArray new];
         self.performedMapping = NO;
     }
-
+    
     return self;
 }
 
@@ -390,7 +402,7 @@ NSString * const RKMappingTestVerificationFailureException = @"RKMappingTestVeri
     // Ensure repeated invocations of verify only result in a single mapping operation
     if (! self.hasPerformedMapping) {
         id sourceObject = self.rootKeyPath ? [self.sourceObject valueForKeyPath:self.rootKeyPath] : self.sourceObject;
-        RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:sourceObject destinationObject:self.destinationObject mapping:self.mapping];
+        RKMappingOperation *mappingOperation = [[RKMappingOperation alloc] initWithSourceObject:sourceObject destinationObject:self.destinationObject mapping:self.mapping metadataList:self.metadataList];
         id<RKMappingOperationDataSource> dataSource = [self dataSourceForMappingOperation:mappingOperation];
         mappingOperation.dataSource = dataSource;
         mappingOperation.delegate = self;


### PR DESCRIPTION
This would allow us to test the metadata mapping without the need to create and use a `RKObjectRequestOperation`.