### PR TITLE
#2529 AFNetworking image view extension fixes

### DIFF
--- a/Code/Network/AFNetworking/UIImageView+AFRKNetworking.m
+++ b/Code/Network/AFNetworking/UIImageView+AFRKNetworking.m
@@ -104,7 +104,7 @@ static char kAFRKImageRequestOperationObjectKey;
         self.afrk_imageRequestOperation = nil;
 
         if (success) {
-            success(nil, nil, cachedImage);
+            success(urlRequest, nil, cachedImage);
         } else {
             self.image = cachedImage;
         }

--- a/RestKit.xcodeproj/project.pbxproj
+++ b/RestKit.xcodeproj/project.pbxproj
@@ -558,6 +558,8 @@
 		5C927E151608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C927E131608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m */; };
 		5CCC295615B7124A0045F0F5 /* RKMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CCC295515B7124A0045F0F5 /* RKMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5CCC295715B7124A0045F0F5 /* RKMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CCC295515B7124A0045F0F5 /* RKMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		60AABB68204A25D200E27367 /* AFRKNetworkingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AABB67204A25D200E27367 /* AFRKNetworkingTests.m */; };
+		60AABB69204A25D800E27367 /* AFRKNetworkingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AABB67204A25D200E27367 /* AFRKNetworkingTests.m */; };
 		73D3907414CA1AE00093E3D6 /* parent.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907114CA19F90093E3D6 /* parent.json */; };
 		73D3907514CA1AE20093E3D6 /* parent.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907114CA19F90093E3D6 /* parent.json */; };
 		73D3907614CA1AE60093E3D6 /* child.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D3907314CA1A4A0093E3D6 /* child.json */; };
@@ -938,6 +940,7 @@
 		5C927E131608FFFD00DC8B07 /* RKDictionaryUtilitiesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RKDictionaryUtilitiesTest.m; sourceTree = "<group>"; };
 		5CCC295515B7124A0045F0F5 /* RKMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKMacros.h; sourceTree = "<group>"; };
 		600765DB06173641BD7D6346 /* Pods-RestKitFrameworkTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RestKitFrameworkTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RestKitFrameworkTests/Pods-RestKitFrameworkTests.debug.xcconfig"; sourceTree = "<group>"; };
+		60AABB67204A25D200E27367 /* AFRKNetworkingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AFRKNetworkingTests.m; sourceTree = "<group>"; };
 		64ECC43055534E1492108E64 /* Pods_RestKitFrameworkTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RestKitFrameworkTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6519C4900327D3F205277C48 /* Pods-RestKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RestKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-RestKit/Pods-RestKit.release.xcconfig"; sourceTree = "<group>"; };
 		7394DF3514CF157A00CE7BCE /* RKManagedObjectCaching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RKManagedObjectCaching.h; sourceTree = "<group>"; };
@@ -1456,6 +1459,7 @@
 				2548AC6C162F5E00009E79BF /* RKManagedObjectRequestOperationTest.m */,
 				2536D1FC167270F100DF9BB0 /* RKRouterTest.m */,
 				2551338E167838590017E4B6 /* RKHTTPRequestOperationTest.m */,
+				60AABB67204A25D200E27367 /* AFRKNetworkingTests.m */,
 			);
 			name = Network;
 			path = Logic/Network;
@@ -2408,6 +2412,7 @@
 				2519764815824455004FE9DD /* RKRelationshipMappingTest.m in Sources */,
 				2519764C158244F8004FE9DD /* RKObjectMappingTest.m in Sources */,
 				25AA23D815AF5085006EF62D /* RKManagedObjectMappingOperationDataSourceTest.m in Sources */,
+				60AABB68204A25D200E27367 /* AFRKNetworkingTests.m in Sources */,
 				258EFF7A15C0CE1400EE4E0D /* RKManagedObjectSeederTest.m in Sources */,
 				25A763E515C7424500A9DF31 /* RKSearchIndexerTest.m in Sources */,
 				25C246A415C83B090032212E /* RKSearchTest.m in Sources */,
@@ -2541,6 +2546,7 @@
 				251610B71456F2330060A5C5 /* RKParent.m in Sources */,
 				251610B91456F2330060A5C5 /* RKResident.m in Sources */,
 				251610D31456F2330060A5C5 /* RKDynamicMappingTest.m in Sources */,
+				60AABB69204A25D800E27367 /* AFRKNetworkingTests.m in Sources */,
 				251610DD1456F2330060A5C5 /* RKObjectMappingNextGenTest.m in Sources */,
 				251610DF1456F2330060A5C5 /* RKMappingOperationTest.m in Sources */,
 				251610E31456F2330060A5C5 /* RKMappingResultTest.m in Sources */,

--- a/Tests/Logic/Network/AFRKNetworkingTests.m
+++ b/Tests/Logic/Network/AFRKNetworkingTests.m
@@ -23,12 +23,31 @@
 
 @interface AFRKNetworkingTests : XCTestCase
 
+@property (nonatomic, strong) UIImage *testImage;
+
 @end
 
 @implementation AFRKNetworkingTests
 
+#pragma mark - Lifecycle
+
+- (void)setUp
+{
+    [super setUp];
+    
+    self.testImage = [[UIImage alloc] init];
+}
+
+- (void)tearDown
+{
+    self.testImage = nil;
+    
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
+// Success block NSURLRequest parameter
 - (void)testSetImageWithURLReturnsURLRequestInCompletionBlockWhenImageIsFetchedFromCache
 {
     [self performMockCachedSetImageWithURLRequestCallWithSuccessAssertion:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
@@ -38,30 +57,38 @@
     }];
 }
 
+// Success block NSHTTPURLResponse parameter
 - (void)testSetImageWithURLReturnsNilURLResponseInCompletionBlockWhenImageIsFetchedFromCache
 {
-    
+    [self performMockCachedSetImageWithURLRequestCallWithSuccessAssertion:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
+        expect(response).to.equal(nil);
+    } failureAssertion:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+        failure(@"image request should always succeed for this test");
+    }];
 }
 
+// Success block UIImage parameter
 - (void)testSetImageWithURLReturnsImageInCompletionBlockWhenImageIsFetchedFromCache
 {
-    
+    [self performMockCachedSetImageWithURLRequestCallWithSuccessAssertion:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
+        expect(image).to.equal(self.testImage);
+    } failureAssertion:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+        failure(@"image request should always succeed for this test");
+    }];
 }
 
 #pragma mark - Private
 
 - (void)performMockCachedSetImageWithURLRequestCallWithSuccessAssertion:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))successAssertion failureAssertion:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failureAssertion
 {
-    // Act
-    // Create dummy request and image
+    // Arrange
+    // Create dummy request
     NSURL *imageURL = [[NSURL alloc] initWithString:@"https://test.com/image.png"];
     NSURLRequest *request = [[NSURLRequest alloc] initWithURL:imageURL];
     
-    UIImage *testImage = [[UIImage alloc] init];
-    
-    // Side-load the image into the cache
+    // Side-load the test image into the cache
     AFRKImageCache *cache = [UIImageView afrk_sharedImageCache];
-    [cache cacheImage:testImage forRequest:request];
+    [cache cacheImage:self.testImage forRequest:request];
     
     // Setup the System Under Test
     UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectZero];

--- a/Tests/Logic/Network/AFRKNetworkingTests.m
+++ b/Tests/Logic/Network/AFRKNetworkingTests.m
@@ -1,0 +1,58 @@
+//
+//  AFRKNetworkingTests.m
+//  RestKitTests
+//
+//  Created by Tyler Milner on 3/2/18.
+//  Copyright © 2018 RestKit. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "UIImageView+AFRKNetworking.h"
+
+// Re-defining the interface for AFRKImageCache since it's only privately declared in UIImageView+AFRKNetworking.m.
+@interface AFRKImageCache : NSCache
+- (UIImage *)cachedImageForRequest:(NSURLRequest *)request;
+- (void)cacheImage:(UIImage *)image
+        forRequest:(NSURLRequest *)request;
+@end
+
+// Also re-defining the interface for accessing the image cache since it's only privately declared in UIImageView+AFRKNetworking.m.
+@interface UIImageView (AFRKNetworking_Tests)
++ (AFRKImageCache *)afrk_sharedImageCache;
+@end
+
+@interface AFRKNetworkingTests : XCTestCase
+
+@end
+
+@implementation AFRKNetworkingTests
+
+- (void)testSetImageWithURLReturnsURLRequestInCompletionBlockWhenImageIsFetchedFromCache
+{
+    // Arrange
+    NSURL *imageURL = [[NSURL alloc] initWithString:@"https://test.com/image.png"];
+    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:imageURL];
+    
+    UIImage *testImage = [[UIImage alloc] init];
+    
+    AFRKImageCache *cache = [UIImageView afrk_sharedImageCache];
+    [cache cacheImage:testImage forRequest:request];
+    
+    UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectZero];
+    
+    // Act
+    XCTestExpectation *asyncExpectation = [self expectationWithDescription:@"image view loads"];
+    
+    [imageView setImageWithURLRequest:request placeholderImage:nil success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
+        XCTAssertNotNil(request);
+        [asyncExpectation fulfill];
+    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+        XCTFail("%@ should succeed", NSStringFromSelector(@selector(setImageWithURLRequest:placeholderImage:success:failure:)));
+        [asyncExpectation fulfill];
+    }];
+    
+    // Assert
+    [self waitForExpectationsWithTimeout:0.5 handler:nil];
+}
+
+@end

--- a/Tests/Logic/Network/AFRKNetworkingTests.m
+++ b/Tests/Logic/Network/AFRKNetworkingTests.m
@@ -6,7 +6,7 @@
 //  Copyright © 2018 RestKit. All rights reserved.
 //
 
-#import <XCTest/XCTest.h>
+#import "RKTestEnvironment.h"
 #import "UIImageView+AFRKNetworking.h"
 
 // Re-defining the interface for AFRKImageCache since it's only privately declared in UIImageView+AFRKNetworking.m.
@@ -27,31 +27,60 @@
 
 @implementation AFRKNetworkingTests
 
+#pragma mark - Tests
+
 - (void)testSetImageWithURLReturnsURLRequestInCompletionBlockWhenImageIsFetchedFromCache
 {
-    // Arrange
+    [self performMockCachedSetImageWithURLRequestCallWithSuccessAssertion:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
+        expect(request).toNot.equal(nil);
+    } failureAssertion:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+        failure(@"image request should always succeed for this test");
+    }];
+}
+
+- (void)testSetImageWithURLReturnsNilURLResponseInCompletionBlockWhenImageIsFetchedFromCache
+{
+    
+}
+
+- (void)testSetImageWithURLReturnsImageInCompletionBlockWhenImageIsFetchedFromCache
+{
+    
+}
+
+#pragma mark - Private
+
+- (void)performMockCachedSetImageWithURLRequestCallWithSuccessAssertion:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))successAssertion failureAssertion:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failureAssertion
+{
+    // Act
+    // Create dummy request and image
     NSURL *imageURL = [[NSURL alloc] initWithString:@"https://test.com/image.png"];
     NSURLRequest *request = [[NSURLRequest alloc] initWithURL:imageURL];
     
     UIImage *testImage = [[UIImage alloc] init];
     
+    // Side-load the image into the cache
     AFRKImageCache *cache = [UIImageView afrk_sharedImageCache];
     [cache cacheImage:testImage forRequest:request];
     
+    // Setup the System Under Test
     UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectZero];
     
     // Act
+    // Call 'setImageWithURLRequest:placeholderImage:success:failure:'
+    // Run the provided assertion blocks inside of their respective completion blocks
     XCTestExpectation *asyncExpectation = [self expectationWithDescription:@"image view loads"];
     
     [imageView setImageWithURLRequest:request placeholderImage:nil success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
-        XCTAssertNotNil(request);
+        successAssertion(request, response, image);
         [asyncExpectation fulfill];
     } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
-        XCTFail("%@ should succeed", NSStringFromSelector(@selector(setImageWithURLRequest:placeholderImage:success:failure:)));
+        failureAssertion(request, response, error);
         [asyncExpectation fulfill];
     }];
     
     // Assert
+    // Assertion blocks should have been run
     [self waitForExpectationsWithTimeout:0.5 handler:nil];
 }
 


### PR DESCRIPTION
Fixed #2529. The `success` block of `setImageWithURLRequest:placeholderImage:success:failure:` in the UIImageView extension bundled in the embedded AFNetworking library now returns the `NSURLRequest` when the image is fetched from the cache. This matches the current behavior of the official AFNetworking library.

I actually found this bug because my app had both libraries included (AFNetworking directly as well as RestKit). When rewriting an Obj-C extension of this behavior that added animation support into Swift, my app started crashing in non-debug builds because there was a mismatch between what the new Swift extension defined (non-nil `NSURLRequest`) and what was being returned (`nil`).

I fixed this bug and added some tests around the parameters in the `success` block of `setImageWithURLRequest:placeholderImage:success:failure:`. I had trouble installing the `nokogiri (1.8.0)` dependency when running `bundle install` to setup the testing environment. As such, most of the tests fail on my machine, but the ones I wrote pass! As such, this PR will likely fail CI tests until the testing environment is fixed.

This is my first PR on this repo. Just hoping to help out anyone else that has a similar issue down the road. Let me know if I need to change something.