### PR TITLE
Issue 2508: __NSCFBoolean private API

### DIFF
--- a/Code/CoreData/RKPropertyInspector+CoreData.m
+++ b/Code/CoreData/RKPropertyInspector+CoreData.m
@@ -50,7 +50,7 @@
         if ([attributeDescription attributeValueClassName]) {
             Class cls = NSClassFromString([attributeDescription attributeValueClassName]);
             if ([cls isSubclassOfClass:[NSNumber class]] && [attributeDescription attributeType] == NSBooleanAttributeType) {
-                cls = objc_getClass("NSCFBoolean") ?: objc_getClass("__NSCFBoolean") ?: cls;
+                cls = [@YES class];
             }
             RKPropertyInspectorPropertyInfo *info;
             info = [RKPropertyInspectorPropertyInfo propertyInfoWithName:name

--- a/Code/CoreData/RKPropertyInspector+CoreData.m
+++ b/Code/CoreData/RKPropertyInspector+CoreData.m
@@ -24,6 +24,7 @@
 #import "RKLog.h"
 #import "RKObjectUtilities.h"
 #import "RKMacros.h"
+#import "RKBooleanClass.h"
 
 // Set Logging Component
 #undef RKLogComponent
@@ -50,7 +51,7 @@
         if ([attributeDescription attributeValueClassName]) {
             Class cls = NSClassFromString([attributeDescription attributeValueClassName]);
             if ([cls isSubclassOfClass:[NSNumber class]] && [attributeDescription attributeType] == NSBooleanAttributeType) {
-                cls = [@YES class];
+                cls = RK_BOOLEAN_CLASS;
             }
             RKPropertyInspectorPropertyInfo *info;
             info = [RKPropertyInspectorPropertyInfo propertyInfoWithName:name

--- a/Code/Network/RKObjectParameterization.m
+++ b/Code/Network/RKObjectParameterization.m
@@ -29,6 +29,7 @@
 #import "RKMappingErrors.h"
 #import "RKPropertyInspector.h"
 #import "RKValueTransformers.h"
+#import "RKBooleanClass.h"
 
 // Set Logging Component
 #undef RKLogComponent
@@ -122,7 +123,7 @@
         transformedValue = [value array];
     } else {
         Class propertyClass = RKPropertyInspectorGetClassForPropertyAtKeyPathOfObject(mapping.sourceKeyPath, operation.sourceObject);
-        if ([propertyClass isSubclassOfClass:[@YES class]]) {
+        if ([propertyClass isSubclassOfClass:RK_BOOLEAN_CLASS]) {
             transformedValue = @([value boolValue]);
         }
     }

--- a/Code/Network/RKObjectParameterization.m
+++ b/Code/Network/RKObjectParameterization.m
@@ -122,7 +122,7 @@
         transformedValue = [value array];
     } else {
         Class propertyClass = RKPropertyInspectorGetClassForPropertyAtKeyPathOfObject(mapping.sourceKeyPath, operation.sourceObject);
-        if ([propertyClass isSubclassOfClass:NSClassFromString(@"__NSCFBoolean")] || [propertyClass isSubclassOfClass:NSClassFromString(@"NSCFBoolean")]) {
+        if ([propertyClass isSubclassOfClass:[@YES class]]) {
             transformedValue = @([value boolValue]);
         }
     }

--- a/Code/ObjectMapping/RKObjectUtilities.m
+++ b/Code/ObjectMapping/RKObjectUtilities.m
@@ -21,6 +21,7 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 #import "RKObjectUtilities.h"
+#import "RKBooleanClass.h"
 
 BOOL RKObjectIsEqualToObject(id object, id anotherObject) {
     NSCAssert(object, @"Expected object not to be nil");
@@ -97,7 +98,7 @@ Class RKKeyValueCodingClassForObjCType(const char *type)
                 return [NSNumber class];
                 
             case _C_BOOL: // C++ bool or C99 _Bool
-                return [@YES class];
+                return RK_BOOLEAN_CLASS;
                 
             case _C_STRUCT_B: // struct
             case _C_BFLD: // bitfield

--- a/Code/ObjectMapping/RKObjectUtilities.m
+++ b/Code/ObjectMapping/RKObjectUtilities.m
@@ -97,9 +97,7 @@ Class RKKeyValueCodingClassForObjCType(const char *type)
                 return [NSNumber class];
                 
             case _C_BOOL: // C++ bool or C99 _Bool
-                return objc_getClass("NSCFBoolean")
-                ?: objc_getClass("__NSCFBoolean")
-                ?: [NSNumber class];
+                return [@YES class];
                 
             case _C_STRUCT_B: // struct
             case _C_BFLD: // bitfield

--- a/Code/Support/RKBooleanClass.h
+++ b/Code/Support/RKBooleanClass.h
@@ -1,0 +1,23 @@
+//
+//  RKBooleanClass.h
+//  RestKit
+//
+//  Created by Valerio Mazzeo on 18/07/17.
+//  Copyright (c) 2017 RestKit. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#define RK_BOOLEAN_CLASS [@YES class]

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -567,6 +567,7 @@
 		7AF2905218DF249C009AEB94 /* RKObjectiveCppTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2501405215366000004E0466 /* RKObjectiveCppTest.mm */; };
 		8AB68F0B1AE5B3B300DD655A /* RKFetchedResultsControllerUpdateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB68F0A1AE5B3B300DD655A /* RKFetchedResultsControllerUpdateTest.m */; };
 		921177BC8BF814CE50A88BBC /* Pods_RestKitFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F006D81E09160AA4A9F0904 /* Pods_RestKitFramework.framework */; };
+		B96933B01F1DF5D10025AB6F /* RKBooleanClass.h in Headers */ = {isa = PBXBuildFile; fileRef = B96933AF1F1DF5D10025AB6F /* RKBooleanClass.h */; };
 		B9ADD4D71D1BD8D80059D029 /* RKHTTPUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = B9ADD4D51D1BD8D80059D029 /* RKHTTPUtilities.h */; };
 		B9ADD4D81D1BD8D80059D029 /* RKHTTPUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = B9ADD4D51D1BD8D80059D029 /* RKHTTPUtilities.h */; };
 		B9ADD4D91D1BD8D80059D029 /* RKHTTPUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = B9ADD4D61D1BD8D80059D029 /* RKHTTPUtilities.m */; };
@@ -950,6 +951,7 @@
 		8AB68F0A1AE5B3B300DD655A /* RKFetchedResultsControllerUpdateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKFetchedResultsControllerUpdateTest.m; sourceTree = "<group>"; };
 		90C7F04F6E4B2167E5855425 /* Pods-RestKitFramework.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RestKitFramework.release.xcconfig"; path = "Pods/Target Support Files/Pods-RestKitFramework/Pods-RestKitFramework.release.xcconfig"; sourceTree = "<group>"; };
 		949F3C99E4A550F125EB1223 /* Pods-RestKitFrameworkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RestKitFrameworkTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RestKitFrameworkTests/Pods-RestKitFrameworkTests.release.xcconfig"; sourceTree = "<group>"; };
+		B96933AF1F1DF5D10025AB6F /* RKBooleanClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKBooleanClass.h; sourceTree = "<group>"; };
 		B9ADD4D51D1BD8D80059D029 /* RKHTTPUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKHTTPUtilities.h; sourceTree = "<group>"; };
 		B9ADD4D61D1BD8D80059D029 /* RKHTTPUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKHTTPUtilities.m; sourceTree = "<group>"; };
 		B9B1C7F31D273AB500F115CB /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
@@ -1247,6 +1249,7 @@
 				253477F015FFBC60002C0E4E /* RKDictionaryUtilities.m */,
 				25C6C0E61716F79B00C98A73 /* RKOperationStateMachine.h */,
 				25C6C0E71716F79B00C98A73 /* RKOperationStateMachine.m */,
+				B96933AF1F1DF5D10025AB6F /* RKBooleanClass.h */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1731,6 +1734,7 @@
 				25160E4A145650490060A5C5 /* RKLog.h in Headers */,
 				25160E4C145650490060A5C5 /* RKMIMETypes.h in Headers */,
 				25160E4E145650490060A5C5 /* RKSerialization.h in Headers */,
+				B96933B01F1DF5D10025AB6F /* RKBooleanClass.h in Headers */,
 				25160E2E145650490060A5C5 /* RestKit.h in Headers */,
 				1689DAEF1B87CEA900254FB7 /* RKLumberjackLogger.h in Headers */,
 				25B408261491CDDC00F21111 /* RKPathUtilities.h in Headers */,


### PR DESCRIPTION
This pull request attempts to hide the use of `__NSCFBoolean` that apparently is not being digested well by Apple #2508 

I know it looks ugly, but as far as I understand, this shouldn't change the behaviour of what was in place previously.

It uses what has been suggested by @mkujalowicz.

Note: that `RKValueTransformer` is using the same private API (https://github.com/RestKit/RKValueTransformers/blob/master/Code/RKValueTransformers.m#L131-L132) so I don't exclude we may have to modify that too.

@honkmaster, @Shyam-Pgmr @mkujalowicz it would be great if you could try and submit your app with the version of RestKit on this branch, so we can see what Apple thinks about it, as I don't have any automated way of verifying the fix.

@blakewatters @segiddins I know it's a bit of a stretch, but it would be great if you could review it.