### PR TITLE
Inverse transformer introspection

### DIFF
--- a/Code/ObjectMapping/RKObjectMapping.m
+++ b/Code/ObjectMapping/RKObjectMapping.m
@@ -74,7 +74,11 @@ static RKSourceToDesinationKeyTransformationBlock defaultSourceToDestinationKeyT
     
     for (RKAttributeMapping *attributeMapping in mapping.attributeMappings) {
         if (predicate && !predicate(attributeMapping)) continue;
-        [inverseMapping addPropertyMapping:[RKAttributeMapping attributeMappingFromKeyPath:attributeMapping.destinationKeyPath toKeyPath:attributeMapping.sourceKeyPath]];
+        RKPropertyMapping *propertyMapping = [RKAttributeMapping attributeMappingFromKeyPath:attributeMapping.destinationKeyPath toKeyPath:attributeMapping.sourceKeyPath];
+        if (propertyMapping.propertyValueClass == Nil && ![mapping.objectClass isSubclassOfClass:[NSDictionary class]]) {
+            propertyMapping.propertyValueClass = [self.mapping classForKeyPath:propertyMapping.destinationKeyPath];
+        }
+        [inverseMapping addPropertyMapping:propertyMapping];
     }
     
     for (RKRelationshipMapping *relationshipMapping in mapping.relationshipMappings) {


### PR DESCRIPTION
This should close #1949 , I had the same issue and was upset for not being able to register a custom transformer globally because of the documented lack of ability to infer types on inverse mappings (because of NSMutableDictionary objectClass)
The implementation is roughly the same as #2095 , only during the inverse mapping construction, introspecting on the original mapping's objectClass.

I tried running the existing development test suite before hand to verify my implementation wouldn't break any of them, but it had hundreds of failing tests right after cloning so I couldn't. It has been working on my own app, appreciate feedback of anything that this might unadvertly break.