### PR TITLE
Allow creation of paginators with custom class

### DIFF
--- a/Code/Network/RKObjectManager.h
+++ b/Code/Network/RKObjectManager.h
@@ -878,6 +878,19 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  */
 - (RKPaginator *)paginatorWithPathPattern:(NSString *)pathPattern parameters:(NSDictionary *)parameters;
 
+/**
+ Creates and returns a paginator object configured to paginate the collection resource accessible at the specified path pattern and the given parameters with the given class.
+ 
+ The paginator instantiated will be initialized with a URL built by appending the given pathPattern to the baseURL of the client and the given parameters if any. The response descriptors and Core Data configuration, if any, are inherited from the receiver.
+ 
+ @param pathPattern A patterned URL fragment to be appended to the baseURL of the receiver in order to construct the pattern URL with which to access the paginated collection.
+ @param parameters The parameters to be encoded and appended as the query string for the request URL. May be nil.
+ @param paginatorClass Class to use for newly created paginator.
+ @return The newly created paginator instance.
+ @see RKPaginator
+ */
+- (RKPaginator *)paginatorWithPathPattern:(NSString *)pathPattern parameters:(NSDictionary *)parameters class: (Class) paginatorClass;
+
 @end
 
 #ifdef _SYSTEMCONFIGURATION_H

--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -823,6 +823,11 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
 
 - (RKPaginator *)paginatorWithPathPattern:(NSString *)pathPattern parameters:(NSDictionary *)parameters
 {
+    return [self paginatorWithPathPattern:pathPattern parameters:parameters class:self.paginationMapping.objectClass];
+}
+
+- (RKPaginator *)paginatorWithPathPattern:(NSString *)pathPattern parameters:(NSDictionary *)parameters class: (Class) paginatorClass
+{
     NSAssert(self.paginationMapping, @"Cannot instantiate a paginator when `paginationMapping` is nil.");
     NSMutableURLRequest *request = [self requestWithMethod:@"GET" path:pathPattern parameters:parameters];
     RKPaginator *paginator = [[self.paginationMapping.objectClass alloc] initWithRequest:request paginationMapping:self.paginationMapping responseDescriptors:self.responseDescriptors];


### PR DESCRIPTION
In our project we have different subclasses of RKPaginator to fulfill different needs within our application. 

In order to support that (since `paginationMapping` is too limited for us), we added a convenience creation method for it isn `RKObjectManager`.