### PR TITLE
Update Project

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 inhibit_all_warnings!
 
 target :RestKit do
-  platform :ios, '5.1.1'
+  platform :ios, '6.1'
   podspec
 end
 
@@ -27,7 +27,7 @@ def import_pods
 end
 
 target :ios do
-  platform :ios, '5.1.1'
+  platform :ios, '6.1'
   link_with 'RestKitTests'
   import_pods
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -61,7 +61,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   RestKit:
-    :path: "."
+    :path: .
 
 SPEC CHECKSUMS:
   AFNetworking: cf8e418e16f0c9c7e5c3150d019a3c679d015018
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   ISO8601DateFormatterValueTransformer: 52da467d6ec899d6aedda8e48280ac92e8ee97e6
   OCHamcrest: e19857683e4eefab64b878668eac04c2f4567118
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
-  RestKit: af05406ca2c203cfdfe6cf2f2c35dfd97ce55429
+  RestKit: 7621919ce9a1abec7bc4808e3fe05f67ef9e199a
   RKCLLocationValueTransformer: 2cf0ea0fb7cd4bc70c56834fb92abc717c66f982
   RKValueTransformers: e5ed67e3811229b616fe01bddeeafe3bb337b1b9
   SOCKit: c7376ac262bea9115b8f749358f762522a47d392

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ RKMappingTest *mappingTest = [[RKMappingTest alloc] initWithMapping:mapping sour
 
 ## Requirements
 
-RestKit requires [iOS 5.1.1](http://developer.apple.com/library/ios/#releasenotes/General/WhatsNewIniPhoneOS/Articles/iOS5.html#//apple_ref/doc/uid/TP30915195-SW1) and above or [Mac OS X 10.7](http://developer.apple.com/library/mac/#releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_7.html#//apple_ref/doc/uid/TP40010355-SW5) and above.
+RestKit requires [iOS 6.1](https://developer.apple.com/library/ios/releasenotes/General/WhatsNewIniOS/Articles/iOS6_1.html#//apple_ref/doc/uid/TP40012873-SW1) and above or [Mac OS X 10.7](http://developer.apple.com/library/mac/#releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_7.html#//apple_ref/doc/uid/TP40010355-SW5) and above.
 
 Several third-party open source libraries are used within RestKit, including:
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ XCTasks::TestTask.new(:test) do |t|
 
   t.subtask(ios: 'RestKitTests') do |s|
     s.sdk = :iphonesimulator
-    s.destination('platform=iOS Simulator,OS=8.1,name=iPhone 6')
+    s.destination('platform=iOS Simulator,OS=9.3,name=iPhone 6')
   end
 
   t.subtask(osx: 'RestKitFrameworkTests') do |s|

--- a/RestKit.podspec
+++ b/RestKit.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   # Platform setup
   s.requires_arc = true
-  s.ios.deployment_target = '5.1.1'
+  s.ios.deployment_target = '6.1'
   s.osx.deployment_target = '10.7'
 
   # Exclude optional Search and Testing modules

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -11,10 +11,10 @@
 		1689DAF01B87CEA900254FB7 /* RKLumberjackLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 1689DAED1B87CEA900254FB7 /* RKLumberjackLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1689DAF11B87CEA900254FB7 /* RKLumberjackLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1689DAEE1B87CEA900254FB7 /* RKLumberjackLogger.m */; };
 		1689DAF21B87CEA900254FB7 /* RKLumberjackLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1689DAEE1B87CEA900254FB7 /* RKLumberjackLogger.m */; };
-		16AAD5A91C067D8400BB5CA7 /* lcl_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 16AAD5A71C067D8400BB5CA7 /* lcl_RK.h */; settings = {ASSET_TAGS = (); }; };
-		16AAD5AA1C067D8400BB5CA7 /* lcl_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 16AAD5A71C067D8400BB5CA7 /* lcl_RK.h */; settings = {ASSET_TAGS = (); }; };
-		16AAD5AB1C067D8400BB5CA7 /* lcl_RK.m in Sources */ = {isa = PBXBuildFile; fileRef = 16AAD5A81C067D8400BB5CA7 /* lcl_RK.m */; settings = {ASSET_TAGS = (); }; };
-		16AAD5AC1C067D8400BB5CA7 /* lcl_RK.m in Sources */ = {isa = PBXBuildFile; fileRef = 16AAD5A81C067D8400BB5CA7 /* lcl_RK.m */; settings = {ASSET_TAGS = (); }; };
+		16AAD5A91C067D8400BB5CA7 /* lcl_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 16AAD5A71C067D8400BB5CA7 /* lcl_RK.h */; };
+		16AAD5AA1C067D8400BB5CA7 /* lcl_RK.h in Headers */ = {isa = PBXBuildFile; fileRef = 16AAD5A71C067D8400BB5CA7 /* lcl_RK.h */; };
+		16AAD5AB1C067D8400BB5CA7 /* lcl_RK.m in Sources */ = {isa = PBXBuildFile; fileRef = 16AAD5A81C067D8400BB5CA7 /* lcl_RK.m */; };
+		16AAD5AC1C067D8400BB5CA7 /* lcl_RK.m in Sources */ = {isa = PBXBuildFile; fileRef = 16AAD5A81C067D8400BB5CA7 /* lcl_RK.m */; };
 		2502C8ED15F79CF70060FD75 /* CoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8E715F79CF70060FD75 /* CoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2502C8EE15F79CF70060FD75 /* CoreData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8E715F79CF70060FD75 /* CoreData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2502C8EF15F79CF70060FD75 /* Network.h in Headers */ = {isa = PBXBuildFile; fileRef = 2502C8E815F79CF70060FD75 /* Network.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1825,7 +1825,6 @@
 				25160D2114564E820060A5C5 /* Sources */,
 				25160D2214564E820060A5C5 /* Frameworks */,
 				25160D2314564E820060A5C5 /* Resources */,
-				25160D2414564E820060A5C5 /* ShellScript */,
 				D00A58B091EC84A57A1FB098 /* Copy Pods Resources */,
 				D53939EC83FE6753732850FE /* Embed Pods Frameworks */,
 			);
@@ -1868,7 +1867,6 @@
 				25160E74145651060060A5C5 /* Frameworks */,
 				25160E75145651060060A5C5 /* Resources */,
 				250CA67F147D8EEC0047D347 /* CopyFiles */,
-				25160E76145651060060A5C5 /* ShellScript */,
 				D9DDA304517443E2F6FD2B2C /* Copy Pods Resources */,
 				2FFB30DF4A3D492F0C2C5F2C /* Embed Pods Frameworks */,
 			);
@@ -2031,32 +2029,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
-		};
-		25160D2414564E820060A5C5 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"";
-		};
-		25160E76145651060060A5C5 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
 		};
 		2FFB30DF4A3D492F0C2C5F2C /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2536,7 +2508,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -2568,7 +2540,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -2617,11 +2589,7 @@
 			baseConfigurationReference = 0B096CE4874E766ECE78D229 /* Pods-ios.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
-					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
-				);
+				FRAMEWORK_SEARCH_PATHS = "\"$(PLATFORM_DIR)/Developer/Library/Frameworks\"";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Code/Support/RestKit-Prefix.pch";
 				INFOPLIST_FILE = "Resources/PLISTs/RestKitTests-Info.plist";
@@ -2637,11 +2605,7 @@
 			baseConfigurationReference = A339C3AFD7C094BEAFE92A93 /* Pods-ios.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
-					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
-				);
+				FRAMEWORK_SEARCH_PATHS = "\"$(PLATFORM_DIR)/Developer/Library/Frameworks\"";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Code/Support/RestKit-Prefix.pch";
 				INFOPLIST_FILE = "Resources/PLISTs/RestKitTests-Info.plist";

--- a/Tests/Logic/CoreData/RKInMemoryManagedObjectCacheTest.m
+++ b/Tests/Logic/CoreData/RKInMemoryManagedObjectCacheTest.m
@@ -92,11 +92,9 @@
     [self waitForPendingChangesToProcess];
     expect([self.managedObjectCache.entityCache containsObject:human1]).will.equal(YES);
 }
-
+/* PENDING: This test is brittle when run in the full suite
 - (void)testManagedObjectContextProcessPendingChangesRemovesExistingObjectsFromCache
 {
-    // PENDING: This test is brittle when run in the full suite
-    return;
     RKHuman *human1 = [NSEntityDescription insertNewObjectForEntityForName:@"Human" inManagedObjectContext:self.managedObjectStore.persistentStoreManagedObjectContext];
     human1.railsID = @12345;
     [self waitForPendingChangesToProcess];
@@ -108,7 +106,7 @@
     }];
     expect([self.managedObjectCache.entityCache containsObject:human1]).will.beFalsy();
 }
-
+*/
 - (void)testCreatingProcessingAndDeletingObjectsWorksAsExpected
 {
     RKHuman *human1 = [NSEntityDescription insertNewObjectForEntityForName:@"Human" inManagedObjectContext:self.managedObjectStore.persistentStoreManagedObjectContext];

--- a/Tests/Logic/ObjectMapping/RKObjectMappingNextGenTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectMappingNextGenTest.m
@@ -1430,7 +1430,7 @@
     RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
     operation.dataSource = dataSource;
     id mockMapping = [OCMockObject partialMockForObject:mapping];
-    [[[mockMapping expect] andReturnValue:@NO] shouldSetDefaultValueForMissingAttributes];
+    [[[mockMapping expect] andReturnValue:@NO] assignsDefaultValueForMissingAttributes];
     NSError *error = nil;
     [operation performMapping:&error];
     assertThat(user.name, is(equalTo(@"Blake Watters")));
@@ -1903,7 +1903,7 @@
     NSMutableDictionary *dictionary = [[RKTestFixture parsedObjectWithContentsOfFixture:@"user.json"] mutableCopy];
     [dictionary removeObjectForKey:@"address"];
     id mockMapping = [OCMockObject partialMockForObject:userMapping];
-    [[[mockMapping expect] andReturnValue:@YES] setNilForMissingRelationships];
+    [[[mockMapping expect] andReturnValue:@YES] assignsNilForMissingRelationships];
     RKMappingOperation *operation = [[RKMappingOperation alloc] initWithSourceObject:dictionary destinationObject:mockUser mapping:mockMapping];
     RKObjectMappingOperationDataSource *dataSource = [RKObjectMappingOperationDataSource new];
     operation.dataSource = dataSource;

--- a/Tests/Logic/Search/RKSearchIndexerTest.m
+++ b/Tests/Logic/Search/RKSearchIndexerTest.m
@@ -455,7 +455,7 @@ static NSManagedObjectModel *RKManagedObjectModel()
     [human setValue:@"This is my name" forKey:@"name"];
     
     id mockDelegate = [OCMockObject niceMockForProtocol:@protocol(RKSearchIndexerDelegate)];
-    RKSearchWord *searchWord = [NSEntityDescription insertNewObjectForEntityForName:@"RKSearchWord" inManagedObjectContext:managedObjectContext];
+    RKSearchWord *searchWord = (RKSearchWord *) [NSEntityDescription insertNewObjectForEntityForName:@"RKSearchWord" inManagedObjectContext:managedObjectContext];
     [[[mockDelegate expect] andReturn:searchWord] searchIndexer:indexer searchWordForWord:@"this" inManagedObjectContext:managedObjectContext error:(NSError * __autoreleasing *)[OCMArg anyPointer]];
     [[[mockDelegate expect] andReturn:searchWord] searchIndexer:indexer searchWordForWord:@"is" inManagedObjectContext:managedObjectContext error:(NSError * __autoreleasing *)[OCMArg anyPointer]];
     [[[mockDelegate expect] andReturn:searchWord] searchIndexer:indexer searchWordForWord:@"my" inManagedObjectContext:managedObjectContext error:(NSError * __autoreleasing *)[OCMArg anyPointer]];

--- a/Tests/Logic/Support/RKHTTPUtilitiesTest.m
+++ b/Tests/Logic/Support/RKHTTPUtilitiesTest.m
@@ -182,7 +182,7 @@
     dateFormatter.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss z";
 
 	NSMutableDictionary * const headers = [[NSMutableDictionary alloc] initWithDictionary:@{
-    	@"Cache-Control" : [NSString stringWithFormat:@"public, max-age=%d", maxAge],
+    	@"Cache-Control" : [NSString stringWithFormat:@"public, max-age=%ld", (long)maxAge],
         @"Date" : [dateFormatter stringFromDate:date]
     }];
     

--- a/Tests/Models/RKHuman.m
+++ b/Tests/Models/RKHuman.m
@@ -40,6 +40,7 @@
 @dynamic catIDs;
 @dynamic catsInOrderByAge;
 @dynamic isHappy;
+@dynamic likesDogs;
 
 @dynamic house;
 @dynamic landlord;


### PR DESCRIPTION
Fixed all the warnings:

* increased deployment target on iOS to 6.1 to fix object file (/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/7.3.0/lib/darwin/libclang_rt.ios.a(chkstk.S.o)) was built for newer iOS version
* safe cast object to silence warning
* run tests against iOS 9,3
* added missing dynamic property
* silence %d warning
* replaced deprecated methods
* silenced warning for pending test (+1 squashed commit)
* removed deprecated run unit test script

Notes:
I have noticed that the tests hangs on semaphore_wait_trap because of `NSURLCache` that's why travis takes ages to complete a build, not sure if anything can be done about it.
I have also noticed that the failing tests pass when run one by one.