### PR TITLE
Fixed access to [UIApplication sharedApplication] from extensions #2440

### DIFF
--- a/Code/Network/AFNetworking/AFRKNetworkActivityIndicatorManager.m
+++ b/Code/Network/AFNetworking/AFRKNetworkActivityIndicatorManager.m
@@ -93,7 +93,11 @@ static NSTimeInterval const kAFRKNetworkActivityIndicatorInvisibilityDelay = 0.1
 }
 
 - (void)updateNetworkActivityIndicatorVisibility {
-    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:[self isNetworkActivityIndicatorVisible]];
+    Class UIApplicationClass = NSClassFromString(@"UIApplication");
+    if (UIApplicationClass != nil && [UIApplicationClass respondsToSelector:@selector(sharedApplication)]) {
+        UIApplication *sharedApplication = [UIApplicationClass performSelector:@selector(sharedApplication)];
+        [sharedApplication setNetworkActivityIndicatorVisible:[self isNetworkActivityIndicatorVisible]];
+    }
 }
 
 // Not exposed, but used if activityCount is set via KVC.


### PR DESCRIPTION
Share Extensions (and other types of extensions, too) have no access to `[UIApplication sharedApplication]`. It's a compile-time issue. Unfortunatelly there is no `#ifdef`-based way to tell if we're compiling the library for an extension or for an app - unless we require the library consumers to add some specific macro to their projects, which may be more error-prone.

Issue: #2440, #2549 and possibly others

Tested in Xcode 10.3 and Xcode 11b5 as well.