### PR TITLE
fixed predicate with substitution variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
+osx_image: xcode7.3
 language: objective-c
-rvm: 2.2.3
+rvm: 2.2.4
+cache:
+  - bundler
+  - cocoapods
 install:
     - bundle install
     - bundle exec pod install

--- a/Code/CoreData/RKFetchRequestManagedObjectCache.m
+++ b/Code/CoreData/RKFetchRequestManagedObjectCache.m
@@ -43,15 +43,31 @@ static NSString *RKPredicateCacheKeyForAttributeValues(NSDictionary *attributesV
     return [keyFragments componentsJoinedByString:@":"];
 }
 
-// NOTE: We build a dynamic format string here because `NSCompoundPredicate` does not support use of substiution variables
-static NSPredicate *RKPredicateWithSubsitutionVariablesForAttributeValues(NSDictionary *attributeValues)
+// NOTE: We make sure to convert the attribute values to compatible names that can be replaced correctly by `predicateWithSubstitutionVariables`
+static NSString *RKAttributePlaceholderForAttributeName(NSString *attributeName)
+{
+    return [[attributeName componentsSeparatedByCharactersInSet:[NSCharacterSet punctuationCharacterSet]] componentsJoinedByString:@"_"];
+}
+
+static NSDictionary *RKSubstitutionVariablesForAttributeValues(NSDictionary *attributeValues)
+{
+    NSMutableDictionary *placeholders = [[NSMutableDictionary alloc] initWithCapacity:attributeValues.count];
+    [attributeValues enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
+        placeholders[RKAttributePlaceholderForAttributeName(key)] = value;
+    }];
+
+    return [NSDictionary dictionaryWithDictionary:placeholders];
+}
+
+// NOTE: We build a dynamic format string here because `NSCompoundPredicate` does not support use of substitution variables
+static NSPredicate *RKPredicateWithSubstitutionVariablesForAttributeValues(NSDictionary *attributeValues)
 {
     NSArray *attributeNames = [attributeValues allKeys];
     NSMutableArray *formatFragments = [NSMutableArray arrayWithCapacity:[attributeNames count]];
     [attributeValues enumerateKeysAndObjectsUsingBlock:^(NSString *attributeName, id value, BOOL *stop) {
         NSString *formatFragment = RKObjectIsCollection(value)
-                                 ? [NSString stringWithFormat:@"%@ IN $%@", attributeName, attributeName]
-                                 : [NSString stringWithFormat:@"%@ = $%@", attributeName, attributeName];
+                                 ? [NSString stringWithFormat:@"%@ IN $%@", attributeName, RKAttributePlaceholderForAttributeName(attributeName)]
+                                 : [NSString stringWithFormat:@"%@ = $%@", attributeName, RKAttributePlaceholderForAttributeName(attributeName)];
         [formatFragments addObject:formatFragment];
     }];
 
@@ -103,16 +119,18 @@ static NSPredicate *RKPredicateWithSubsitutionVariablesForAttributeValues(NSDict
     dispatch_sync(self.cacheQueue, ^{
         substitutionPredicate = (self.predicateCache)[predicateCacheKey];
     });
-         
+    
+    NSDictionary *substitutionVariables = RKSubstitutionVariablesForAttributeValues(attributeValues);
+    
     if (! substitutionPredicate) {
-        substitutionPredicate = RKPredicateWithSubsitutionVariablesForAttributeValues(attributeValues);
+        substitutionPredicate = RKPredicateWithSubstitutionVariablesForAttributeValues(attributeValues);
         dispatch_barrier_async(self.cacheQueue, ^{
             (self.predicateCache)[predicateCacheKey] = substitutionPredicate;
         });
     }
     
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:[entity name]];
-    fetchRequest.predicate = [substitutionPredicate predicateWithSubstitutionVariables:attributeValues];
+    fetchRequest.predicate = [substitutionPredicate predicateWithSubstitutionVariables:substitutionVariables];
     __block NSError *error = nil;
     __block NSArray *objects = nil;
     [managedObjectContext performBlockAndWait:^{

--- a/Tests/Logic/CoreData/RKFetchRequestMappingCacheTest.m
+++ b/Tests/Logic/CoreData/RKFetchRequestMappingCacheTest.m
@@ -9,6 +9,8 @@
 #import "RKTestEnvironment.h"
 #import "RKCat.h"
 #import "RKEvent.h"
+#import "RKHouse.h"
+#import "RKHuman.h"
 
 @interface RKFetchRequestMappingCacheTest : RKTestCase
 
@@ -65,6 +67,27 @@
                                        inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
     NSSet *birthdays = [NSSet setWithObject:birthday];
     expect(managedObjects).to.equal(birthdays);
+}
+
+- (void)testFetchRequestMappingCacheReturnsObjectsWithStringUsingDotNotation
+{
+    // RKEvent entity. String primary key
+    RKManagedObjectStore *managedObjectStore = [RKTestFactory managedObjectStore];
+    RKFetchRequestManagedObjectCache *cache = [RKFetchRequestManagedObjectCache new];
+    NSEntityDescription *entity = [NSEntityDescription entityForName:@"Human" inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
+    RKHouse *house = [NSEntityDescription insertNewObjectForEntityForName:@"House" inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
+    house.city = @"myCity";
+    RKHuman *human = [NSEntityDescription insertNewObjectForEntityForName:@"Human" inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
+    human.house = house;
+    house.owner = human;
+    
+    [managedObjectStore.persistentStoreManagedObjectContext save:nil];
+    
+    NSSet *managedObjects = [cache managedObjectsWithEntity:entity
+                                            attributeValues:@{ @"house.city": @"myCity" }
+                                     inManagedObjectContext:managedObjectStore.persistentStoreManagedObjectContext];
+    NSSet *humans = [NSSet setWithObject:human];
+    expect(managedObjects).to.equal(humans);
 }
 
 - (void)testThatCacheCanHandleSwitchingBetweenSingularAndPluralAttributeValues


### PR DESCRIPTION
It should be possible to retrieve `NSManagedObject`s by identification attributes specified in a related object.

To do so, the identification attributes have to be in the format `relation.attributeName`.
Although, this doesn't work with the current implementation of `RKFetchRequestManagedObjectCache` because the `predicateWithSubstitutionVariables` method fails in replace constants placeholders that contain a dot `.`.

@segiddins this should be easy to merge