### PR TITLE
Use explicit `userInfo` keys for `NSManagedObjectContextDidSaveNotification`

### DIFF
--- a/Code/CoreData/RKManagedObjectStore.h
+++ b/Code/CoreData/RKManagedObjectStore.h
@@ -24,6 +24,8 @@
 
 @class RKManagedObjectStore;
 
+extern NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification);
+
 /**
  The `RKManagedObjectStore` class encapsulates a Core Data stack including a managed object model, a persistent store coordinator, and a set of managed object contexts. The managed object store simplifies the task of properly setting up a Core Data stack and provides some additional functionality, such as the use of a seed database to initialize a SQLite backed persistent store and a simple code path for resetting the store by destroying and recreating the persistent stores.
 

--- a/Code/CoreData/RKManagedObjectStore.h
+++ b/Code/CoreData/RKManagedObjectStore.h
@@ -24,8 +24,6 @@
 
 @class RKManagedObjectStore;
 
-extern NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification);
-
 /**
  The `RKManagedObjectStore` class encapsulates a Core Data stack including a managed object model, a persistent store coordinator, and a set of managed object contexts. The managed object store simplifies the task of properly setting up a Core Data stack and provides some additional functionality, such as the use of a seed database to initialize a SQLite backed persistent store and a simple code path for resetting the store by destroying and recreating the persistent stores.
 

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -52,11 +52,18 @@ static BOOL RKIsManagedObjectContextDescendentOfContext(NSManagedObjectContext *
 
 static NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification)
 {
-    NSUInteger count = [[[notification.userInfo allValues] valueForKeyPath:@"@sum.@count"] unsignedIntegerValue];
-    NSMutableSet *objectIDs = [NSMutableSet setWithCapacity:count];
-    for (NSSet *objects in [notification.userInfo allValues]) {
-        [objectIDs unionSet:[objects valueForKey:@"objectID"]];
-    }
+    NSMutableSet <NSManagedObjectID *> *objectIDs = [NSMutableSet set];
+    
+    void (^unionObjectIDs)(NSMutableSet *, NSSet *) = ^(NSMutableSet *objectIDs, NSSet *objects) {
+        if (objects != nil) {
+            [objectIDs unionSet:[objects valueForKey:NSStringFromSelector(@selector(objectID))]];
+        }
+    };
+    
+    unionObjectIDs(objectIDs,notification.userInfo[NSInsertedObjectsKey]);
+    unionObjectIDs(objectIDs,notification.userInfo[NSUpdatedObjectsKey]);
+    unionObjectIDs(objectIDs,notification.userInfo[NSDeletedObjectsKey]);
+    
     return objectIDs;
 }
 

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -50,6 +50,7 @@ static BOOL RKIsManagedObjectContextDescendentOfContext(NSManagedObjectContext *
     return NO;
 }
 
+NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification);
 NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification)
 {
     NSMutableSet <NSManagedObjectID *> *objectIDs = [NSMutableSet set];

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -27,6 +27,7 @@
 #import "RKInMemoryManagedObjectCache.h"
 #import "RKFetchRequestManagedObjectCache.h"
 #import "NSManagedObjectContext+RKAdditions.h"
+#import "RKManagedObjectStore_Private.h"
 
 // Set Logging Component
 #undef RKLogComponent
@@ -48,24 +49,6 @@ static BOOL RKIsManagedObjectContextDescendentOfContext(NSManagedObjectContext *
         context = [context parentContext];
     }
     return NO;
-}
-
-NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification);
-NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification)
-{
-    NSMutableSet <NSManagedObjectID *> *objectIDs = [NSMutableSet set];
-    
-    void (^unionObjectIDs)(NSMutableSet *, NSSet *) = ^(NSMutableSet *objectIDs, NSSet *objects) {
-        if (objects != nil) {
-            [objectIDs unionSet:[objects valueForKey:NSStringFromSelector(@selector(objectID))]];
-        }
-    };
-    
-    unionObjectIDs(objectIDs,notification.userInfo[NSInsertedObjectsKey]);
-    unionObjectIDs(objectIDs,notification.userInfo[NSUpdatedObjectsKey]);
-    unionObjectIDs(objectIDs,notification.userInfo[NSDeletedObjectsKey]);
-    
-    return objectIDs;
 }
 
 @interface RKManagedObjectContextChangeMergingObserver : NSObject

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -51,6 +51,23 @@ static BOOL RKIsManagedObjectContextDescendentOfContext(NSManagedObjectContext *
     return NO;
 }
 
+NSSet <NSManagedObjectID *> *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification)
+{
+    NSMutableSet <NSManagedObjectID *> *objectIDs = [NSMutableSet set];
+    
+    void (^unionObjectIDs)(NSMutableSet *, NSSet *) = ^(NSMutableSet *objectIDs, NSSet *objects) {
+        if (objects != nil) {
+            [objectIDs unionSet:[objects valueForKey:NSStringFromSelector(@selector(objectID))]];
+        }
+    };
+    
+    unionObjectIDs(objectIDs,notification.userInfo[NSInsertedObjectsKey]);
+    unionObjectIDs(objectIDs,notification.userInfo[NSUpdatedObjectsKey]);
+    unionObjectIDs(objectIDs,notification.userInfo[NSDeletedObjectsKey]);
+    
+    return objectIDs;
+}
+
 @interface RKManagedObjectContextChangeMergingObserver : NSObject
 @property (nonatomic, weak) NSManagedObjectContext *observedContext;
 @property (nonatomic, weak) NSManagedObjectContext *mergeContext;

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -50,7 +50,7 @@ static BOOL RKIsManagedObjectContextDescendentOfContext(NSManagedObjectContext *
     return NO;
 }
 
-static NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification)
+NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification)
 {
     NSMutableSet <NSManagedObjectID *> *objectIDs = [NSMutableSet set];
     

--- a/Code/CoreData/RKManagedObjectStore_Private.h
+++ b/Code/CoreData/RKManagedObjectStore_Private.h
@@ -1,0 +1,28 @@
+//
+//  RKManagedObjectStore_Private.h
+//  RestKit
+//
+//  Created by Alexander Edge on 03/08/2016.
+//  Copyright © 2016 RestKit. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification);
+NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification)
+{
+    NSMutableSet <NSManagedObjectID *> *objectIDs = [NSMutableSet set];
+    
+    void (^unionObjectIDs)(NSMutableSet *, NSSet *) = ^(NSMutableSet *objectIDs, NSSet *objects) {
+        if (objects != nil) {
+            [objectIDs unionSet:[objects valueForKey:NSStringFromSelector(@selector(objectID))]];
+        }
+    };
+    
+    unionObjectIDs(objectIDs,notification.userInfo[NSInsertedObjectsKey]);
+    unionObjectIDs(objectIDs,notification.userInfo[NSUpdatedObjectsKey]);
+    unionObjectIDs(objectIDs,notification.userInfo[NSDeletedObjectsKey]);
+    
+    return objectIDs;
+}

--- a/Code/CoreData/RKManagedObjectStore_Private.h
+++ b/Code/CoreData/RKManagedObjectStore_Private.h
@@ -7,22 +7,5 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <CoreData/CoreData.h>
 
-NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification);
-NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification)
-{
-    NSMutableSet <NSManagedObjectID *> *objectIDs = [NSMutableSet set];
-    
-    void (^unionObjectIDs)(NSMutableSet *, NSSet *) = ^(NSMutableSet *objectIDs, NSSet *objects) {
-        if (objects != nil) {
-            [objectIDs unionSet:[objects valueForKey:NSStringFromSelector(@selector(objectID))]];
-        }
-    };
-    
-    unionObjectIDs(objectIDs,notification.userInfo[NSInsertedObjectsKey]);
-    unionObjectIDs(objectIDs,notification.userInfo[NSUpdatedObjectsKey]);
-    unionObjectIDs(objectIDs,notification.userInfo[NSDeletedObjectsKey]);
-    
-    return objectIDs;
-}
+NSSet <NSManagedObjectID *> *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification);

--- a/RestKit.podspec
+++ b/RestKit.podspec
@@ -29,6 +29,7 @@ Pod::Spec.new do |s|
     os.dependency       'RestKit/Support'
     os.dependency       'RKValueTransformers', '~> 1.1.0'
     os.dependency       'ISO8601DateFormatterValueTransformer', '~> 0.6.1'
+    os.private_header_files = 'Code/ObjectMapping/**/*_Private.h'
   end
 
   s.subspec 'Network' do |ns|
@@ -44,6 +45,7 @@ Pod::Spec.new do |s|
     cdos.source_files = 'Code/CoreData.h', 'Code/CoreData/**/*'
     cdos.frameworks   = 'CoreData'
     cdos.dependency 'RestKit/ObjectMapping'
+    cdos.private_header_files = 'Code/CoreData/**/*_Private.h'
   end
 
   s.subspec 'Testing' do |ts|

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -581,6 +581,8 @@
 		C0F11CE6190883460054AEA0 /* RKPathMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F11CE2190883380054AEA0 /* RKPathMatcher.m */; };
 		CC3C009EB6D5ACD3B01300FC /* Pods_RestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF210C1916C936CF01427B6D /* Pods_RestKit.framework */; };
 		DEAC698D1B8F55A600FF6134 /* RKRefetchingMappingResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DEAC698C1B8F55A600FF6134 /* RKRefetchingMappingResultTests.m */; };
+		DEF8B7EF1D52938D00DA4DC0 /* RKManagedObjectStore_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DEF8B7ED1D52938D00DA4DC0 /* RKManagedObjectStore_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DEF8B7F01D52938D00DA4DC0 /* RKManagedObjectStore_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DEF8B7ED1D52938D00DA4DC0 /* RKManagedObjectStore_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -958,6 +960,7 @@
 		CF210C1916C936CF01427B6D /* Pods_RestKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RestKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D65BD48D9807D81B001FA9EF /* Pods-RestKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RestKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RestKit/Pods-RestKit.debug.xcconfig"; sourceTree = "<group>"; };
 		DEAC698C1B8F55A600FF6134 /* RKRefetchingMappingResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKRefetchingMappingResultTests.m; sourceTree = "<group>"; };
+		DEF8B7ED1D52938D00DA4DC0 /* RKManagedObjectStore_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKManagedObjectStore_Private.h; sourceTree = "<group>"; };
 		E5A80EE4D025CD3978C8403B /* Pods_RestKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RestKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F66056291744FF9000A87A45 /* and_cats.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = and_cats.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1141,6 +1144,7 @@
 				E4081E0915FB8FD800364948 /* Mapping */,
 				25160D52145650490060A5C5 /* RKManagedObjectStore.h */,
 				25160D53145650490060A5C5 /* RKManagedObjectStore.m */,
+				DEF8B7ED1D52938D00DA4DC0 /* RKManagedObjectStore_Private.h */,
 				2597F99A15AF6DC400E547D7 /* RKRelationshipConnectionOperation.h */,
 				2597F99B15AF6DC400E547D7 /* RKRelationshipConnectionOperation.m */,
 			);
@@ -1781,6 +1785,7 @@
 				2595B47315F670530087A59B /* RKNSJSONSerialization.h in Headers */,
 				2502C8ED15F79CF70060FD75 /* CoreData.h in Headers */,
 				2502C8EF15F79CF70060FD75 /* Network.h in Headers */,
+				DEF8B7EF1D52938D00DA4DC0 /* RKManagedObjectStore_Private.h in Headers */,
 				2502C8F115F79CF70060FD75 /* ObjectMapping.h in Headers */,
 				2502C8F315F79CF70060FD75 /* Search.h in Headers */,
 				2502C8F515F79CF70060FD75 /* Support.h in Headers */,
@@ -1882,6 +1887,7 @@
 				2502C8F015F79CF70060FD75 /* Network.h in Headers */,
 				2502C8F215F79CF70060FD75 /* ObjectMapping.h in Headers */,
 				2502C8F415F79CF70060FD75 /* Search.h in Headers */,
+				DEF8B7F01D52938D00DA4DC0 /* RKManagedObjectStore_Private.h in Headers */,
 				2502C8F615F79CF70060FD75 /* Support.h in Headers */,
 				2502C8F815F79CF70060FD75 /* Testing.h in Headers */,
 				253477F215FFBC61002C0E4E /* RKDictionaryUtilities.h in Headers */,

--- a/Tests/Logic/CoreData/RKManagedObjectStoreTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectStoreTest.m
@@ -634,6 +634,8 @@ static NSManagedObjectModel *RKManagedObjectModel()
     expect(error).to.beNil();
 }
 
+extern NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification);
+
 - (void)testSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification {
     
     NSManagedObjectModel *managedObjectModel = RKManagedObjectModel();

--- a/Tests/Logic/CoreData/RKManagedObjectStoreTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectStoreTest.m
@@ -38,8 +38,14 @@ static NSManagedObjectModel *RKManagedObjectModelWithNameAtVersion(NSString *mod
     return model;
 }
 
-@interface RKManagedObjectStoreTest : RKTestCase
+static NSManagedObjectModel *RKManagedObjectModel()
+{
+    NSURL *modelURL = [[RKTestFixture fixtureBundle] URLForResource:@"Data Model" withExtension:@"mom"];
+    return [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
+}
 
+@interface RKManagedObjectStoreTest : RKTestCase
+@property (nonatomic, strong) id observerReference;
 @end
 
 @implementation RKManagedObjectStoreTest
@@ -63,6 +69,7 @@ static NSManagedObjectModel *RKManagedObjectModelWithNameAtVersion(NSString *mod
 
 - (void)tearDown
 {
+    if (self.observerReference) [[NSNotificationCenter defaultCenter] removeObserver:self.observerReference];
     [RKTestFactory tearDown];
 }
 
@@ -625,6 +632,43 @@ static NSManagedObjectModel *RKManagedObjectModelWithNameAtVersion(NSString *mod
     }];
     expect(success).to.equal(YES);
     expect(error).to.beNil();
+}
+
+- (void)testSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification {
+    
+    NSManagedObjectModel *managedObjectModel = RKManagedObjectModel();
+    NSEntityDescription *entity = [managedObjectModel entitiesByName][@"Human"];
+    
+    NSPersistentStoreCoordinator *persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:managedObjectModel];
+    NSError *error;
+    [persistentStoreCoordinator addPersistentStoreWithType:NSInMemoryStoreType configuration:nil URL:nil options:nil error:&error];
+    NSManagedObjectContext *managedObjectContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+    managedObjectContext.persistentStoreCoordinator = persistentStoreCoordinator;
+    
+    __block NSUInteger count = 0;
+    
+    NSManagedObject *human1 = [NSEntityDescription insertNewObjectForEntityForName:entity.name inManagedObjectContext:managedObjectContext];
+    [managedObjectContext save:NULL];
+    
+    NSManagedObject *human2 = [NSEntityDescription insertNewObjectForEntityForName:entity.name inManagedObjectContext:managedObjectContext];
+    [managedObjectContext save:NULL];
+    
+    self.observerReference = [[NSNotificationCenter defaultCenter] addObserverForName:NSManagedObjectContextDidSaveNotification object:managedObjectContext queue:nil usingBlock:^(NSNotification *notification) {
+        NSSet *set = RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(notification);
+        count = set.count;
+    }];
+    
+    [human1 setValue:@"Jane Doe" forKey:@"name"];
+    [managedObjectContext deleteObject:human2];
+    
+    [NSEntityDescription insertNewObjectForEntityForName:entity.name inManagedObjectContext:managedObjectContext];
+    [managedObjectContext save:NULL];
+    
+    // 1 inserted
+    // 1 updated
+    // 1 deleted
+    expect(count).will.equal(3);
+    
 }
 
 @end

--- a/Tests/Logic/CoreData/RKManagedObjectStoreTest.m
+++ b/Tests/Logic/CoreData/RKManagedObjectStoreTest.m
@@ -23,6 +23,7 @@
 #import "RKHuman.h"
 #import "RKPathUtilities.h"
 #import "RKSearchIndexer.h"
+#import "RKManagedObjectStore_Private.h"
 
 // TODO: Does this become `RKManagedObjectStore managedObjectModelWithName:version:inBundle:` ??? URLForManagedObjectModel
 static NSURL *RKURLForManagedObjectModelWithNameAtVersion(NSString *modelName, NSUInteger version)
@@ -633,8 +634,6 @@ static NSManagedObjectModel *RKManagedObjectModel()
     expect(success).to.equal(YES);
     expect(error).to.beNil();
 }
-
-extern NSSet *RKSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification(NSNotification *notification);
 
 - (void)testSetOfManagedObjectIDsFromManagedObjectContextDidSaveNotification {
     


### PR DESCRIPTION
In iOS 10 beta 4 there is a new key in the `userInfo` dictionary, `managedObjectContext`, so the existing collection operator causes a crash as it assumes all values are `NSSet`s.

I have added explicit checking for inserted, deleted and updated objects.