### PR TITLE
Perform access to NSManagedObjectContext's properties only on its queue

### DIFF
--- a/Code/Search/RKSearchIndexer.m
+++ b/Code/Search/RKSearchIndexer.m
@@ -257,7 +257,11 @@ NSString * const RKSearchableAttributeNamesUserInfoKey = @"RestKitSearchableAttr
 {
     NSParameterAssert(managedObjectContext);
     
-    NSSet *candidateObjects = [[NSSet setWithSet:managedObjectContext.insertedObjects] setByAddingObjectsFromSet:managedObjectContext.updatedObjects];
+    __block NSSet *candidateObjects;
+    [managedObjectContext performBlockAndWait:^{
+        candidateObjects = [[NSSet setWithSet:managedObjectContext.insertedObjects] setByAddingObjectsFromSet:managedObjectContext.updatedObjects];
+    }];
+    
     NSSet *objectsToIndex = [self objectsToIndexFromCandidateObjects:candidateObjects checkChangedValues:YES];
     
     if (wait) {

--- a/Tests/Logic/ObjectMapping/RKObjectManagerTest.m
+++ b/Tests/Logic/ObjectMapping/RKObjectManagerTest.m
@@ -988,6 +988,30 @@
     expect(caughtException).notTo.beNil();
 }
 
+- (void)testForConcurrencyIssueCausedByAccessingInsertedObjectsProperty {
+    NSManagedObjectContext *managedObjectContext = [[RKTestFactory managedObjectStore] persistentStoreManagedObjectContext];
+    
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+        for (NSInteger i = 0; i < 1000; ++i) {
+            RKHuman *temporaryHuman = [RKTestFactory insertManagedObjectForEntityForName:@"Human" inManagedObjectContext:managedObjectContext withProperties:nil];
+            temporaryHuman.name = @"My Name";
+        }
+        
+        dispatch_semaphore_signal(sem);
+    });
+    
+    RKHuman *temporaryHuman = [RKTestFactory insertManagedObjectForEntityForName:@"Human" inManagedObjectContext:managedObjectContext withProperties:nil];
+    temporaryHuman.name = @"My Name";
+    
+    for (NSInteger i = 0; i < 1000; ++i) {
+        [_objectManager appropriateObjectRequestOperationWithObject:temporaryHuman method:RKRequestMethodGET path:nil parameters:nil];
+    }
+    
+    dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+}
+
 #pragma mark - Object Request Operation Registration
 
 - (void)testRegistrationOfObjectRequestOperationClass


### PR DESCRIPTION
Hi!

I found a few places where wrong accessing to NSManagedObjectContext's properties is performing. We must access it's properties only on the queue otherwise we will faced with concurrency problems.