### PR TITLE
Fix missing performBlock's RKManagedObjectMappingOperationDataSource

### DIFF
--- a/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
+++ b/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
@@ -253,7 +253,12 @@ extern NSString * const RKObjectMappingNestingAttributeKeyName;
         if (existingObjectsOfRelationship && !RKObjectIsCollection(existingObjectsOfRelationship)) existingObjectsOfRelationship = @[ existingObjectsOfRelationship ];
         NSSet *setWithNull = [NSSet setWithObject:[NSNull null]];
         for (NSManagedObject *existingObject in existingObjectsOfRelationship) {
-            if(existingObject.isDeleted) {
+            __block BOOL isDeleted = NO;
+            [existingObject.managedObjectContext performBlockAndWait:^{
+                isDeleted = existingObject.isDeleted;
+            }];
+            
+            if(isDeleted) {
                 continue;
             }
             

--- a/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
+++ b/Code/CoreData/RKManagedObjectMappingOperationDataSource.m
@@ -268,7 +268,11 @@ extern NSString * const RKObjectMappingNestingAttributeKeyName;
                 break;
             }
             
-            NSDictionary *identificationAttributeValues = [existingObject dictionaryWithValuesForKeys:identificationAttributes];
+            __block NSDictionary *identificationAttributeValues;
+            [existingObject.managedObjectContext performBlockAndWait:^{
+                identificationAttributeValues = [existingObject dictionaryWithValuesForKeys:identificationAttributes];
+            }];
+
             if ([[NSSet setWithArray:[identificationAttributeValues allValues]] isEqualToSet:setWithNull]) {
                 managedObject = existingObject;
                 break;


### PR DESCRIPTION
I had '-com.apple.CoreData.ConcurrencyDebug 1' passed as launch argument and ran into two CoreData-AllThatIsLeftToUsIsHonor exceptions.