### PR TITLE
Add a valueForUndefinedKey

### DIFF
--- a/Code/Network/RKPaginator.m
+++ b/Code/Network/RKPaginator.m
@@ -91,6 +91,11 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
     [self.objectRequestOperation cancel];
 }
 
+-(id)valueForUndefinedKey:(NSString *)key {
+    // If parameter is unknown, ignore it
+    return [NSString stringWithFormat:@":%@",key];
+}
+
 - (NSURL *)patternURL
 {
     return self.request.URL;

--- a/Code/Network/RKPaginator.m
+++ b/Code/Network/RKPaginator.m
@@ -91,6 +91,7 @@ static NSUInteger RKPaginatorDefaultPerPage = 25;
     [self.objectRequestOperation cancel];
 }
 
+
 -(id)valueForUndefinedKey:(NSString *)key {
     // If parameter is unknown, ignore it
     return [NSString stringWithFormat:@":%@",key];

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
     colored (1.2)
     daemons (1.2.3)
     escape (0.0.4)
-    eventmachine (1.2.0.1)
+    eventmachine (1.0.7)
     fuzzy_match (2.0.4)
     i18n (0.7.0)
     json (1.8.3)
@@ -102,4 +102,4 @@ DEPENDENCIES
   xctasks (~> 0.5.0)
 
 BUNDLED WITH
-   1.12.4
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
     colored (1.2)
     daemons (1.2.3)
     escape (0.0.4)
-    eventmachine (1.0.7)
+    eventmachine (1.2.0.1)
     fuzzy_match (2.0.4)
     i18n (0.7.0)
     json (1.8.3)
@@ -102,4 +102,4 @@ DEPENDENCIES
   xctasks (~> 0.5.0)
 
 BUNDLED WITH
-   1.10.6
+   1.12.4

--- a/Tests/Logic/ObjectMapping/RKPaginatorTest.m
+++ b/Tests/Logic/ObjectMapping/RKPaginatorTest.m
@@ -456,6 +456,23 @@ static NSString * const RKPaginatorTestResourcePathPatternWithOffset = @"/pagina
     expect(paginator.objectCount).to.equal(0);
 }
 
+- (void)testPaginatorWithPaginationURLThatIncludesAColon
+{
+    NSURL *paginationURL = [NSURL URLWithString:@"/paginate/do:123/?per_page=:perPage&page=:currentPage" relativeToURL:[RKTestFactory baseURL]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:paginationURL];
+    RKPaginator *paginator = [[RKPaginator alloc] initWithRequest:request paginationMapping:self.paginationMapping responseDescriptors:@[ self.responseDescriptor ]];
+    __block NSArray *blockObjects = nil;
+    [paginator setCompletionBlockWithSuccess:^(RKPaginator *paginator, NSArray *objects, NSUInteger page) {
+        blockObjects = objects;
+    } failure:nil];
+    [paginator loadPage:1];
+    [paginator waitUntilFinished];
+    expect(blockObjects).willNot.beNil();
+    expect(paginator.pageCount).to.equal(0);
+    expect(paginator.objectCount).to.equal(0);
+}
+
+
 - (void)testOffsetNumberOfNextPage
 {
     NSURLRequest *request = [NSURLRequest requestWithURL:self.paginationOffsetURL];

--- a/Tests/Server/server.rb
+++ b/Tests/Server/server.rb
@@ -262,6 +262,13 @@ class RestKitTestServer < Sinatra::Base
      :current_page => 1, :entries => [], :total_pages => 0}.to_json
   end
 
+  get '/paginate/doc:123/' do
+    status 200
+    content_type 'application/json'
+    {:per_page => 10, :total_entries => 0,
+        :current_page => 1, :entries => [], :total_pages => 0}.to_json
+  end
+
   get '/coredata/etag' do
     content_type 'application/json'
     tag = '2cdd0a2b329541d81e82ab20aff6281b'

--- a/Tests/Server/server.rb
+++ b/Tests/Server/server.rb
@@ -262,7 +262,7 @@ class RestKitTestServer < Sinatra::Base
      :current_page => 1, :entries => [], :total_pages => 0}.to_json
   end
 
-  get '/paginate/doc:123/' do
+  get '/paginate/do:123/' do
     status 200
     content_type 'application/json'
     {:per_page => 10, :total_entries => 0,


### PR DESCRIPTION
To ignore unknown parameters in a RKPaginatorObject. A URL my already have a colon in it to represent a custom reference to a API object. This pull request will ignore such unknown parameters. 
A URL like /elements/DO:1234/Structure will now work with. Without the change, the URL will be parsed as a patterned URL and will fail.