### PR TITLE
Method signature update

### DIFF
--- a/Code/Support/RKOperationStateMachine.h
+++ b/Code/Support/RKOperationStateMachine.h
@@ -148,7 +148,7 @@
  
  @param block The block to execute after acquiring an exclusive lock on the receiver.
  */
-- (void)performBlockWithLock:(void (^)())block;
+- (void)performBlockWithLock:(void (^)(void))block;
 
 @end
 

--- a/Code/Support/RKOperationStateMachine.m
+++ b/Code/Support/RKOperationStateMachine.m
@@ -199,7 +199,7 @@ static NSString *const RKOperationLockName = @"org.restkit.operation.lock";
             ([self isCancelled] ? @"YES" : @"NO")];
 }
 
-- (void)performBlockWithLock:(void (^)())block
+- (void)performBlockWithLock:(void (^)(void))block
 {
     [self.lock lock];
     block();


### PR DESCRIPTION
To fix Xcode 9 "The block declaration is not a prototype" warning