### PR TITLE
Replaced NSURLConnection with NSURLSession

### DIFF
--- a/Code/Network/AFNetworking/AFRKURLConnectionOperation.h
+++ b/Code/Network/AFNetworking/AFRKURLConnectionOperation.h
@@ -214,6 +214,20 @@ NSCoding, NSCopying>
  */
 - (id)initWithRequest:(NSURLRequest *)urlRequest;
 
+///------------------------------------------------------
+/// @name Initializing an AFURLConnectionOperation Object
+///------------------------------------------------------
+
+/**
+ Initializes and returns a newly allocated operation object with a url connection configured with the specified url request.
+ 
+ This is the designated initializer.
+ 
+ @param urlRequest The request object to be used by the operation connection.
+ @param sessionConfiguration The session configuration object that defines the behavior of the NSURLSession
+ */
+- (id)initWithRequest:(NSURLRequest *)urlRequest sessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration;
+
 ///----------------------------------
 /// @name Pausing / Resuming Requests
 ///----------------------------------

--- a/Code/Network/AFNetworking/AFRKURLConnectionOperation.h
+++ b/Code/Network/AFNetworking/AFRKURLConnectionOperation.h
@@ -114,6 +114,11 @@ NSCoding, NSCopying>
 @property (readonly, nonatomic, strong) NSURLRequest *request;
 
 /**
+ The object that coordinates the related network data transfer tasks.
+ */
+@property (readwrite, nonatomic, strong) NSURLSession *session;
+
+/**
  The last response received by the operation's connection.
  */
 @property (readonly, nonatomic, strong) NSURLResponse *response;

--- a/Code/Network/AFNetworking/AFRKURLConnectionOperation.h
+++ b/Code/Network/AFNetworking/AFRKURLConnectionOperation.h
@@ -25,37 +25,37 @@
 #import <Availability.h>
 
 /**
- `AFURLConnectionOperation` is a subclass of `NSOperation` that implements `NSURLConnection` delegate methods.
-
+ `AFURLConnectionOperation` is a subclass of `NSOperation` that implements `NSURLSession` delegate methods.
+ 
  ## Subclassing Notes
-
- This is the base class of all network request operations. You may wish to create your own subclass in order to implement additional `NSURLConnection` delegate methods (see "`NSURLConnection` Delegate Methods" below), or to provide additional properties and/or class constructors.
-
+ 
+ This is the base class of all network request operations. You may wish to create your own subclass in order to implement additional `NSURLSession` delegate methods (see "`NSURLSession` Delegate Methods" below), or to provide additional properties and/or class constructors.
+ 
  If you are creating a subclass that communicates over the HTTP or HTTPS protocols, you may want to consider subclassing `AFHTTPRequestOperation` instead, as it supports specifying acceptable content types or status codes.
-
- ## NSURLConnection Delegate Methods
-
- `AFURLConnectionOperation` implements the following `NSURLConnection` delegate methods:
-
- - `connection:didReceiveResponse:`
- - `connection:didReceiveData:`
- - `connectionDidFinishLoading:`
- - `connection:didFailWithError:`
- - `connection:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite:`
- - `connection:willCacheResponse:`
- - `connectionShouldUseCredentialStorage:`
- - `connection:willSendRequestForAuthenticationChallenge:`
-
+ 
+ ## NSURLSession Delegate Methods
+ 
+ `AFURLConnectionOperation` implements the following `NSURLSession` delegate methods:
+ 
+ - `URLSession:didReceiveChallenge:completionHandler:`
+ - `URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:`
+ - `URLSession:task:didSendBodyData:totalBytesSent:`
+ - `URLSession:dataTask:didReceiveResponse:completionHandler:`
+ - `URLSession:dataTask:didReceiveData:`
+ - `URLSession:task:didCompleteWithError:`
+ - `URLSession:didBecomeInvalidWithError:`
+ - `URLSession:dataTask:willCacheResponse:completionHandler:`
+ 
  If any of these methods are overridden in a subclass, they _must_ call the `super` implementation first.
-
+ 
  ## Class Constructors
-
+ 
  Class constructors, or methods that return an unowned instance, are the preferred way for subclasses to encapsulate any particular logic for handling the setup or parsing of response data. For instance, `AFJSONRequestOperation` provides `JSONRequestOperationWithRequest:success:failure:`, which takes block arguments, whose parameter on for a successful request is the JSON object initialized from the `response data`.
-
+ 
  ## Callbacks and Completion Blocks
-
+ 
  The built-in `completionBlock` provided by `NSOperation` allows for custom behavior to be executed after the request finishes. It is a common pattern for class constructors in subclasses to take callback block parameters, and execute them conditionally in the body of its `completionBlock`. Make sure to handle cancelled operations appropriately when setting a `completionBlock` (i.e. returning early before parsing response data). See the implementation of any of the `AFHTTPRequestOperation` subclasses for an example of this.
-
+ 
  Subclasses are strongly discouraged from overriding `setCompletionBlock:`, as `AFURLConnectionOperation`'s implementation includes a workaround to mitigate retain cycles, and what Apple rather ominously refers to as ["The Deallocation Problem"](http://developer.apple.com/library/ios/#technotes/tn2109/).
  
  ## SSL Pinning
@@ -63,20 +63,20 @@
  Relying on the CA trust model to validate SSL certificates exposes your app to security vulnerabilities, such as man-in-the-middle attacks. For applications that connect to known servers, SSL certificate pinning provides an increased level of security, by checking server certificate validity against those specified in the app bundle.
  
  SSL with certificate pinning is strongly recommended for any application that transmits sensitive information to an external webservice.
-
+ 
  When `defaultSSLPinningMode` is defined on `AFHTTPClient` and the Security framework is linked, connections will be validated on all matching certificates with a `.cer` extension in the bundle root.
-
+ 
  ## NSCoding & NSCopying Conformance
-
+ 
  `AFURLConnectionOperation` conforms to the `NSCoding` and `NSCopying` protocols, allowing operations to be archived to disk, and copied in memory, respectively. However, because of the intrinsic limitations of capturing the exact state of an operation at a particular moment, there are some important caveats to keep in mind:
-
+ 
  ### NSCoding Caveats
-
+ 
  - Encoded operations do not include any block or stream properties. Be sure to set `completionBlock`, `outputStream`, and any callback blocks as necessary when using `-initWithCoder:` or `NSKeyedUnarchiver`.
  - Operations are paused on `encodeWithCoder:`. If the operation was encoded while paused or still executing, its archived state will return `YES` for `isReady`. Otherwise, the state of an operation when encoding will remain unchanged.
-
+ 
  ### NSCopying Caveats
-
+ 
  - `-copy` and `-copyWithZone:` return a new operation with the `NSURLRequest` of the original. So rather than an exact copy of the operation at that particular instant, the copying mechanism returns a completely new instance, which can be useful for retrying operations.
  - A copy of an operation will not include the `outputStream` of the original.
  - Operation copies do not include `completionBlock`. `completionBlock` often strongly captures a reference to `self`, which would otherwise have the unintuitive side-effect of pointing to the _original_ operation when copied.
@@ -88,10 +88,10 @@ typedef enum {
     AFRKSSLPinningModeCertificate,
 } AFRKURLConnectionOperationSSLPinningMode;
 
-@interface AFRKURLConnectionOperation : NSOperation <NSURLConnectionDelegate,
-#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000) || \
-    (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1080)
-NSURLConnectionDataDelegate, 
+@interface AFRKURLConnectionOperation : NSOperation <NSURLSessionDelegate,
+#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000) || \
+(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1080)
+NSURLSessionDataDelegate, NSURLSessionTaskDelegate,
 #endif
 NSCoding, NSCopying>
 
@@ -146,7 +146,7 @@ NSCoding, NSCopying>
 
 /**
  The string encoding of the response.
-
+ 
  If the response does not specify a valid string encoding, `responseStringEncoding` will return `NSUTF8StringEncoding`.
  */
 @property (readonly, nonatomic, assign) NSStringEncoding responseStringEncoding;
@@ -156,15 +156,8 @@ NSCoding, NSCopying>
 ///-------------------------------
 
 /**
- Whether the URL connection should consult the credential storage for authenticating the connection. `YES` by default.
-
- This is the value that is returned in the `NSURLConnectionDelegate` method `-connectionShouldUseCredentialStorage:`.
- */
-@property (nonatomic, assign) BOOL shouldUseCredentialStorage;
-
-/**
  The credential used for authentication challenges in `-connection:didReceiveAuthenticationChallenge:`.
-
+ 
  This will be overridden by any shared credentials that exist for the username or password of the request URL, if present.
  */
 @property (nonatomic, strong) NSURLCredential *credential;
@@ -182,14 +175,14 @@ NSCoding, NSCopying>
 
 /**
  The input stream used to read data to be sent during the request.
-
+ 
  This property acts as a proxy to the `HTTPBodyStream` property of `request`.
  */
 @property (nonatomic, strong) NSInputStream *inputStream;
 
 /**
  The output stream that is used to write data received until the request is finished.
-
+ 
  By default, data is accumulated into a buffer that is stored into `responseData` upon completion of the request. When `outputStream` is set, the data will not be accumulated into an internal buffer, and as a result, the `responseData` property of the completed request will be `nil`. The output stream will be scheduled in the network thread runloop upon being set.
  */
 @property (nonatomic, strong) NSOutputStream *outputStream;
@@ -222,21 +215,21 @@ NSCoding, NSCopying>
 
 /**
  Pauses the execution of the request operation.
-
+ 
  A paused operation returns `NO` for `-isReady`, `-isExecuting`, and `-isFinished`. As such, it will remain in an `NSOperationQueue` until it is either cancelled or resumed. Pausing a finished, cancelled, or paused operation has no effect.
  */
 - (void)pause;
 
 /**
  Whether the request operation is currently paused.
-
+ 
  @return `YES` if the operation is currently paused, otherwise `NO`.
  */
 - (BOOL)isPaused;
 
 /**
  Resumes the execution of the paused request operation.
-
+ 
  Pause/Resume behavior varies depending on the underlying implementation for the operation class. In its base implementation, resuming a paused requests restarts the original request. However, since HTTP defines a specification for how to request a specific content range, `AFHTTPRequestOperation` will resume downloading the request from where it left off, instead of restarting the original request.
  */
 - (void)resume;
@@ -247,7 +240,7 @@ NSCoding, NSCopying>
 
 /**
  Specifies that the operation should continue execution after the app has entered the background, and the expiration handler for that background task.
-
+ 
  @param handler A handler to be called shortly before the application’s remaining background time reaches 0. The handler is wrapped in a block that cancels the operation, and cleans up and marks the end of execution, unlike the `handler` parameter in `UIApplication -beginBackgroundTaskWithExpirationHandler:`, which expects this to be done in the handler itself. The handler is called synchronously on the main thread, thus blocking the application’s suspension momentarily while the application is notified.
  */
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
@@ -260,44 +253,44 @@ NSCoding, NSCopying>
 
 /**
  Sets a callback to be called when an undetermined number of bytes have been uploaded to the server.
-
+ 
  @param block A block object to be called when an undetermined number of bytes have been uploaded to the server. This block has no return value and takes three arguments: the number of bytes written since the last time the upload progress block was called, the total bytes written, and the total bytes expected to be written during the request, as initially determined by the length of the HTTP body. This block may be called multiple times, and will execute on the main thread.
  */
 - (void)setUploadProgressBlock:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))block;
 
 /**
  Sets a callback to be called when an undetermined number of bytes have been downloaded from the server.
-
+ 
  @param block A block object to be called when an undetermined number of bytes have been downloaded from the server. This block has no return value and takes three arguments: the number of bytes read since the last time the download progress block was called, the total bytes read, and the total bytes expected to be read during the request, as initially determined by the expected content size of the `NSHTTPURLResponse` object. This block may be called multiple times, and will execute on the main thread.
  */
 - (void)setDownloadProgressBlock:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))block;
 
 ///-------------------------------------------------
-/// @name Setting NSURLConnection Delegate Callbacks
+/// @name Setting NSURLSession Delegate Callbacks
 ///-------------------------------------------------
 
 /**
- Sets a block to be executed when the connection will authenticate a challenge in order to download its request, as handled by the `NSURLConnectionDelegate` method `connection:willSendRequestForAuthenticationChallenge:`.
+ Sets a block to be executed when the connection will authenticate a challenge in order to download its request, as handled by the `NSURLSessionDelegate` method `URLSession:didReceiveChallenge:completionHandler:`.
  
  @param block A block object to be executed when the connection will authenticate a challenge in order to download its request. The block has no return type and takes two arguments: the URL connection object, and the challenge that must be authenticated. This block must invoke one of the challenge-responder methods (NSURLAuthenticationChallengeSender protocol).
  
  If `allowsInvalidSSLCertificate` is set to YES, `connection:willSendRequestForAuthenticationChallenge:` will attempt to have the challenge sender use credentials with invalid SSL certificates.
  */
-- (void)setWillSendRequestForAuthenticationChallengeBlock:(void (^)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge))block;
+- (void)setWillSendRequestForAuthenticationChallengeBlock:(void (^)(NSURLSession *session, NSURLAuthenticationChallenge *challenge))block;
 
 /**
- Sets a block to be executed when the server redirects the request from one URL to another URL, or when the request URL changed by the `NSURLProtocol` subclass handling the request in order to standardize its format, as handled by the `NSURLConnectionDelegate` method `connection:willSendRequest:redirectResponse:`.
-
+ Sets a block to be executed when the server redirects the request from one URL to another URL, or when the request URL changed by the `NSURLProtocol` subclass handling the request in order to standardize its format, as handled by the `NSURLSessionTaskDelegate` method `URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler`.
+ 
  @param block A block object to be executed when the request URL was changed. The block returns an `NSURLRequest` object, the URL request to redirect, and takes three arguments: the URL connection object, the the proposed redirected request, and the URL response that caused the redirect.
  */
-- (void)setRedirectResponseBlock:(NSURLRequest * (^)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse))block;
+- (void)setRedirectResponseBlock:(NSURLRequest * (^)(NSURLSession *session, NSURLRequest *request, NSURLResponse *redirectResponse))block;
 
 /**
- Sets a block to be executed to modify the response a connection will cache, if any, as handled by the `NSURLConnectionDelegate` method `connection:willCacheResponse:`.
-
+ Sets a block to be executed to modify the response a connection will cache, if any, as handled by the `NSURLSessionDataDelegate` method `URLSession:dataTask:willCacheResponse:completionHandler`.
+ 
  @param block A block object to be executed to determine what response a connection will cache, if any. The block returns an `NSCachedURLResponse` object, the cached response to store in memory or `nil` to prevent the response from being cached, and takes two arguments: the URL connection object, and the cached response provided for the request.
  */
-- (void)setCacheResponseBlock:(NSCachedURLResponse * (^)(NSURLConnection *connection, NSCachedURLResponse *cachedResponse))block;
+- (void)setCacheResponseBlock:(NSCachedURLResponse * (^)(NSURLSession *session, NSCachedURLResponse *cachedResponse))block;
 
 @end
 
@@ -307,9 +300,9 @@ NSCoding, NSCopying>
 
 /**
  ## SSL Pinning Options
-
+ 
  The following constants are provided by `AFURLConnectionOperation` as possible SSL Pinning options.
-
+ 
  enum {
  AFSSLPinningModeNone,
  AFSSLPinningModePublicKey,
@@ -318,36 +311,36 @@ NSCoding, NSCopying>
  
  `AFSSLPinningModeNone`
  Do not pin SSL connections
-
+ 
  `AFSSLPinningModePublicKey`
  Pin SSL connections to certificate public key (SPKI).
-
+ 
  `AFSSLPinningModeCertificate`
  Pin SSL connections to exact certificate. This may cause problems when your certificate expires and needs re-issuance.
-
+ 
  ## User info dictionary keys
-
+ 
  These keys may exist in the user info dictionary, in addition to those defined for NSError.
-
+ 
  - `NSString * const AFNetworkingOperationFailingURLRequestErrorKey`
  - `NSString * const AFNetworkingOperationFailingURLResponseErrorKey`
-
+ 
  ### Constants
-
+ 
  `AFNetworkingOperationFailingURLRequestErrorKey`
  The corresponding value is an `NSURLRequest` containing the request of the operation associated with an error. This key is only present in the `AFNetworkingErrorDomain`.
-
+ 
  `AFNetworkingOperationFailingURLResponseErrorKey`
  The corresponding value is an `NSURLResponse` containing the response of the operation associated with an error. This key is only present in the `AFNetworkingErrorDomain`.
-
+ 
  ## Error Domains
-
+ 
  The following error domain is predefined.
-
+ 
  - `NSString * const AFNetworkingErrorDomain`
-
+ 
  ### Constants
-
+ 
  `AFNetworkingErrorDomain`
  AFNetworking errors. Error codes for `AFNetworkingErrorDomain` correspond to codes in `NSURLErrorDomain`.
  */

--- a/Code/Network/AFNetworking/AFRKURLConnectionOperation.h
+++ b/Code/Network/AFNetworking/AFRKURLConnectionOperation.h
@@ -214,20 +214,6 @@ NSCoding, NSCopying>
  */
 - (id)initWithRequest:(NSURLRequest *)urlRequest;
 
-///------------------------------------------------------
-/// @name Initializing an AFURLConnectionOperation Object
-///------------------------------------------------------
-
-/**
- Initializes and returns a newly allocated operation object with a url connection configured with the specified url request.
- 
- This is the designated initializer.
- 
- @param urlRequest The request object to be used by the operation connection.
- @param sessionConfiguration The session configuration object that defines the behavior of the NSURLSession
- */
-- (id)initWithRequest:(NSURLRequest *)urlRequest sessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration;
-
 ///----------------------------------
 /// @name Pausing / Resuming Requests
 ///----------------------------------

--- a/Code/Network/AFNetworking/AFRKURLConnectionOperation.m
+++ b/Code/Network/AFNetworking/AFRKURLConnectionOperation.m
@@ -135,7 +135,6 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 @property (readwrite, nonatomic, assign) AFRKOperationState state;
 @property (readwrite, nonatomic, assign, getter = isCancelled) BOOL cancelled;
 @property (readwrite, nonatomic, strong) NSRecursiveLock *lock;
-@property (readwrite, nonatomic, strong) NSURLSession *session;
 @property (readwrite, nonatomic, strong) NSURLSessionDataTask *sessionTask;
 
 @property (readwrite, nonatomic, strong) NSURLRequest *request;

--- a/Code/Network/AFNetworking/AFRKURLConnectionOperation.m
+++ b/Code/Network/AFNetworking/AFRKURLConnectionOperation.m
@@ -150,7 +150,6 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 @property (readwrite, nonatomic, copy) AFRKURLConnectionOperationAuthenticationChallengeBlock authenticationChallenge;
 @property (readwrite, nonatomic, copy) AFRKURLConnectionOperationCacheResponseBlock cacheResponse;
 @property (readwrite, nonatomic, copy) AFRKURLConnectionOperationRedirectResponseBlock redirectResponse;
-@property (readwrite, nonatomic, strong) NSURLSessionConfiguration *sessionConfiguration;
 
 - (void)operationDidStart;
 - (void)finish;
@@ -282,7 +281,8 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
     self.runLoopModes = [NSSet setWithObject:NSRunLoopCommonModes];
     
     self.request = urlRequest;
-    [self setSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    NSURLSessionConfiguration *defaultConfigurationObject = [NSURLSessionConfiguration defaultSessionConfiguration];
+    self.session = [NSURLSession sessionWithConfiguration:defaultConfigurationObject delegate:self delegateQueue: nil];
     
     // #ifdef included for backwards-compatibility
 #ifdef _AFRKNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
@@ -290,35 +290,6 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 #endif
     
     self.state = AFRKOperationReadyState;
-    
-    return self;
-}
-
-- (id)initWithRequest:(NSURLRequest *)urlRequest sessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration {
-    NSParameterAssert(urlRequest);
-    
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    
-    self.lock = [[NSRecursiveLock alloc] init];
-    self.lock.name = kAFRKNetworkingLockName;
-    
-    self.runLoopModes = [NSSet setWithObject:NSRunLoopCommonModes];
-    
-    self.request = urlRequest;
-    
-    if (!sessionConfiguration) {
-        self.sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    } else {
-        self.sessionConfiguration = sessionConfiguration;
-    }
-    
-    // #ifdef included for backwards-compatibility
-#ifdef _AFRKNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
-    self.allowsInvalidSSLCertificate = YES;
-#endif
     
     return self;
 }
@@ -355,12 +326,6 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
         }];
     }
     [self.lock unlock];
-}
-
-- (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration {
-    _sessionConfiguration = sessionConfiguration;
-    self.session = [NSURLSession sessionWithConfiguration:sessionConfiguration delegate:self delegateQueue: nil];
-    self.state = AFRKOperationReadyState;
 }
 
 - (NSInputStream *)inputStream {

--- a/Code/Network/AFNetworking/AFRKURLConnectionOperation.m
+++ b/Code/Network/AFNetworking/AFRKURLConnectionOperation.m
@@ -56,9 +56,11 @@ NSString * const AFRKNetworkingOperationDidStartNotification = @"com.restkit.ala
 NSString * const AFRKNetworkingOperationDidFinishNotification = @"com.restkit.alamofire.networking.operation.finish";
 
 typedef void (^AFRKURLConnectionOperationProgressBlock)(NSUInteger bytes, long long totalBytes, long long totalBytesExpected);
-typedef void (^AFRKURLConnectionOperationAuthenticationChallengeBlock)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge);
-typedef NSCachedURLResponse * (^AFRKURLConnectionOperationCacheResponseBlock)(NSURLConnection *connection, NSCachedURLResponse *cachedResponse);
-typedef NSURLRequest * (^AFRKURLConnectionOperationRedirectResponseBlock)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse);
+
+typedef void (^AFRKURLConnectionOperationAuthenticationChallengeBlock)(NSURLSession *session, NSURLAuthenticationChallenge *challenge);
+typedef NSCachedURLResponse * (^AFRKURLConnectionOperationCacheResponseBlock)(NSURLSession *session, NSCachedURLResponse *cachedResponse);
+typedef NSURLRequest * (^AFRKURLConnectionOperationRedirectResponseBlock)(NSURLSession *session, NSURLRequest *request, NSURLResponse *redirectResponse);
+
 
 static inline NSString * AFRKKeyPathFromOperationState(AFRKOperationState state) {
     switch (state) {
@@ -114,7 +116,7 @@ static NSData *AFRKSecKeyGetData(SecKeyRef key) {
     OSStatus status = SecItemExport(key, kSecFormatUnknown, kSecItemPemArmour, NULL, &data);
     NSCAssert(status == errSecSuccess, @"SecItemExport error: %ld", (long int)status);
 #endif
-
+    
     NSCParameterAssert(data);
     
     return (__bridge_transfer NSData *)data;
@@ -133,7 +135,9 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 @property (readwrite, nonatomic, assign) AFRKOperationState state;
 @property (readwrite, nonatomic, assign, getter = isCancelled) BOOL cancelled;
 @property (readwrite, nonatomic, strong) NSRecursiveLock *lock;
-@property (readwrite, nonatomic, strong) NSURLConnection *connection;
+@property (readwrite, nonatomic, strong) NSURLSession *session;
+@property (readwrite, nonatomic, strong) NSURLSessionDataTask *sessionTask;
+
 @property (readwrite, nonatomic, strong) NSURLRequest *request;
 @property (readwrite, nonatomic, strong) NSURLResponse *response;
 @property (readwrite, nonatomic, strong) NSError *error;
@@ -156,7 +160,8 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 @implementation AFRKURLConnectionOperation
 @synthesize state = _state;
 @synthesize cancelled = _cancelled;
-@synthesize connection = _connection;
+@synthesize session = _session;
+@synthesize sessionTask = _sessionTask;
 @synthesize runLoopModes = _runLoopModes;
 @synthesize request = _request;
 @synthesize response = _response;
@@ -170,7 +175,6 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 @synthesize outputStream = _outputStream;
 @synthesize credential = _credential;
 @synthesize SSLPinningMode = _SSLPinningMode;
-@synthesize shouldUseCredentialStorage = _shouldUseCredentialStorage;
 @synthesize userInfo = _userInfo;
 @synthesize backgroundTaskIdentifier = _backgroundTaskIdentifier;
 @synthesize uploadProgress = _uploadProgress;
@@ -183,7 +187,7 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 + (void)networkRequestThreadEntryPoint:(id __unused)object {
     @autoreleasepool {
         [[NSThread currentThread] setName:@"AFRKNetworking"];
-
+        
         NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
         [runLoop addPort:[NSMachPort port] forMode:NSDefaultRunLoopMode];
         [runLoop run];
@@ -251,7 +255,7 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
                 }
                 
                 CFRelease(allowedTrust);
-            }          
+            }
             
             CFRelease(policy);
             CFRelease(certificates);
@@ -266,10 +270,10 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 
 - (id)initWithRequest:(NSURLRequest *)urlRequest {
     NSParameterAssert(urlRequest);
-
+    
     self = [super init];
     if (!self) {
-		return nil;
+        return nil;
     }
     
     self.lock = [[NSRecursiveLock alloc] init];
@@ -278,16 +282,16 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
     self.runLoopModes = [NSSet setWithObject:NSRunLoopCommonModes];
     
     self.request = urlRequest;
+    NSURLSessionConfiguration *defaultConfigurationObject = [NSURLSessionConfiguration defaultSessionConfiguration];
+    self.session = [NSURLSession sessionWithConfiguration:defaultConfigurationObject delegate:self delegateQueue: nil];
     
-    self.shouldUseCredentialStorage = YES;
-
-    // #ifdef included for backwards-compatibility 
+    // #ifdef included for backwards-compatibility
 #ifdef _AFRKNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
     self.allowsInvalidSSLCertificate = YES;
 #endif
-
+    
     self.state = AFRKOperationReadyState;
-
+    
     return self;
 }
 
@@ -341,7 +345,7 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
     if (!_outputStream) {
         self.outputStream = [NSOutputStream outputStreamToMemory];
     }
-
+    
     return _outputStream;
 }
 
@@ -391,15 +395,15 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
     self.downloadProgress = block;
 }
 
-- (void)setWillSendRequestForAuthenticationChallengeBlock:(void (^)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge))block {
+- (void)setWillSendRequestForAuthenticationChallengeBlock:(void (^)(NSURLSession *session, NSURLAuthenticationChallenge *challenge))block {
     self.authenticationChallenge = block;
 }
 
-- (void)setCacheResponseBlock:(NSCachedURLResponse * (^)(NSURLConnection *connection, NSCachedURLResponse *cachedResponse))block {
+- (void)setCacheResponseBlock:(NSCachedURLResponse * (^)(NSURLSession *session, NSCachedURLResponse *cachedResponse))block {
     self.cacheResponse = block;
 }
 
-- (void)setRedirectResponseBlock:(NSURLRequest * (^)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse))block {
+- (void)setRedirectResponseBlock:(NSURLRequest * (^)(NSURLSession *session, NSURLRequest *request, NSURLResponse *redirectResponse))block {
     self.redirectResponse = block;
 }
 
@@ -456,7 +460,7 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
     [self.lock lock];
     
     if ([self isExecuting]) {
-        [self.connection performSelector:@selector(cancel) onThread:[[self class] networkRequestThread] withObject:nil waitUntilDone:NO modes:[self.runLoopModes allObjects]];
+        [self.sessionTask performSelector:@selector(cancel) onThread:[[self class] networkRequestThread] withObject:nil waitUntilDone:NO modes:[self.runLoopModes allObjects]];
         
         dispatch_async(dispatch_get_main_queue(), ^{
             NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
@@ -516,15 +520,14 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 - (void)operationDidStart {
     [self.lock lock];
     if (![self isCancelled]) {
-        self.connection = [[NSURLConnection alloc] initWithRequest:self.request delegate:self startImmediately:NO];
+        self.sessionTask = [self.session dataTaskWithRequest:self.request];
         
         NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
         for (NSString *runLoopMode in self.runLoopModes) {
-            [self.connection scheduleInRunLoop:runLoop forMode:runLoopMode];
             [self.outputStream scheduleInRunLoop:runLoop forMode:runLoopMode];
         }
         
-        [self.connection start];
+        [self.sessionTask resume];
     }
     [self.lock unlock];
     
@@ -538,7 +541,7 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
             userInfo = [NSDictionary dictionaryWithObject:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
         }
         self.error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo];
-
+        
         [self finish];
     }
 }
@@ -572,19 +575,17 @@ static BOOL AFRKSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
     }
     NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo];
     
-    if (![self isFinished] && self.connection) {
-        [self.connection cancel];
-        [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:error];
+    if (![self isFinished] && self.sessionTask) {
+        [self.sessionTask cancel];
+        [self performSelector:@selector(URLSession:didBecomeInvalidWithError:) withObject:self.sessionTask withObject:error];
     }
 }
 
-#pragma mark - NSURLConnectionDelegate
+#pragma mark - NSURLSessionDelegate
 
-- (void)connection:(NSURLConnection *)connection
-willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
-{
+- (void)URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable credential))completionHandler {
     if (self.authenticationChallenge) {
-        self.authenticationChallenge(connection, challenge);
+        self.authenticationChallenge(session, challenge);
         return;
     }
     
@@ -592,7 +593,8 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
         SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
         
         SecPolicyRef policy = SecPolicyCreateBasicX509();
-        SecTrustEvaluate(serverTrust, NULL);
+        SecTrustResultType result;
+        SecTrustEvaluate(serverTrust, &result);
         CFIndex certificateCount = SecTrustGetCertificateCount(serverTrust);
         NSMutableArray *trustChain = [NSMutableArray arrayWithCapacity:certificateCount];
         
@@ -616,10 +618,10 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
                     if (status == errSecSuccess) {
                         [trustChain addObject:(__bridge_transfer id)SecTrustCopyPublicKey(trust)];
                     }
-
+                    
                     CFRelease(trust);
                 }
-              
+                
                 CFRelease(certificates);
             }
         }
@@ -630,7 +632,7 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
             case AFRKSSLPinningModePublicKey: {
                 NSArray *pinnedPublicKeys = [self.class pinnedPublicKeys];
                 NSAssert([pinnedPublicKeys count] > 0, @"AFRKSSLPinningModePublicKey needs at least one key file in the application bundle");
-
+                
                 for (id publicKey in trustChain) {
                     for (id pinnedPublicKey in pinnedPublicKeys) {
                         if (AFRKSecKeyIsEqualToKey((__bridge SecKeyRef)publicKey, (__bridge SecKeyRef)pinnedPublicKey)) {
@@ -691,66 +693,52 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
     }
 }
 
-- (BOOL)connectionShouldUseCredentialStorage:(NSURLConnection __unused *)connection {
-    return self.shouldUseCredentialStorage;
-}
-
-- (NSURLRequest *)connection:(NSURLConnection *)connection
-             willSendRequest:(NSURLRequest *)request
-            redirectResponse:(NSURLResponse *)redirectResponse
-{
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
     if (self.redirectResponse) {
-        return self.redirectResponse(connection, request, redirectResponse);
+        completionHandler(self.redirectResponse(session, request, response));
     } else {
-        return request;
+        completionHandler(request);
     }
 }
 
-- (void)connection:(NSURLConnection __unused *)connection
-   didSendBodyData:(NSInteger)bytesWritten
- totalBytesWritten:(NSInteger)totalBytesWritten
-totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite
-{
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
     if (self.uploadProgress) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            self.uploadProgress((NSUInteger)bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
+            self.uploadProgress((NSUInteger)bytesSent, totalBytesSent, totalBytesExpectedToSend);
         });
     }
 }
 
-- (void)connection:(NSURLConnection __unused *)connection
-didReceiveResponse:(NSURLResponse *)response
-{
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler {
     self.response = response;
     
     [self.outputStream open];
+    completionHandler(NSURLSessionResponseAllow);
 }
 
-- (void)connection:(NSURLConnection __unused *)connection
-    didReceiveData:(NSData *)data
-{
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data {
     NSUInteger length = [data length];
     while (YES) {
         NSUInteger totalNumberOfBytesWritten = 0;
         if ([self.outputStream hasSpaceAvailable]) {
             const uint8_t *dataBuffer = (uint8_t *)[data bytes];
-
+            
             NSInteger numberOfBytesWritten = 0;
             while (totalNumberOfBytesWritten < length) {
                 numberOfBytesWritten = [self.outputStream write:&dataBuffer[0] maxLength:length];
                 if (numberOfBytesWritten == -1) {
                     break;
                 }
-
+                
                 totalNumberOfBytesWritten += numberOfBytesWritten;
             }
-
+            
             break;
         }
-
+        
         if (self.outputStream.streamError) {
-            [self.connection cancel];
-            [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.outputStream.streamError];
+            [self.sessionTask cancel];
+            [self performSelector:@selector(URLSession:didBecomeInvalidWithError:) withObject:self.sessionTask withObject:self.outputStream.streamError];
             return;
         }
     }
@@ -764,39 +752,45 @@ didReceiveResponse:(NSURLResponse *)response
     });
 }
 
-- (void)connectionDidFinishLoading:(NSURLConnection __unused *)connection {
-    self.responseData = [self.outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
-    
-    [self.outputStream close];
-    
-    [self finish];
-    
-    self.connection = nil;
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(nullable NSError *)error {
+    if (!error) {
+        self.responseData = [self.outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
+        
+        [self.outputStream close];
+        
+        [self finish];
+        
+        self.sessionTask = nil;
+    } else {
+        self.error = error;
+        
+        [self.outputStream close];
+        
+        [self finish];
+        
+        self.sessionTask = nil;
+    }
 }
 
-- (void)connection:(NSURLConnection __unused *)connection
-  didFailWithError:(NSError *)error
-{
+- (void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(nullable NSError *)error {
     self.error = error;
     
     [self.outputStream close];
     
     [self finish];
     
-    self.connection = nil;
+    self.sessionTask = nil;
 }
 
-- (NSCachedURLResponse *)connection:(NSURLConnection *)connection
-                  willCacheResponse:(NSCachedURLResponse *)cachedResponse
-{
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask willCacheResponse:(NSCachedURLResponse *)proposedResponse completionHandler:(void (^)(NSCachedURLResponse * _Nullable cachedResponse))completionHandler {
     if (self.cacheResponse) {
-        return self.cacheResponse(connection, cachedResponse);
+        completionHandler(self.cacheResponse(session, proposedResponse));
     } else {
         if ([self isCancelled]) {
-            return nil;
+            completionHandler(nil);
         }
         
-        return cachedResponse;
+        completionHandler(proposedResponse);
     }
 }
 
@@ -817,7 +811,7 @@ didReceiveResponse:(NSURLResponse *)response
     self.responseData = [aDecoder decodeObjectForKey:@"responseData"];
     self.totalBytesRead = [[aDecoder decodeObjectForKey:@"totalBytesRead"] longLongValue];
     self.allowsInvalidSSLCertificate = [[aDecoder decodeObjectForKey:@"allowsInvalidSSLCertificate"] boolValue];
-
+    
     return self;
 }
 

--- a/Code/Network/RKObjectManager.h
+++ b/Code/Network/RKObjectManager.h
@@ -300,11 +300,6 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
 @property (nonatomic, readonly) NSURL *baseURL;
 
 /**
- The default session configuration.
- */
-@property (nonatomic, readonly) NSURLSessionConfiguration *defaultSessionConfiguration;
-
-/**
  The default HTTP headers for all `NSURLRequest` objects constructed by the object manager.
  
  The returned dictionary contains all of the default headers set on the underlying `AFHTTPClient` object and the value of the 'Accept' header set on the object manager, if any.

--- a/Code/Network/RKObjectManager.h
+++ b/Code/Network/RKObjectManager.h
@@ -300,6 +300,11 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
 @property (nonatomic, readonly) NSURL *baseURL;
 
 /**
+ The default session configuration.
+ */
+@property (nonatomic, readonly) NSURLSessionConfiguration *defaultSessionConfiguration;
+
+/**
  The default HTTP headers for all `NSURLRequest` objects constructed by the object manager.
  
  The returned dictionary contains all of the default headers set on the underlying `AFHTTPClient` object and the value of the 'Accept' header set on the object manager, if any.

--- a/Code/Network/RKObjectManager.h
+++ b/Code/Network/RKObjectManager.h
@@ -45,13 +45,13 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  
  Many of the methods of the object manager accept a path argument, either directly or in the form of a path pattern. Whenever a path is provided to the object manager directly, as part of a request or response descriptor (see "Request and Response Descriptors"), or via a route (see the "Routing" section), the path is used to construct an `NSURL` object with `[NSURL URLWithString:relativeToURL:]`. The rules for the evaluation of a relative URL can at times be surprising and many configuration errors result from incorrectly configuring the `baseURL` and relative paths thereof. For reference, here are some examples borrowed from the AFNetworking documentation detailing how base URL's and relative paths interact:
  
-     NSURL *baseURL = [NSURL URLWithString:@"http://example.com/v1/"];
-     [NSURL URLWithString:@"foo" relativeToURL:baseURL];                  // http://example.com/v1/foo
-     [NSURL URLWithString:@"foo?bar=baz" relativeToURL:baseURL];          // http://example.com/v1/foo?bar=baz
-     [NSURL URLWithString:@"/foo" relativeToURL:baseURL];                 // http://example.com/foo
-     [NSURL URLWithString:@"foo/" relativeToURL:baseURL];                 // http://example.com/v1/foo
-     [NSURL URLWithString:@"/foo/" relativeToURL:baseURL];                // http://example.com/foo/
-     [NSURL URLWithString:@"http://example2.com/" relativeToURL:baseURL]; // http://example2.com/
+ NSURL *baseURL = [NSURL URLWithString:@"http://example.com/v1/"];
+ [NSURL URLWithString:@"foo" relativeToURL:baseURL];                  // http://example.com/v1/foo
+ [NSURL URLWithString:@"foo?bar=baz" relativeToURL:baseURL];          // http://example.com/v1/foo?bar=baz
+ [NSURL URLWithString:@"/foo" relativeToURL:baseURL];                 // http://example.com/foo
+ [NSURL URLWithString:@"foo/" relativeToURL:baseURL];                 // http://example.com/v1/foo
+ [NSURL URLWithString:@"/foo/" relativeToURL:baseURL];                // http://example.com/foo/
+ [NSURL URLWithString:@"http://example2.com/" relativeToURL:baseURL]; // http://example2.com/
  
  Keep these rules in mind when providing relative paths to the object manager.
  
@@ -59,32 +59,32 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  
  Path patterns appear throughout RestKit, but the most fundamental uses are for the dynamic generation of URL paths from objects and the matching of request and response URLs for mapping configuration. When generating a URL, a path pattern is interpolated with the value of an object. Consider this example:
  
-    // Set object attributes
-    RKArticle *article = [RKArticle new];
-    article.articleID = @12345;
+ // Set object attributes
+ RKArticle *article = [RKArticle new];
+ article.articleID = @12345;
  
-    // Interpolate with the object
-    NSString *path = RKPathFromPatternWithObject(@"/articles/:articleID", article);
-    NSLog(@"The path is %@", path); // prints /articles/12345
+ // Interpolate with the object
+ NSString *path = RKPathFromPatternWithObject(@"/articles/:articleID", article);
+ NSLog(@"The path is %@", path); // prints /articles/12345
  
  This may at first glance appear to provide only a small syntactic improvement over using `[NSString stringWithFormat:]`, but it becomes more interesting once you consider that the dynamic key can include key path:
  
-    RKCategory *category = [RKCategory new];
-    comment.name = @"RestKit;
-    article.category = category;
+ RKCategory *category = [RKCategory new];
+ comment.name = @"RestKit;
+ article.category = category;
  
-    NSString *path = RKPathFromPatternWithObject(@"/categories/:comment.name/articles/:articleID/comments/", article);
-    NSLog(@"The path is %@", path); // prints /categories/RestKit/articles/12345
+ NSString *path = RKPathFromPatternWithObject(@"/categories/:comment.name/articles/:articleID/comments/", article);
+ NSLog(@"The path is %@", path); // prints /categories/RestKit/articles/12345
  
  These path patterns can then be registered with the manager via an `RKRoute` object (discussed in detail below), enabling one to perform object request operations like so:
  
-    RKObjectManager *manager = [RKObjectManager managerWithBaseURL:[NSURL URLWithString:@"http://restkit.org"]];
-    [manager.router.routeSet addRoute:[RKRoute routeWithClass:[RKArticle class] pathPattern:@"/categories/:comment.name/articles/:articleID/comments/" method:RKRequestMethodGET]];
+ RKObjectManager *manager = [RKObjectManager managerWithBaseURL:[NSURL URLWithString:@"http://restkit.org"]];
+ [manager.router.routeSet addRoute:[RKRoute routeWithClass:[RKArticle class] pathPattern:@"/categories/:comment.name/articles/:articleID/comments/" method:RKRequestMethodGET]];
  
-    // Now GET our article object... sending a GET to '/categories/RestKit/articles/12345'
-    [manager getObject:article path:nil parameters:nil success:^(RKObjectRequestOperation *operation, RKMappingResult *result) {
-        NSLog(@"Loading mapping result: %@", result);
-    } failure:nil];
+ // Now GET our article object... sending a GET to '/categories/RestKit/articles/12345'
+ [manager getObject:article path:nil parameters:nil success:^(RKObjectRequestOperation *operation, RKMappingResult *result) {
+ NSLog(@"Loading mapping result: %@", result);
+ } failure:nil];
  
  Once a path pattern has been registered via the routing system, the manager can automatically build full request URL's when given nothing but the object to be sent.
  
@@ -104,60 +104,60 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  
  To better illustrate these concepts, consider the following example for an imaginary Wiki client application:
  
-    @interface RKWikiPage : NSObject
-    @property (nonatomic, copy) NSString *title;
-    @property (nonatomic, copy) NSString *body;
-    @end
+ @interface RKWikiPage : NSObject
+ @property (nonatomic, copy) NSString *title;
+ @property (nonatomic, copy) NSString *body;
+ @end
  
-    // Construct a request mapping for our class
-    RKObjectMapping *requestMapping = [RKObjectMapping requestMapping];
-    [requestMapping addAttributeMappingsFromDictionary:@{ @"title": @"title", @"body": @"body" }];
-    
-    // We wish to generate parameters of the format: 
-    // @{ @"page": @{ @"title": @"An Example Page", @"body": @"Some example content" } }
-    RKRequestDescriptor *requestDescriptor = [RKRequestDescriptor requestDescriptorWithMapping:mapping
-                                                                                   objectClass:[RKWikiPage class]
-                                                                                   rootKeyPath:@"page"];
+ // Construct a request mapping for our class
+ RKObjectMapping *requestMapping = [RKObjectMapping requestMapping];
+ [requestMapping addAttributeMappingsFromDictionary:@{ @"title": @"title", @"body": @"body" }];
  
-    // Construct an object mapping for the response
-    // We are expecting JSON in the format:
-    // {"page": {"title": "<title value>", "body": "<body value>"}
-    RKObjectMapping *responseMapping = [RKObjectMapping mappingForClass:[RKWikiPage class]];
-    [responseMapping addAttributeMappingsFromArray:@[ @"title", @"body" ]];
+ // We wish to generate parameters of the format:
+ // @{ @"page": @{ @"title": @"An Example Page", @"body": @"Some example content" } }
+ RKRequestDescriptor *requestDescriptor = [RKRequestDescriptor requestDescriptorWithMapping:mapping
+ objectClass:[RKWikiPage class]
+ rootKeyPath:@"page"];
  
-    // Construct a response descriptor that matches any URL (the pathPattern is nil), when the response payload
-    // contains content nested under the `@"page"` key path, if the response status code is 200 (OK)
-    RKResponseDescriptor *responseDescriptor = [RKResponseDescriptor responseDescriptorWithMapping:responseMapping
-                                                                                       pathPattern:nil
-                                                                                           keyPath:@"page"
-                                                                                       statusCodes:[NSIndexSet indexSetWithIndex:200]];
+ // Construct an object mapping for the response
+ // We are expecting JSON in the format:
+ // {"page": {"title": "<title value>", "body": "<body value>"}
+ RKObjectMapping *responseMapping = [RKObjectMapping mappingForClass:[RKWikiPage class]];
+ [responseMapping addAttributeMappingsFromArray:@[ @"title", @"body" ]];
  
-    // Register our descriptors with a manager
-    RKObjectManager *manager = [RKObjectManager managerWithBaseURL:[NSURL URLWithString:@"http://restkit.org/"]];
-    [manager addRequestDescriptor:requestDescriptor];
-    [manager addResponseDescriptor:responseDescriptor];
+ // Construct a response descriptor that matches any URL (the pathPattern is nil), when the response payload
+ // contains content nested under the `@"page"` key path, if the response status code is 200 (OK)
+ RKResponseDescriptor *responseDescriptor = [RKResponseDescriptor responseDescriptorWithMapping:responseMapping
+ pathPattern:nil
+ keyPath:@"page"
+ statusCodes:[NSIndexSet indexSetWithIndex:200]];
  
-    // Work with the object
-    RKWikiPage *page = [RKWikiPage new];
-    page.title = @"An Example Page";
-    page.body  = @"Some example content";
+ // Register our descriptors with a manager
+ RKObjectManager *manager = [RKObjectManager managerWithBaseURL:[NSURL URLWithString:@"http://restkit.org/"]];
+ [manager addRequestDescriptor:requestDescriptor];
+ [manager addResponseDescriptor:responseDescriptor];
  
-    // POST the parameterized representation of the `page` object to `/posts` and map the response
-    [manager postObject:page path:@"/pages" parameters:nil success:^(RKObjectRequestOperation *operation, RKMappingResult *result) {
-        NSLog(@"We object mapped the response with the following result: %@", result);
-    } failure:nil];
+ // Work with the object
+ RKWikiPage *page = [RKWikiPage new];
+ page.title = @"An Example Page";
+ page.body  = @"Some example content";
+ 
+ // POST the parameterized representation of the `page` object to `/posts` and map the response
+ [manager postObject:page path:@"/pages" parameters:nil success:^(RKObjectRequestOperation *operation, RKMappingResult *result) {
+ NSLog(@"We object mapped the response with the following result: %@", result);
+ } failure:nil];
  
  In the above example, request and response mapping configurations were described for a simple data model and then used to perform a basic POST operation and map the results. An arbitrary number of request and response descriptors may be added to the manager to accommodate your application's needs.
  
  ## Multi-object Parameterization
-
+ 
  The object manager provides support for the parameterization of multiple objects provided as an array. The `requestWithObject:method:path:parameters:` and `multipartFormRequestWithObject:method:path:parameters:constructingBodyWithBlock:` methods can parameterize an array of objects for you provided that the `RKRequestDescriptor` objects are configured in a compatible way. The rules for multi-object parameterization are simple:
-
+ 
  1. If a `nil` root key path is used, then it must be used for all objects in the array. This is because the objects will be parameterized into a dictionary and then each dictionary will be added to an array. This array is then serialized for transport, so objects parameterized to a non-nil key path cannot be merged with the array.
  1. If a `nil` root key path is used to parameterize the array of objects, then you cannot provide additional parameters to be merged with the request. This is again because you cannot merge a dictionary with an array.
-
+ 
  If non-nil key paths are used, then each object will be set in the parameters dictionary at the specified key path. If more than one object uses the same root key path, then the parameters will be combined into an array for transport.
-
+ 
  ## MIME Types
  
  MIME Types serve an important function to the object manager. They are used to identify how content is to be serialized when constructing request bodies and also used to set the 'Accept' header for content negotiation. RestKit aspires to be content type agnostic by leveraging the pluggable `RKMIMESerialization` class to handle content serialization and deserialization.
@@ -176,24 +176,24 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  
  To better understand these concepts, please consider the following example code for configuring the above routing examples:
  
-    RKObjectManager *manager = [RKObjectManager managerWithBaseURL:[NSURL URLWithString:@"http://restkit.org"]];
+ RKObjectManager *manager = [RKObjectManager managerWithBaseURL:[NSURL URLWithString:@"http://restkit.org"]];
  
-    // Class Route
-    [manager.router.routeSet addRoute:[RKRoute routeWithClass:[User class] pathPattern:@"/users/:userID" method:RKRequestMethodGET]];
+ // Class Route
+ [manager.router.routeSet addRoute:[RKRoute routeWithClass:[User class] pathPattern:@"/users/:userID" method:RKRequestMethodGET]];
  
-    // Relationship Route
-    [manager.router.routeSet addRoute:[RKRoute routeWithRelationshipName:@"friends" objectClass:[User class] pathPattern:@"/users/:userID/friends" method:RKRequestMethodGET]];
+ // Relationship Route
+ [manager.router.routeSet addRoute:[RKRoute routeWithRelationshipName:@"friends" objectClass:[User class] pathPattern:@"/users/:userID/friends" method:RKRequestMethodGET]];
  
-    // Named Route
-    [manager.router.routeSet addRoute:[RKRoute routeWithName:@"follow_user" pathPattern:@"/users/:userID/follow" method:RKRequestMethodPOST]];
+ // Named Route
+ [manager.router.routeSet addRoute:[RKRoute routeWithName:@"follow_user" pathPattern:@"/users/:userID/follow" method:RKRequestMethodPOST]];
  
  Once configured, routes will be consulted by the object manager whenever the path parameter provided to a method is given as nil. For example, invoking the following code would result in a `GET` to the path `@"/users/1234"`:
  
-    User *user = [User new];
-    user.userID = 1234;
-    [manager getObject:user path:nil parameters:nil success:^(RKObjectRequestOperation *operation, RKMappingResult *result) {
-        // Request 
-    } failure:nil];
+ User *user = [User new];
+ user.userID = 1234;
+ [manager getObject:user path:nil parameters:nil success:^(RKObjectRequestOperation *operation, RKMappingResult *result) {
+ // Request
+ } failure:nil];
  
  Routes can also be explicitly used to construct `NSMutableURLRequest` objects and are referenced explicitly in a few object request operation methods:
  
@@ -230,8 +230,8 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  * `appropriateObjectRequestOperationWithObject:method:path:parameters:` - Used to construct all object request operations for the manager, both managed and unmanaged. Invokes either `objectRequestOperationWithRequest:success:failure:` or `managedObjectRequestOperationWithRequest:managedObjectContext:success:failure:` to construct the actual request. Provide a subclass implementation to alter behaviors for all object request operations constructed by the manager.
  * `enqueueObjectRequestOperation:` - Invoked to enqueue all operations constructed by the manager that are to be started as soon as possible. Provide a subclass implementation if you wish to work with object request operations as they are be enqueued.
  
- If you wish to more specifically customize the behavior of the lower level HTTP details, you have several options. All HTTP requests made by the `RKObjectManager` class are made with an instance of the `RKHTTPRequestOperation` class, which is a subclass of the `AFHTTPRequestOperation` class from AFNetworking. This operation class implements the `NSURLConnectionDelegate` and `NSURLConnectionDataDelegate` protocols and as such, has full access to all details of the HTTP request/response cycle exposed by `NSURLConnection`. You can provide the object manager with your own custom subclass of `RKHTTPRequestOperation` to the manager via the `registerRequestOperationClass:` method and all HTTP requests made through the manager will pass through your operation.
-
+ If you wish to more specifically customize the behavior of the lower level HTTP details, you have several options. All HTTP requests made by the `RKObjectManager` class are made with an instance of the `RKHTTPRequestOperation` class, which is a subclass of the `AFHTTPRequestOperation` class from AFNetworking. This operation class implements the `NSURLSessionDelegate`, `NSURLSessionDataDelegate` and `NSURLSessionTaskDelegate` protocols and as such, has full access to all details of the HTTP request/response cycle exposed by `NSURLSession`. You can provide the object manager with your own custom subclass of `RKHTTPRequestOperation` to the manager via the `registerRequestOperationClass:` method and all HTTP requests made through the manager will pass through your operation.
+ 
  You can also customize the HTTP details at the AFNetworking level by subclassing `AFHTTPClient` and using an instance of your subclassed client to initialize the manager.
  
  @warning Note that when subclassing `AFHTTPClient` to change object manager behaviors it is not possible to alter the paramters of requests that are constructed on behalf of the manager. This is because the object manager handles its own serialization and construction of the request body, but defers to the `AFHTTPClient` for all other details (such as default HTTP headers, etc).
@@ -279,7 +279,7 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  Initializes the receiver with the given AFNetworking HTTP client object, adopting the network configuration from the client.
  
  This is the designated initializer. If the `sharedManager` instance is `nil`, the receiver will be set as the `sharedManager`. The default headers and parameter encoding of the given HTTP client are adopted by the receiver to initialize the values of the `defaultHeaders` and `requestSerializationMIMEType` properties.
-
+ 
  @param client The AFNetworking HTTP client with which to initialize the receiver.
  @return The receiver, initialized with the given client.
  */
@@ -327,11 +327,11 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
 
 /**
  The MIME Type to serialize request parameters into when constructing request objects.
-
+ 
  The value of the `requestSerializationMIMEType` is used to obtain an appropriate `RKSerialization` conforming class from the `RKMIMESerialization` interface. Parameterized objects and dictionaries of parameters are then serialized for transport using the class registered for the MIME Type. By default, the value is `RKMIMETypeFormURLEncoded` which means that the request body of all `POST`, `PUT`, and `PATCH` requests will be sent in the URL encoded format. This is analagous to submitting an HTML form via a web browser. Other common formats include `RKMIMETypeJSON`, which will cause request bodies to be encoded as JSON.
-
+ 
  The value given for the `requestSerializationMIMEType` must correspond to a MIME Type registered via `[RKMIMETypeSerialization registerClass:forMIMEType:]`. Implementations are provided by default for `RKMIMETypeFormURLEncoded` and `RKMIMETypeJSON`.
-
+ 
  **Default**: `RKMIMETypeFormURLEncoded` or the value of the parameter encoding for the underlying `AFHTTPClient`.
  */
 @property (nonatomic, strong) NSString *requestSerializationMIMEType;
@@ -341,8 +341,8 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  
  This method is a convenience method whose implementation is equivalent to the following example code:
  
-    [manager.HTTPClient setDefaultHeader:@"Accept" value:MIMEType];
-
+ [manager.HTTPClient setDefaultHeader:@"Accept" value:MIMEType];
+ 
  @param MIMEType The MIME Type to set as the value for the HTTP "Accept" header.
  */
 - (void)setAcceptHeaderWithMIMEType:(NSString *)MIMEType;
@@ -492,7 +492,7 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
 /**
  Creates and returns an object request operation of the appropriate type for the given object, request method, path, and parameters.
  
- The type of object request operation created is determined by evaluating the type of the object given and examining the list of `RKResponseDescriptor` objects added to the manager. 
+ The type of object request operation created is determined by evaluating the type of the object given and examining the list of `RKResponseDescriptor` objects added to the manager.
  
  If the given object is non-nil and inherits from `NSManagedObject`, then an instance of `RKManagedObjectRequestOperation` is returned.
  
@@ -558,12 +558,12 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  Creates and enqueues an `RKObjectRequestOperation` to the object manager's operation queue for each specified object into a batch. Each object request operation is built by evaluating the object against the given route to construct a request path and then invoking `appropriateObjectRequestOperationWithObject:method:path:parameters:`. When each object request operation finishes, the specified progress block is executed, until all of the request operations have finished, at which point the completion block also executes.
  
  @warning Note that the route type is significant in how that the object request operation is constructed. If the given route is a class route, then the `targetObject` of the operation will be set to the object for which the operation is being constructed. For named routes and relationship routes, the target object is `nil`.
-
+ 
  @param route The route specifying the request method and the path pattern with which to construct the request for each object object request operation in the batch.
  @param objects The set of objects for which to enqueue a batch of object request operations.
  @param progress A block object to be executed when an object request operation completes. This block has no return value and takes two arguments: the number of finished operations and the total number of operations initially executed.
  @param completion A block object to be executed when the object request operations complete. This block has no return value and takes one argument: the list of operations executed.
-
+ 
  @see `[RKObjectManager enqueueBatchOfObjectRequestOperations:progress:completion]`
  @see `RKRoute`
  */
@@ -575,11 +575,11 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
 
 /**
  Enqueues a set of `RKObjectRequestOperation` to the object manager's operation queue.
-
+ 
  @param operations The set of object request operations to be enqueued.
  @param progress A block object to be executed when an object request operation completes. This block has no return value and takes two arguments: the number of finished operations and the total number of operations initially executed.
  @param completion A block object to be executed when the object request operations complete. This block has no return value and takes one argument: the list of operations executed.
-
+ 
  */
 - (void)enqueueBatchOfObjectRequestOperations:(NSArray *)operations
                                      progress:(void (^)(NSUInteger numberOfFinishedOperations,
@@ -595,7 +595,7 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
  
  The type of object request operation created is determined by invoking `appropriateObjectRequestOperationWithObject:method:path:parameters:`.
  
- @param path The path to be appended to the HTTP client's base URL and used as the request URL. 
+ @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param parameters The parameters to be encoded and appended as the query string for the request URL.
  @param success A block object to be executed when the object request operation finishes successfully. This block has no return value and takes two arguments: the created object request operation and the `RKMappingResult` object created by object mapping the response data of request.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the resonse data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
@@ -770,7 +770,7 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
 /**
  Adds the `RKRequestDescriptor` objects contained in a given array to the manager.
  
- @param requestDescriptors An array of `RKRequestDescriptor` objects to be added to the manager. 
+ @param requestDescriptors An array of `RKRequestDescriptor` objects to be added to the manager.
  @exception NSInvalidArgumentException Raised if any element of the given array is not an `RKRequestDescriptor` object.
  */
 - (void)addRequestDescriptorsFromArray:(NSArray *)requestDescriptors;
@@ -847,7 +847,7 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
 /**
  The object mapping describing how to map pagination metadata from paginated responses.
  
- The object mapping must have an object class of `RKPaginator`. 
+ The object mapping must have an object class of `RKPaginator`.
  
  @see [RKPaginator initWithRequest:paginationMapping:responseDescriptors]
  */
@@ -883,7 +883,7 @@ RKMappingResult, RKRequestDescriptor, RKResponseDescriptor;
 #ifdef _SYSTEMCONFIGURATION_H
 /**
  Returns a string description of the given network status.
-
+ 
  @param networkReachabilityStatus The network reachability status.
  @return A string describing the reachability status.
  */

--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -351,6 +351,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
 @property (nonatomic, strong) NSMutableArray *registeredHTTPRequestOperationClasses;
 @property (nonatomic, strong) NSMutableArray *registeredObjectRequestOperationClasses;
 @property (nonatomic, strong) NSMutableArray *registeredManagedObjectRequestOperationClasses;
+@property (nonatomic, strong) NSURLSessionConfiguration *sessionConfiguration;
 
 @end
 
@@ -378,7 +379,8 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
         self.registeredManagedObjectRequestOperationClasses = [NSMutableArray new];
         self.registeredObjectRequestOperationClasses = [NSMutableArray new];
         self.requestSerializationMIMEType = RKMIMETypeFromAFHTTPClientParameterEncoding(client.parameterEncoding);        
-
+        self.sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
+        
         // Set shared manager if nil
         if (nil == sharedManager) {
             [RKObjectManager setSharedManager:self];
@@ -415,6 +417,10 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
 - (NSURL *)baseURL
 {
     return self.HTTPClient.baseURL;
+}
+
+- (NSURLSessionConfiguration *)defaultSessionConfiguration {
+    return self.sessionConfiguration;
 }
 
 - (NSDictionary *)defaultHeaders
@@ -590,7 +596,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
                                                         failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     Class HTTPRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredHTTPRequestOperationClasses] ?: [RKHTTPRequestOperation class];
-    RKHTTPRequestOperation *HTTPRequestOperation = [[HTTPRequestOperationClass alloc] initWithRequest:request];
+    RKHTTPRequestOperation *HTTPRequestOperation = [[HTTPRequestOperationClass alloc] initWithRequest:request sessionConfiguration:self.sessionConfiguration];
     [self copyStateFromHTTPClientToHTTPRequestOperation:HTTPRequestOperation];
     Class objectRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredObjectRequestOperationClasses] ?: [RKObjectRequestOperation class];
     RKObjectRequestOperation *operation = [[objectRequestOperationClass alloc] initWithHTTPRequestOperation:HTTPRequestOperation responseDescriptors:responseDescriptors];
@@ -614,7 +620,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
                                                                       failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     Class HTTPRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredHTTPRequestOperationClasses] ?: [RKHTTPRequestOperation class];
-    RKHTTPRequestOperation *HTTPRequestOperation = [[HTTPRequestOperationClass alloc] initWithRequest:request];
+    RKHTTPRequestOperation *HTTPRequestOperation = [[HTTPRequestOperationClass alloc] initWithRequest:request sessionConfiguration:self.sessionConfiguration];
     [self copyStateFromHTTPClientToHTTPRequestOperation:HTTPRequestOperation];
     Class objectRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredManagedObjectRequestOperationClasses] ?: [RKManagedObjectRequestOperation class];
     RKManagedObjectRequestOperation *operation = (RKManagedObjectRequestOperation *)[[objectRequestOperationClass alloc] initWithHTTPRequestOperation:HTTPRequestOperation responseDescriptors:responseDescriptors];

--- a/Code/Network/RKObjectManager.m
+++ b/Code/Network/RKObjectManager.m
@@ -351,7 +351,6 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
 @property (nonatomic, strong) NSMutableArray *registeredHTTPRequestOperationClasses;
 @property (nonatomic, strong) NSMutableArray *registeredObjectRequestOperationClasses;
 @property (nonatomic, strong) NSMutableArray *registeredManagedObjectRequestOperationClasses;
-@property (nonatomic, strong) NSURLSessionConfiguration *sessionConfiguration;
 
 @end
 
@@ -379,8 +378,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
         self.registeredManagedObjectRequestOperationClasses = [NSMutableArray new];
         self.registeredObjectRequestOperationClasses = [NSMutableArray new];
         self.requestSerializationMIMEType = RKMIMETypeFromAFHTTPClientParameterEncoding(client.parameterEncoding);        
-        self.sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-        
+
         // Set shared manager if nil
         if (nil == sharedManager) {
             [RKObjectManager setSharedManager:self];
@@ -417,10 +415,6 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
 - (NSURL *)baseURL
 {
     return self.HTTPClient.baseURL;
-}
-
-- (NSURLSessionConfiguration *)defaultSessionConfiguration {
-    return self.sessionConfiguration;
 }
 
 - (NSDictionary *)defaultHeaders
@@ -596,7 +590,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
                                                         failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     Class HTTPRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredHTTPRequestOperationClasses] ?: [RKHTTPRequestOperation class];
-    RKHTTPRequestOperation *HTTPRequestOperation = [[HTTPRequestOperationClass alloc] initWithRequest:request sessionConfiguration:self.sessionConfiguration];
+    RKHTTPRequestOperation *HTTPRequestOperation = [[HTTPRequestOperationClass alloc] initWithRequest:request];
     [self copyStateFromHTTPClientToHTTPRequestOperation:HTTPRequestOperation];
     Class objectRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredObjectRequestOperationClasses] ?: [RKObjectRequestOperation class];
     RKObjectRequestOperation *operation = [[objectRequestOperationClass alloc] initWithHTTPRequestOperation:HTTPRequestOperation responseDescriptors:responseDescriptors];
@@ -620,7 +614,7 @@ static NSString *RKMIMETypeFromAFHTTPClientParameterEncoding(AFRKHTTPClientParam
                                                                       failure:(void (^)(RKObjectRequestOperation *operation, NSError *error))failure
 {
     Class HTTPRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredHTTPRequestOperationClasses] ?: [RKHTTPRequestOperation class];
-    RKHTTPRequestOperation *HTTPRequestOperation = [[HTTPRequestOperationClass alloc] initWithRequest:request sessionConfiguration:self.sessionConfiguration];
+    RKHTTPRequestOperation *HTTPRequestOperation = [[HTTPRequestOperationClass alloc] initWithRequest:request];
     [self copyStateFromHTTPClientToHTTPRequestOperation:HTTPRequestOperation];
     Class objectRequestOperationClass = [self requestOperationClassForRequest:request fromRegisteredClasses:self.registeredManagedObjectRequestOperationClasses] ?: [RKManagedObjectRequestOperation class];
     RKManagedObjectRequestOperation *operation = (RKManagedObjectRequestOperation *)[[objectRequestOperationClass alloc] initWithHTTPRequestOperation:HTTPRequestOperation responseDescriptors:responseDescriptors];

--- a/Code/Network/RKObjectRequestOperation.h
+++ b/Code/Network/RKObjectRequestOperation.h
@@ -38,20 +38,20 @@ extern NSString * const RKResponseHasBeenMappedCacheUserInfoKey;
  
  ## Error Mapping
  
- If the HTTP request returned a response in the Client Error (400-499 range) or Server Error (500-599 range) class and an appropriate `RKResponseDescriptor` is provided to perform mapping on the response, then the object mapping result is considered to contain a server returned error. In this case, an `NSError` object is created in the `RKErrorDomain` with an error code of `RKMappingErrorFromMappingResult` and the object request operation is failed. In the event that an a response is returned in an error class and no `RKResponseDescriptor` has been provided to the operation to handle it, then an `NSError` object in the `AFNetworkingErrorDomain` with an error code of `NSURLErrorBadServerResponse` will be returned by the underlying `RKHTTPRequestOperation` indicating that an unexpected status code was returned. 
+ If the HTTP request returned a response in the Client Error (400-499 range) or Server Error (500-599 range) class and an appropriate `RKResponseDescriptor` is provided to perform mapping on the response, then the object mapping result is considered to contain a server returned error. In this case, an `NSError` object is created in the `RKErrorDomain` with an error code of `RKMappingErrorFromMappingResult` and the object request operation is failed. In the event that an a response is returned in an error class and no `RKResponseDescriptor` has been provided to the operation to handle it, then an `NSError` object in the `AFNetworkingErrorDomain` with an error code of `NSURLErrorBadServerResponse` will be returned by the underlying `RKHTTPRequestOperation` indicating that an unexpected status code was returned.
  
  ## Metadata Mapping
-
+ 
  The `RKObjectRequestOperation` class provides support for metadata mapping via the `mappingMetadata` property. This optional dictionary of user supplied information is made available to the mapping operations executed when processing the HTTP response loaded by an object request operation. More details about the metadata mapping architecture is available on the `RKMappingOperation` documentation.
-
+ 
  ## Prioritization and Cancellation
  
  Object request operations support prioritization and cancellation of the underlying `RKHTTPRequestOperation` and `RKResponseMapperOperation` operations that perform the network transport and object mapping duties on their behalf. The queue priority of the object request operation, as set via the `[NSOperation setQueuePriority:]` method, is applied to the underlying response mapping operation when it is enqueued onto the `responseMappingQueue`. If the object request operation is cancelled, then the underlying HTTP request operation and response mapping operation are also cancelled.
  
  ## Caching
  
- Instances of `RKObjectRequestOperation` support all the HTTP caching facilities available via the `NSURLConnection` family of API's. For caching to be enabled, the remote web server that the application is communicating with must emit the appropriate `Cache-Control`, `Expires`, and/or `ETag` headers. When the response headers include the appropriate caching information, the shared `NSURLCache` instance will manage responses and transparently add conditional GET support to cachable requests. HTTP caching is a deep topic explored in depth across the web and detailed in RFC 2616: http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
-
+ Instances of `RKObjectRequestOperation` support all the HTTP caching facilities available via the `NSURLSession` family of API's. For caching to be enabled, the remote web server that the application is communicating with must emit the appropriate `Cache-Control`, `Expires`, and/or `ETag` headers. When the response headers include the appropriate caching information, the shared `NSURLCache` instance will manage responses and transparently add conditional GET support to cachable requests. HTTP caching is a deep topic explored in depth across the web and detailed in RFC 2616: http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+ 
  The `RKObjectRequestOperation` class also provides support for utilizing the `NSURLCache` to satisfy requests without hitting the network. This support enables applications to display views presenting data retrieved via a cachable `GET` request without revalidating with the server and incurring any overhead. The optimization is controlled via `avoidsNetworkAccess` property. When enabled, the operation will skip the network transport portion of the object request operation and proceed directly to object mapping the cached response data. When the object request operation is an instance of `RKManagedObjectRequestOperation`, the deserialization and mapping portion of the process can be skipped entirely and the operation will fetch the appropriate object directly from Core Data, falling back to network transport once the cache entry has expired. Please refer to the documentation accompanying `RKManagedObjectRequestOperation` for more details.
  
  ## Core Data
@@ -68,7 +68,7 @@ extern NSString * const RKResponseHasBeenMappedCacheUserInfoKey;
  @see `RKManagedObjectRequestOperation`
  */
 @interface RKObjectRequestOperation : NSOperation <NSCopying, RKMapperOperationDelegate> {
-  @protected
+@protected
     RKMappingResult *_mappingResult;
 }
 
@@ -92,8 +92,8 @@ extern NSString * const RKResponseHasBeenMappedCacheUserInfoKey;
  
  This method is a convenience initializer for initializing an object request operation from a URL request with the default HTTP operation class `RKHTTPRequestOperation`. This method is functionally equivalent to the following example code:
  
-    RKHTTPRequestOperation *requestOperation = [[RKHTTPRequestOperation alloc] initWithRequest:request];
-    RKObjectRequestOperation *objectRequestOperation = [[RKObjectRequestOperation alloc] initWithHTTPRequestOperation:requestOperation responseDescriptors:responseDescriptors];
+ RKHTTPRequestOperation *requestOperation = [[RKHTTPRequestOperation alloc] initWithRequest:request];
+ RKObjectRequestOperation *objectRequestOperation = [[RKObjectRequestOperation alloc] initWithHTTPRequestOperation:requestOperation responseDescriptors:responseDescriptors];
  
  @param request The request object to be used with the underlying network operation.
  @param responseDescriptors An array of `RKResponseDescriptor` objects specifying how object mapping is to be performed on the response loaded by the network operation.
@@ -157,7 +157,7 @@ extern NSString * const RKResponseHasBeenMappedCacheUserInfoKey;
 
 /**
  Sets the `completionBlock` property with a block that executes either the specified success or failure block, depending on the state of the object request on completion. If `error` returns a value, which can be set during HTTP transport by the underlying `HTTPRequestOperation` or during object mapping by the `RKResponseMapperOperation` object, then `failure` is executed. If the object request operation is cancelled, then the failure block will be executed with either a `RKOperationCancelledError` or a `NSURLErrorCancelled`, depending on the internal state of the operation at time of cancellation. Otherwise, `success` is executed.
-
+ 
  @param success The block to be executed on the completion of a successful operation. This block has no return value and takes two arguments: the receiver operation and the mapping result from object mapping the response data of the request.
  @param failure The block to be executed on the completion of an unsuccessful operation. This block has no return value and takes two arguments: the receiver operation and the error that occurred during the execution of the operation.
  */


### PR DESCRIPTION
Replaced NSURLConnection with NSURLSession.

It was about time to replace NSURLConnection. 
The NSURLConnection class should no longer be used.
For example, `connection:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite:` was not working anymore.