### PR TITLE
ios 12 crash, entity is not visible to managedObject context

### DIFF
--- a/Code/CoreData/RKEntityByAttributeCache.m
+++ b/Code/CoreData/RKEntityByAttributeCache.m
@@ -153,7 +153,12 @@ static NSArray *RKCacheKeysForEntityFromAttributeValues(NSEntityDescription *ent
 
     [self.managedObjectContext performBlock:^{
         NSError *error = nil;
-        NSArray *dictionaries = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
+        NSArray *dictionaries;
+        @try {
+            dictionaries = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
+        } @catch (NSException *exception) {
+            NSLog(@"%@", exception.reason);
+        }
         if (dictionaries) {
             RKLogDebug(@"Retrieved %ld dictionaries for cachable `NSManagedObjectID` objects with fetch request: %@", (long) [dictionaries count], fetchRequest);
         } else {

--- a/RestKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/RestKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
this error is only for ios 12 