### PR TITLE
Fixes #2531. Fixed namespace collision with the official AFNetworking…

### DIFF
--- a/Code/Network/AFNetworking/UIImageView+AFRKNetworking.h
+++ b/Code/Network/AFNetworking/UIImageView+AFRKNetworking.h
@@ -40,7 +40,7 @@
 
  @param url The URL used for the image request.
  */
-- (void)setImageWithURL:(NSURL *)url;
+- (void)afrk_setImageWithURL:(NSURL *)url;
 
 /**
  Creates and enqueues an image request operation, which asynchronously downloads the image from the specified URL. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
@@ -50,7 +50,7 @@
  @param url The URL used for the image request.
  @param placeholderImage The image to be set initially, until the image request finishes. If `nil`, the image view will not change its image until the image request finishes.
  */
-- (void)setImageWithURL:(NSURL *)url
+- (void)afrk_setImageWithURL:(NSURL *)url
        placeholderImage:(UIImage *)placeholderImage;
 
 /**
@@ -63,7 +63,7 @@
  @param success A block to be executed when the image request operation finishes successfully, with a status code in the 2xx range, and with an acceptable content type (e.g. `image/png`). This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the image created from the response data of request. If the image was returned from cache, the request and response parameters will be `nil`.
  @param failure A block object to be executed when the image request operation finishes unsuccessfully, or that finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the error object describing the network or parsing error that occurred.
  */
-- (void)setImageWithURLRequest:(NSURLRequest *)urlRequest
+- (void)afrk_setImageWithURLRequest:(NSURLRequest *)urlRequest
               placeholderImage:(UIImage *)placeholderImage
                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
@@ -71,7 +71,7 @@
 /**
  Cancels any executing image request operation for the receiver, if one exists.
  */
-- (void)cancelImageRequestOperation;
+- (void)afrk_cancelImageRequestOperation;
 
 @end
 

--- a/Code/Network/AFNetworking/UIImageView+AFRKNetworking.m
+++ b/Code/Network/AFNetworking/UIImageView+AFRKNetworking.m
@@ -79,25 +79,25 @@ static char kAFRKImageRequestOperationObjectKey;
 
 #pragma mark -
 
-- (void)setImageWithURL:(NSURL *)url {
-    [self setImageWithURL:url placeholderImage:nil];
+- (void)afrk_setImageWithURL:(NSURL *)url {
+    [self afrk_setImageWithURL:url placeholderImage:nil];
 }
 
-- (void)setImageWithURL:(NSURL *)url
+- (void)afrk_setImageWithURL:(NSURL *)url
        placeholderImage:(UIImage *)placeholderImage
 {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     [request addValue:@"image/*" forHTTPHeaderField:@"Accept"];
 
-    [self setImageWithURLRequest:request placeholderImage:placeholderImage success:nil failure:nil];
+    [self afrk_setImageWithURLRequest:request placeholderImage:placeholderImage success:nil failure:nil];
 }
 
-- (void)setImageWithURLRequest:(NSURLRequest *)urlRequest
+- (void)afrk_setImageWithURLRequest:(NSURLRequest *)urlRequest
               placeholderImage:(UIImage *)placeholderImage
                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
 {
-    [self cancelImageRequestOperation];
+    [self afrk_cancelImageRequestOperation];
 
     UIImage *cachedImage = [[[self class] afrk_sharedImageCache] cachedImageForRequest:urlRequest];
     if (cachedImage) {
@@ -151,7 +151,7 @@ static char kAFRKImageRequestOperationObjectKey;
     }
 }
 
-- (void)cancelImageRequestOperation {
+- (void)afrk_cancelImageRequestOperation {
     [self.afrk_imageRequestOperation cancel];
     self.afrk_imageRequestOperation = nil;
 }


### PR DESCRIPTION
Fixes #2531. Fixed namespace collision with the official AFNetworking library's implementation of the UIImageView helper category for setting an image from a URL. This will be a breaking change, but should help make people aware of potential unwanted behavior if their project includes both AFNetworking and RestKit.

I couldn't get the test suite to work on my machine, but none of these changes should have affected the tests. Let me know if there's anything else I can do!